### PR TITLE
Surround imports with a TYPE_CHECKING conditional.

### DIFF
--- a/righttyper/get_import_details.py
+++ b/righttyper/get_import_details.py
@@ -98,7 +98,7 @@ def get_import_details(
         frame = frame.f_back
     tup = ImportDetails(
         obj_name,
-        frozenset(), # temporarily disabling this: frozenset(obj_aliases),
+        frozenset(), # temporarily disabling this: frozenset(obj_aliases) - this was intended to capture import aliases but is not reliable
         module_name,
         frozenset(module_aliases),
     )

--- a/righttyper/get_import_details.py
+++ b/righttyper/get_import_details.py
@@ -98,7 +98,7 @@ def get_import_details(
         frame = frame.f_back
     tup = ImportDetails(
         obj_name,
-        frozenset(obj_aliases),
+        frozenset(), # temporarily disabling this: frozenset(obj_aliases),
         module_name,
         frozenset(module_aliases),
     )
@@ -228,17 +228,16 @@ def generate_import_nodes(
 
     for alias in details.object_aliases:
         try:
-            import_nodes.append(
-                cst.ImportFrom(
-                    module=create_dotted_name(details.import_module_name),
-                    names=[
-                        cst.ImportAlias(
-                            name=cst.Name(details.object_name),
-                            asname=cst.AsName(name=cst.Name(alias)),
-                        )
-                    ],
-                )
+            stmt = cst.ImportFrom(
+                module=create_dotted_name(details.import_module_name),
+                names=[
+                    cst.ImportAlias(
+                        name=cst.Name(details.object_name),
+                        asname=cst.AsName(name=cst.Name(alias)),
+                    )
+                ],
             )
+            import_nodes.append(stmt)
             import_nodes.append(cst.EmptyLine())
         except cst.CSTValidationError:
             logger.warning(
@@ -257,16 +256,15 @@ def generate_import_nodes(
     import_nodes.append(cst.EmptyLine())
 
     for alias in details.module_aliases:
-        import_nodes.append(
-            cst.Import(
-                names=[
-                    cst.ImportAlias(
-                        name=create_dotted_name(details.import_module_name),
-                        asname=cst.AsName(name=cst.Name(alias)),
-                    )
-                ]
-            )
+        stmt = cst.Import(
+            names=[
+                cst.ImportAlias(
+                    name=create_dotted_name(details.import_module_name),
+                    asname=cst.AsName(name=cst.Name(alias)),
+                )
+            ]
         )
+        import_nodes.append(stmt)
         import_nodes.append(cst.EmptyLine())
 
     return import_nodes

--- a/righttyper/insert_typing_import_transformer.py
+++ b/righttyper/insert_typing_import_transformer.py
@@ -46,6 +46,7 @@ class InsertTypingImportTransformer(cst.CSTTransformer):
                             cst.ImportAlias(name=cst.Name(value="Optional")),
                             cst.ImportAlias(name=cst.Name(value="Set")),
                             cst.ImportAlias(name=cst.Name(value="Tuple")),
+                            cst.ImportAlias(name=cst.Name(value="TYPE_CHECKING")),
                             cst.ImportAlias(name=cst.Name(value="Union")),
                         ],
                     )

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -1039,7 +1039,7 @@ def main(
         overwrite=overwrite,
         output_files=output_files,
         ignore_annotations=ignore_annotations,
-        insert_imports=True, # FIXME # False,  # disable inserting imports
+        insert_imports=True,
         generate_stubs=generate_stubs,
         srcdir=srcdir,
     )

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -1039,7 +1039,7 @@ def main(
         overwrite=overwrite,
         output_files=output_files,
         ignore_annotations=ignore_annotations,
-        insert_imports=False,  # disable inserting imports
+        insert_imports=True, # FIXME # False,  # disable inserting imports
         generate_stubs=generate_stubs,
         srcdir=srcdir,
     )

--- a/righttyper/righttyper_process.py
+++ b/righttyper/righttyper_process.py
@@ -110,16 +110,12 @@ def process_file(
     if modified_tree.code == source:
         return
 
-    # Add an import statement if needed.
-    # FIXME: this messes with from __future__ imports, which need to be the first import
-    transformed = preface_with_typing_import(modified_tree.code)
-
     # If there are needed imports for class defs, process these
     needed_imports = set(
         imp for imp in imports if imp.function_fname == filename
     )
     if needed_imports:
-        tree = cst.parse_module(transformed)
+        tree = cst.parse_module(modified_tree.code)
         import_transformer = ConstructImportTransformer(
             imports=needed_imports,
             root_path=srcdir,
@@ -133,6 +129,11 @@ def process_file(
             print(traceback.format_exc())
             print(e)
 
+    # Add an import statement if needed.
+    # FIXME: this messes with from __future__ imports, which need to be the first import
+    transformed = preface_with_typing_import(transformed)
+
+            
     with open(
         filename + ("" if overwrite else ".typed"),
         "w",


### PR DESCRIPTION
*Description of changes:*

This PR places imports in a TYPE_CHECKING conditional block, which prevents circular references. It now unconditionally adds imports, since this can no longer cause any issues.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
