### PR TITLE
Added deletion of old-style type hint comments when adding annotations, since having both causes mypy errors.

### DIFF
--- a/righttyper/unified_transformer.py
+++ b/righttyper/unified_transformer.py
@@ -1,6 +1,7 @@
 from typing import Dict, List, Optional, Set, Tuple
 
 import libcst as cst
+import re
 
 from righttyper.righttyper_types import (
     ArgumentName,
@@ -44,6 +45,17 @@ _TYPING_TYPES : Set[Typename] = {
     ]
 }
 
+# Regex for a type hint comment
+_TYPE_HINT_COMMENT = re.compile(
+    r"#\stype:\s*[^\s]+"
+)
+
+
+# Regex for a function and retval type hint comment
+_TYPE_HINT_COMMENT_FUNC = re.compile(
+    r"#\stype:\s*\([^\)]*\)\s*->\s*[^\s]+"
+)
+
 
 def _dotted_name(name: str) -> cst.Attribute | cst.Name:
     """Creates CST nodes equivalent to a module name, dotted or not"""
@@ -54,6 +66,18 @@ def _dotted_name(name: str) -> cst.Attribute | cst.Name:
     for part in parts[1:]:
         base = cst.Attribute(value=base, attr=cst.Name(part))
     return base
+
+
+def _get_str_attr(obj: object, path: str) -> Optional[str]:
+    """Looks for a str-valued attribute along the given dot-separated attribute path."""
+    for elem in path.split('.'):
+        if obj and isinstance(obj, (list, tuple)):
+            obj = obj[0]
+
+        if (obj := getattr(obj, elem, None)) is None:
+            break
+
+    return obj if isinstance(obj, str) else None
 
 
 class UnifiedTransformer(cst.CSTTransformer):
@@ -109,23 +133,49 @@ class UnifiedTransformer(cst.CSTTransformer):
                         # TODO recognize (and use) import aliases, transforming annotation
                         annotation_expr: cst.BaseExpression
                         if self._should_output_as_string(annotation_):
-                            annotation_expr = cst.SimpleString(
-                                f'"{annotation_}"'
-                            )
-                        else:
-                            parsed_expr = cst.parse_expression(annotation_)
-                            annotation_expr = parsed_expr
-                        new_parameters.append(
-                            parameter.with_changes(
+                            new_par = parameter.with_changes(
                                 annotation=cst.Annotation(
-                                    annotation=annotation_expr
+                                    annotation=cst.SimpleString(f'"{annotation_}"')
                                 )
                             )
-                        )
+                        else:
+                            new_par = parameter.with_changes(
+                                annotation=cst.Annotation(
+                                    annotation=cst.parse_expression(annotation_)
+                                )
+                            )
+
+                        # remove per-parameter type hint comment for non-last parameter
+                        if ((comment := _get_str_attr(new_par, "comma.whitespace_after.first_line.comment.value"))
+                            and _TYPE_HINT_COMMENT.match(comment)):
+                            new_par = new_par.with_changes(
+                                comma=new_par.comma.with_changes(   # type: ignore[union-attr]
+                                    whitespace_after=new_par.comma.whitespace_after.with_changes( # type: ignore[union-attr]
+                                        first_line=cst.TrailingWhitespace()
+                                    )
+                                )
+                            )
+
+                        # remove per-parameter type hint comment for last parameter
+                        if ((comment := _get_str_attr(new_par, "whitespace_after_param.first_line.comment.value"))
+                            and _TYPE_HINT_COMMENT.match(comment)):
+                            new_par = new_par.with_changes(
+                                whitespace_after_param=new_par.whitespace_after_param.with_changes(
+                                    first_line=cst.TrailingWhitespace()
+                                )
+                            )
+
+                        new_parameters.append(new_par)
                         self.used_types |= types_in_annotation(annotation_)
                         break
                 else:
                     new_parameters.append(parameter)
+
+            updated_node = updated_node.with_changes(
+                params=updated_node.params.with_changes(
+                    params=new_parameters
+                )
+            )
 
             if "return" in self.not_annotated.get(key, set()):
                 return_type_expr: cst.BaseExpression
@@ -135,18 +185,27 @@ class UnifiedTransformer(cst.CSTTransformer):
                     return_type_expr = cst.parse_expression(return_type)
 
                 updated_node = updated_node.with_changes(
-                    params=updated_node.params.with_changes(
-                        params=new_parameters
-                    ),
                     returns=cst.Annotation(annotation=return_type_expr),
                 )
                 self.used_types |= types_in_annotation(return_type)
-            else:
+
+                # remove "(...) -> retval"-style type hint comment
+                if ((comment := _get_str_attr(updated_node, "body.body.leading_lines.comment.value"))
+                    and _TYPE_HINT_COMMENT_FUNC.match(comment)):
+                    updated_node = updated_node.with_changes(
+                        body=updated_node.body.with_changes(
+                            body=(updated_node.body.body[0].with_changes(leading_lines=[]),
+                                  *updated_node.body.body[1:])
+                        )
+                    )
+
+            # remove single-line type hint comment in the same line as the 'def'
+            if ((comment := _get_str_attr(updated_node, "body.header.comment.value"))
+                and _TYPE_HINT_COMMENT_FUNC.match(comment)):
                 updated_node = updated_node.with_changes(
-                    params=updated_node.params.with_changes(
-                        params=new_parameters
-                    ),
-                )
+                    body=updated_node.body.with_changes(
+                        header=cst.TrailingWhitespace()))
+
         return updated_node
 
     # ConstructImportTransformer logic
@@ -240,15 +299,15 @@ class UnifiedTransformer(cst.CSTTransformer):
         return updated_node
 
 
-def types_in_annotation(annotation: str) -> Set[str]:
+def types_in_annotation(annotation: str) -> Set[Typename]:
     """Extracts all type names included in a type annotation."""
 
     class TypeNameExtractor(cst.CSTVisitor):
         def __init__(self) -> None:
-            self.names: Set[str] = set()
+            self.names: Set[Typename] = set()
 
         def visit_Name(self, node: cst.Name) -> Optional[bool]:
-            self.names.add(node.value)
+            self.names.add(Typename(node.value))
             return False 
 
         def visit_Attribute(self, node: cst.Attribute) -> Optional[bool]:
@@ -259,7 +318,7 @@ def types_in_annotation(annotation: str) -> Set[str]:
                 current_node = current_node.value
             if isinstance(current_node, cst.Name):
                 full_name = f"{current_node.value}.{full_name}"
-            self.names.add(full_name)
+            self.names.add(Typename(full_name))
             return False 
 
     parsed_expr = cst.parse_expression(annotation)


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
