### PR TITLE
Remove per function stats

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,14 +33,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "righttyper"
-version = "0.0.5"
+version = "0.0.6"
 authors = [
   { name="Emery Berger", email="emerydb@amazon.com" },
 ]
 dependencies = [ "libcst >= 1.2.0",
 		 "click >= 8.1.7",
 		 "rich >= 13.7.1",
-		 "runstats>=2.0.0",
 		 ]
 	 
 description = "A fast runtime type hint assistant for Python code."

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -64,7 +64,6 @@ from righttyper.righttyper_types import (
     ArgInfo,
     ArgumentName,
     ArgumentType,
-    ExecInfo,
     Filename,
     FuncInfo,
     FunctionName,
@@ -134,9 +133,6 @@ not_annotated: Dict[FuncInfo, Set[str]] = defaultdict(set)
 # Existing annotations (variable to type annotations, optionally
 # including 'return')
 existing_annotations: Dict[FuncInfo, Dict[str, str]] = defaultdict(dict)
-
-# Thread-local execution time tracking for functions
-exec_info = ExecInfo()
 
 # Track the file names and class names for classes
 # that will need import statements

--- a/righttyper/righttyper_types.py
+++ b/righttyper/righttyper_types.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import runstats
 import threading
 from collections import defaultdict
 from dataclasses import dataclass
@@ -82,13 +81,3 @@ class ImportInfo:
     class_name: str
     # 4. details for possible imports (see get_import_details).
     import_details: ImportDetails
-
-
-# Track execution time of functions to adjust sampling
-class ExecInfo(threading.local):
-    def __init__(self) -> None:
-        self.start_time: Dict[FuncInfo, List[float]] = defaultdict(list)
-        self.execution_time: Dict[FuncInfo, runstats.Statistics] = defaultdict(
-            runstats.Statistics
-        )
-        self.total_function_calls: int = 0


### PR DESCRIPTION
*Description of changes:*

Removes now obsolete per-function execution time tracking.
Also bumps the minor version number for a new release.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
