### PR TITLE
Use strings for annotations of unknown types

### DIFF
--- a/righttyper/annotate_function_transformer.py
+++ b/righttyper/annotate_function_transformer.py
@@ -77,7 +77,27 @@ class AnnotateFunctionTransformer(cst.CSTTransformer):
         self.not_annotated = not_annotated
         self.class_name: List[str] = []
         # Initialize allowed types or use a default list
-        self.allowed_types = allowed_types or ["list", "str", "Any", "None", "Dict", "List", "Tuple", "int", "float", "bool", "Optional", "Union", "FrozenSet", "frozenset"]
+        self.allowed_types = allowed_types or [
+            "Any",
+            "bool",
+            "bytes",
+            "complex",
+            "Dict",
+            "dict",
+            "float",
+            "FrozenSet",
+            "frozenset",
+            "int",
+            "List",
+            "list",
+            "None",
+            "Optional",
+            "Set",
+            "set",
+            "str",
+            "Tuple",
+            "Union"
+        ]
 
     def visit_ClassDef(self, node: cst.ClassDef) -> Optional[bool]:
         self.class_name.append(node.name.value)

--- a/righttyper/annotate_function_transformer.py
+++ b/righttyper/annotate_function_transformer.py
@@ -18,6 +18,45 @@ from righttyper.righttyper_types import (
 )
 
 
+class TypeNameExtractor(cst.CSTVisitor):
+    def __init__(self):
+        self.names = set()
+
+    def visit_Name(self, node: cst.Name) -> Optional[bool]:
+        self.names.add(node.value)
+        return True
+
+    def leave_ClassDef(
+        self,
+        original_node: cst.ClassDef,
+        updated_node: cst.ClassDef,
+    ) -> Union[cst.BaseStatement, cst.RemovalSentinel]:
+        self.class_name.pop()
+        return original_node
+
+    def _should_output_as_string(self, annotation: str) -> bool:
+        # Parse the annotation expression and extract all names
+        parsed_expr = cst.parse_expression(annotation)
+        extractor = TypeNameExtractor()
+        parsed_expr.visit(extractor)
+        components = extractor.names
+        
+        # Check if all extracted names are in the allowed types list
+        return not all(comp in self.allowed_types for comp in components)
+    
+    def visit_Attribute(self, node: cst.Attribute) -> Optional[bool]:
+        # Handle cases like typing.List or custom_module.MyType
+        full_name = node.attr.value
+        current_node = node.value
+        while isinstance(current_node, cst.Attribute):
+            full_name = f"{current_node.attr.value}.{full_name}"
+            current_node = current_node.value
+        if isinstance(current_node, cst.Name):
+            full_name = f"{current_node.value}.{full_name}"
+        self.names.add(full_name)
+        return True
+
+    
 class AnnotateFunctionTransformer(cst.CSTTransformer):
     def __init__(
         self,
@@ -30,11 +69,15 @@ class AnnotateFunctionTransformer(cst.CSTTransformer):
             ],
         ],
         not_annotated: Dict[FuncInfo, Set[str]],
+        allowed_types: List[str] = None,
+        # generate_annotations_as_strings: bool = False,
     ) -> None:
         self.filename = filename
         self.type_annotations = type_annotations
         self.not_annotated = not_annotated
         self.class_name: List[str] = []
+        # Initialize allowed types or use a default list
+        self.allowed_types = allowed_types or ["list", "str", "Any", "None", "Dict", "List", "Tuple", "int", "float", "bool", "Optional", "Union", "FrozenSet", "frozenset"]
 
     def visit_ClassDef(self, node: cst.ClassDef) -> Optional[bool]:
         self.class_name.append(node.name.value)
@@ -48,50 +91,81 @@ class AnnotateFunctionTransformer(cst.CSTTransformer):
         self.class_name.pop()
         return original_node
 
+
+    def leave_ClassDef(
+        self,
+        original_node: cst.ClassDef,
+        updated_node: cst.ClassDef,
+    ) -> Union[cst.BaseStatement, cst.RemovalSentinel]:
+        self.class_name.pop()
+        return original_node
+
+    def leave_ClassDef(
+        self,
+        original_node: cst.ClassDef,
+        updated_node: cst.ClassDef,
+    ) -> Union[cst.BaseStatement, cst.RemovalSentinel]:
+        self.class_name.pop()
+        return original_node
+
+    def _should_output_as_string(self, annotation: str) -> bool:
+        # Parse the annotation expression and extract all names
+        parsed_expr = cst.parse_expression(annotation)
+        extractor = TypeNameExtractor()
+        parsed_expr.visit(extractor)
+        components = extractor.names
+        
+        # Check if all extracted names are in the allowed types list
+        return not all(comp in self.allowed_types for comp in components)
+
     def leave_FunctionDef(
         self,
         original_node: cst.FunctionDef,
         updated_node: cst.FunctionDef,
     ) -> cst.FunctionDef:
-        # real_name = ".".join(self.class_name + [original_node.name.value])
         name = original_node.name.value
-
-        # TODO: the current handling will lead to a bug if a function
-        # appears inside and outside a class definition in the same
-        # file. We need to handle this case.
 
         key = FuncInfo(
             Filename(self.filename),
             FunctionName(name),
-        )  # original_node.name.value))
+        )
         if key in self.type_annotations:
             args, return_type = self.type_annotations[key]
