### PR TITLE
Makes loader more compatible and fixes undefined symbol

### DIFF
--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -3,6 +3,7 @@ import functools
 import inspect
 import logging
 import multiprocessing
+import multiprocessing.connection
 import os
 import runpy
 import signal


### PR DESCRIPTION
*Description of changes:*
- `righttyper` was failing loading certain system modules (e.g., `httpx`), even if not set to modify them. This moves the file selection to its `MetaPathFinder`, which allows modules it need not modify to be processed normally.

- `righttyper` was running into the error:
```
Traceback (most recent call last):
  File "/opt/homebrew/bin/righttyper", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/juan/project/RightTyper/righttyper/righttyper.py", line 1055, in main
    post_process(
  File "/Users/juan/project/RightTyper/righttyper/righttyper.py", line 693, in post_process
    process_all_files(
  File "/Users/juan/project/RightTyper/righttyper/righttyper.py", line 785, in process_all_files
    ready_sentinels = multiprocessing.connection.wait(sentinels)  # Wait for any process sentinel to become ready
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'multiprocessing' has no attribute 'connection'. Did you mean: 'Condition'?

```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