-            # print(f"{args=}, {return_type=}")
-            # Update arguments with type annotations
+
             new_parameters = []
             for parameter in updated_node.params.params:
                 for arg, annotation_ in args:
                     if parameter.name.value == arg:
                         if arg not in self.not_annotated[key]:
                             continue
-                        parsed_annotation = cst.parse_expression(annotation_)
+                        if self._should_output_as_string(annotation_):
+                            annotation_expr = cst.SimpleString(
+                                f'"{annotation_}"'
+                            )
+                        else:
+                            annotation_expr = cst.parse_expression(annotation_)
                         new_parameters.append(
                             parameter.with_changes(
                                 annotation=cst.Annotation(
-                                    annotation=parsed_annotation
+                                    annotation=annotation_expr
                                 )
                             )
                         )
                         break
                 else:
                     new_parameters.append(parameter)
-            parsed_return_type = cst.parse_expression(return_type)
+
+            if self._should_output_as_string(return_type):
+                return_type_expr = cst.SimpleString(f'"{return_type}"')
+            else:
+                return_type_expr = cst.parse_expression(return_type)
+
             if "return" in self.not_annotated[key]:
                 updated_node = updated_node.with_changes(
                     params=updated_node.params.with_changes(
                         params=new_parameters
                     ),
-                    returns=cst.Annotation(annotation=parsed_return_type),
+                    returns=cst.Annotation(annotation=return_type_expr),
                 )
             else:
                 updated_node = updated_node.with_changes(
@@ -99,4 +173,5 @@ class AnnotateFunctionTransformer(cst.CSTTransformer):
                         params=new_parameters
                     ),
                 )
-        return updated_node
+        return updated_node    
+

--- a/righttyper/insert_typing_import_transformer.py
+++ b/righttyper/insert_typing_import_transformer.py
@@ -24,11 +24,29 @@ class InsertTypingImportTransformer(cst.CSTTransformer):
     ) -> cst.Module:
         if not self.has_typing_import:
             # Create the import statement
-            typing_import = cst.SimpleStatementLine(
+            typing_import_star = cst.SimpleStatementLine(
                 body=[
                     cst.ImportFrom(
                         module=cst.Name(value="typing"),
                         names=cst.ImportStar(),
+                    )
+                ]
+            )
+            typing_import = cst.SimpleStatementLine(
+                body=[
+                    cst.ImportFrom(
+                        module=cst.Name(value="typing"),
+                        names=[
+                            cst.ImportAlias(name=cst.Name(value="Any")),
+                            cst.ImportAlias(name=cst.Name(value="Dict")),
+                            cst.ImportAlias(name=cst.Name(value="FrozenSet")),
+                            cst.ImportAlias(name=cst.Name(value="List")),
+                            cst.ImportAlias(name=cst.Name(value="None")),
+                            cst.ImportAlias(name=cst.Name(value="Optional")),
+                            cst.ImportAlias(name=cst.Name(value="Set")),
+                            cst.ImportAlias(name=cst.Name(value="Tuple")),
+                            cst.ImportAlias(name=cst.Name(value="Union")),
+                        ],
                     )
                 ]
             )

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -798,6 +798,23 @@ class ScriptParamType(click.ParamType):
             return ""
 
 
+def split_args_at_triple_dash(
+    args: List[str],
+) -> Tuple[List[str], List[str]]:
+    tool_args = []
+    script_args = []
+    triple_dash_found = False
+    for arg in args:
+        if arg == "---":
+            triple_dash_found = True
+            continue
+        if triple_dash_found:
+            script_args.append(arg)
+        else:
+            tool_args.append(arg)
+    return tool_args, script_args
+
+
 SCRIPT = ScriptParamType()
 
 
@@ -996,20 +1013,3 @@ def main(
         generate_stubs=generate_stubs,
         srcdir=srcdir,
     )
-
-
-def split_args_at_triple_dash(
-    args: List[str],
-) -> Tuple[List[str], List[str]]:
-    tool_args = []
-    script_args = []
-    triple_dash_found = False
-    for arg in args:
-        if arg == "---":
-            triple_dash_found = True
-            continue
-        if triple_dash_found:
-            script_args.append(arg)
-        else:
-            tool_args.append(arg)
-    return tool_args, script_args

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -877,12 +877,6 @@ SCRIPT = ScriptParamType()
     help="Print diagnostic information.",
 )
 @click.option(
-    "--insert-imports",
-    is_flag=True,
-    help="Insert import statements for missing classes (MAY LEAD TO CIRCULAR IMPORTS).",
-    default=False,
-)
-@click.option(
     "--generate-stubs",
     is_flag=True,
     help="Generate stub files (.pyi).",
@@ -935,7 +929,6 @@ def main(
     overwrite: bool,
     output_files: bool,
     ignore_annotations: bool,
-    insert_imports: bool,
     generate_stubs: bool,
     infer_shapes: bool,
     srcdir: str,
@@ -1009,7 +1002,7 @@ def main(
         overwrite=overwrite,
         output_files=output_files,
         ignore_annotations=ignore_annotations,
-        insert_imports=insert_imports,
+        insert_imports=False, # disable inserting imports
         generate_stubs=generate_stubs,
         srcdir=srcdir,
     )


### PR DESCRIPTION
*Description of changes:*

Inserting import statements can lead to circular dependencies. This PR solves this problem by emitting strings as type annotations that contain any unknown types.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
