### PR TITLE
Moved to transformer-based alias search, avoiding confusion when types are seen in other context

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: install dependencies
       run: |
-        python3 -m pip install pytest pytest-asyncio pytest-mock hypothesis ml_dtypes
+        python3 -m pip install pytest pytest-asyncio pytest-mock hypothesis ml_dtypes mypy
         python3 -m pip install .
 
     - name: run tests

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -232,7 +232,7 @@ def exit_function_worker(
       and then disables the monitoring if appropriate.
 
     Args:
-    code (CodeType): bytecode of the function.
+    code (CodeType): code object of the function.
     instruction_offset (int): position of the current instruction.
     return_value (Any): return value of the function.
     event_type (int): if this is a PY_RETURN (regular return) or a PY_YIELD (yield)
@@ -275,12 +275,12 @@ def exit_function_worker(
     if event_type == sys.monitoring.events.PY_YIELD:
         # Yield: call it a generator
         if type(return_value).__name__ == "async_generator_wrapped_value":
-            # FIXME: how to obtain wrapped value? how to get send value?
-            typename = f"AsyncGenerator[Any, Any]"
+            # FIXME: how to obtain wrapped value without await? how to get send value?
+            typename = f"typing.AsyncGenerator[typing.Any, typing.Any]"
         else:
             # FIXME: We should be returning more precise Generators if we discover a return value.
             # See https://docs.python.org/3.10/library/typing.html#typing.Generator
-            typename = f"Generator[{typename}, Any, Any]"
+            typename = f"typing.Generator[{typename}, typing.Any, typing.Any]"
         yielded_funcs.add(t)
 
     # Check if the return value type is already in the set

--- a/righttyper/righttyper_runtime.py
+++ b/righttyper/righttyper_runtime.py
@@ -8,6 +8,7 @@ from functools import cache
 from itertools import islice
 from types import CodeType, FrameType, NoneType, FunctionType, MethodType, GenericAlias
 from typing import Any, cast
+from pathlib import Path
 
 from righttyper.random_dict import RandomDict
 from righttyper.righttyper_types import (
@@ -162,7 +163,7 @@ def get_type_name(obj: type, depth: int = 0) -> str:
         # We have likely fallen into an infinite recursion.
         # Fail gracefully to return "Never" while reporting the warning.
         print(f"Warning: RightTyper failed to compute the type of {obj}.")
-        return "Never"
+        return "typing.Never"
 
     # Some builtin types are available from the "builtins" module,
     # some from the "types" module, but others still, such as
@@ -175,10 +176,10 @@ def get_type_name(obj: type, depth: int = 0) -> str:
         elif (name := from_types_import(obj)):
             return f"types.{name}"
         elif obj is RANGE_ITER_TYPE:
-            return "Iterator[int]"
+            return "typing.Iterator[int]"
         # TODO match other ABC from collections.abc based on interface
         elif issubclass(obj, Iterator):
-            return "Iterator[Any]"
+            return "typing.Iterator[typing.Any]"
         else:
             # fall back to its name, just so we can tell where it came from.
             return f"builtins.{obj.__name__}"
@@ -188,28 +189,31 @@ def get_type_name(obj: type, depth: int = 0) -> str:
         t_name = obj.__qualname__.split('[')[0]
         return f"{obj.__module__}.{t_name}[{get_type_name(obj.type, depth+1)}]"
 
-    # Look for a local alias for the type
-    # FIXME this only checks for globally known names, and doesn't match inner classes (e.g., Foo.Bar).
-    # FIXME that name may be locally bound to something different, hiding the global
-    if caller_frame := find_caller_frame():
-        current_namespace = caller_frame.f_globals
-        if current_namespace.get(obj.__name__) is obj:
-            return obj.__name__
+    # Disabled for now: passing types using aliases at this point can lead to
+    # confusion, as there can be an alias that conflicts with a module's fully
+    # qualified name.  For example, "import x.y as ast" would conflict with "ast.If"
+    if False:
+        # Look for a local alias for the type
+        # FIXME this only checks for globally known names, and doesn't match inner classes (e.g., Foo.Bar).
+        # FIXME that name may be locally bound to something different, hiding the global
+        if caller_frame := find_caller_frame():
+            current_namespace = caller_frame.f_globals
+            if current_namespace.get(obj.__name__) is obj:
+                return obj.__name__
 
-        # Check if the type is accessible from a module in the current namespace
-        for name, mod in current_namespace.items():
-            if (
-                inspect.ismodule(mod)
-                and hasattr(mod, obj.__name__)
-                and getattr(mod, obj.__name__) is obj
-            ):
-                return f"{name}.{obj.__name__}"
+            # Check if the type is accessible from a module in the current namespace
+            for name, mod in current_namespace.items():
+                if (
+                    inspect.ismodule(mod)
+                    and hasattr(mod, obj.__name__)
+                    and getattr(mod, obj.__name__) is obj
+                ):
+                    return f"{name}.{obj.__name__}"
 
-    # We currently consider all "typing" types well known (and import them as needed)
-    if obj.__module__ and obj.__module__ not in ("__main__", "typing"):
-        return f"{obj.__module__}.{obj.__qualname__}"
+    if obj.__module__ == "__main__":
+        return f"{get_main_module_fqn()}.{obj.__qualname__}"
 
-    return obj.__qualname__
+    return f"{obj.__module__}.{obj.__qualname__}"
 
 
 def _is_instance(obj: object, types: tuple[type, ...]) -> type|None:
@@ -234,29 +238,30 @@ def get_full_type(value: Any, depth: int = 0) -> str:
         # We have likely fallen into an infinite recursion.
         # Fail gracefully to return "Never" while reporting the warning.
         print(f"Warning: RightTyper failed to compute the type of {value}.")
-        return "Never"
+        return "typing.Never"
 
     if isinstance(value, dict):
         if value:
             el = value.random_item() if isinstance(value, RandomDict) else sample_from_collection(value.items())
             return f"dict[{get_full_type(el[0], depth+1)}, {get_full_type(el[1], depth+1)}]"
         else:
-            return "dict[Never, Never]"
+            return "dict[typing.Never, typing.Never]"
     elif (t := _is_instance(value, (KeysView, ValuesView, list, set))):
+        module = "" if t.__module__ == "builtins" else f"typing."
         if value:
             el = sample_from_collection(value)
-            return f"{t.__qualname__}[{get_full_type(el, depth+1)}]"
+            return f"{module}{t.__qualname__}[{get_full_type(el, depth+1)}]"
         else:
-            return f"{t.__qualname__}[Never]"
+            return f"{module}{t.__qualname__}[typing.Never]"
     elif isinstance(value, ItemsView):
         if value:
             el = sample_from_collection(value)
-            return f"ItemsView[{get_full_type(el[0], depth+1)}, {get_full_type(el[1], depth+1)}]"
+            return f"typing.ItemsView[{get_full_type(el[0], depth+1)}, {get_full_type(el[1], depth+1)}]"
         else:
-            return "ItemsView[Never, Never]"
+            return "typing.ItemsView[typing.Never, typing.Never]"
     elif isinstance(value, tuple):
         if isinstance_namedtuple(value):
-            return f"{value.__class__.__name__}"
+            return f"{value.__class__.__module__}.{value.__class__.__qualname__}"
         else:
             if value:
                 return f"tuple[{', '.join(get_full_type(elem, depth+1) for elem in value)}]"
@@ -265,15 +270,15 @@ def get_full_type(value: Any, depth: int = 0) -> str:
     elif isinstance(value, (FunctionType, MethodType)):
         return type_from_annotations(value)
     elif isinstance(value, Generator):
-        return "Generator[Any, Any, Any]"  # FIXME needs yield / send / return types
+        return "typing.Generator[typing.Any, typing.Any, typing.Any]"  # FIXME needs yield / send / return types
     elif isinstance(value, AsyncGenerator):
-        return "AsyncGenerator[Any, Any]"  # FIXME needs yield / send types
+        return "typing.AsyncGenerator[typing.Any, typing.Any]"  # FIXME needs yield / send types
     elif isinstance(value, Coroutine):
-        return "Coroutine[Any, Any, Any]"  # FIXME needs yield / send / return types
+        return "typing.Coroutine[typing.Any, typing.Any, typing.Any]"  # FIXME needs yield / send / return types
     elif hasattr(value, "dtype"):
         # Certain dtype types' __qualname__ doesn't include a fully qualified
         # name of their inner type; look them up separately to work around that.
-        return f"{get_type_name(type(value), depth+1)}[Any, {get_type_name(type(value.dtype), depth+1)}]"
+        return f"{get_type_name(type(value), depth+1)}[typing.Any, {get_type_name(type(value.dtype), depth+1)}]"
     else:
         return get_type_name(type(value), depth+1)
 
@@ -281,7 +286,7 @@ def get_full_type(value: Any, depth: int = 0) -> str:
 def get_adjusted_full_type(value: Any, class_type: type|None=None) -> str:
     #print(f"{type(value)=} {class_type=}")
     if type(value) == class_type:
-        return "Self"
+        return "typing.Self"
 
     return get_full_type(value)
 
@@ -434,3 +439,41 @@ def get_class_source_file(cls: type) -> str:
         pass
 
     return ""
+
+
+def _source_relative_to_pkg(file: Path) -> Path|None:
+    """Returns a Python source file's path relative to its package"""
+    if not file.is_absolute():
+        file = file.resolve()
+
+    parents = list(file.parents)
+
+    for d in sys.path:
+        path = Path(d)
+        if not path.is_absolute():
+            path = path.resolve()
+
+        for p in parents:
+            if p == path:
+                return file.relative_to(p)
+
+    return None
+
+
+def source_to_module_fqn(file: Path) -> str|None:
+    """Returns a source file's fully qualified package name, if possible."""
+    if not (path := _source_relative_to_pkg(file)):
+        return None
+
+    path = path.parent if path.name == '__init__.py' else path.parent / path.stem
+    return '.'.join(path.parts)
+
+
+@cache
+def get_main_module_fqn() -> str:
+    main = sys.modules['__main__']
+    if hasattr(main, "__file__") and main.__file__:
+        if fqn := source_to_module_fqn(Path(main.__file__)):
+            return fqn
+
+    return "__main__"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -102,7 +102,7 @@ def test_numpy_type_name(tmp_cwd):
     output = Path("t.py").read_text()
 
     assert "import bfloat16" not in output
-    assert "def f(t: \"numpy.dtype[ml_dtypes.bfloat16]\") -> None" in output
+    assert "def f(t: np.dtype[ml_dtypes.bfloat16]) -> None" in output
 
 
 @pytest.mark.skipif((importlib.util.find_spec('ml_dtypes') is None or
@@ -126,8 +126,8 @@ def test_numpy_ndarray_dtype_name(tmp_cwd):
                     '--no-use-multiprocessing', 't.py'], check=True)
     output = Path("t.py").read_text()
 
-    assert "import bfloat16" not in output
-    assert "def f(p: \"np.ndarray[Any, numpy.dtype[ml_dtypes.bfloat16]]\") -> str" in output
+    assert "import bfloat16\n" not in output
+    assert "def f(p: np.ndarray[Any, np.dtype[ml_dtypes.bfloat16]]) -> str" in output
 
 
 @pytest.mark.skipif((importlib.util.find_spec('ml_dtypes') is None or
@@ -153,9 +153,7 @@ def test_annotation_with_numpy_dtype_name(tmp_cwd):
                     '--no-use-multiprocessing', 't.py'], check=True)
     output = Path("t.py").read_text()
 
-    assert "def g() -> \"Callable[[], numpy.ndarray[typing.Any, numpy.dtype[ml_dtypes.bfloat16]]]\":" in output
-    assert "import numpy" in output
-    assert "import ml_dtypes" in output
+    assert "def g() -> Callable[[], np.ndarray[Any, np.dtype[bf16]]]:" in output
 
 
 def test_call_with_none_default(tmp_cwd):
@@ -550,7 +548,6 @@ def test_generate_stubs(tmp_cwd):
         """)
 
 
-@pytest.mark.xfail(reason="Doesn't work yet")
 def test_type_from_main(tmp_cwd):
     Path("m.py").write_text(textwrap.dedent("""\
         def f(x):
@@ -572,7 +569,7 @@ def test_type_from_main(tmp_cwd):
     subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
                     '--no-use-multiprocessing', 't.py'], check=True)
     output = Path("m.py").read_text()
-    assert "def foo(x: t.C) -> str:" in output
+    assert "def f(x: \"t.C\") -> str:" in output
 
     subprocess.run([sys.executable, '-m', 'mypy', 'm.py', 't.py'], check=True)
 
@@ -695,8 +692,7 @@ def test_function_type_in_annotation(tmp_cwd):
 
     output = Path("t.py").read_text()
     assert 'def bar(g: FunctionType, x: int) -> float:' in output
-    # FIXME the quotes around the type are because UnifiedTransformer doesn't realize it's already known
-    assert 'def baz(f: "Callable[[types.FunctionType, Any], Any]", g: Callable[[int], float], x: int) -> float:' in output
+    assert 'def baz(f: Callable[[FunctionType, Any], Any], g: Callable[[int], float], x: int) -> float:' in output
 
 
 @pytest.mark.xfail(reason="our function types are all annotation-based so far")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -262,7 +262,7 @@ def test_class_method(tmp_cwd):
     output = Path("t.py").read_text()
     
     assert "def f(self: Self, n: int) -> int" in output
-    assert "import Self" not in output
+    assert "\nimport Self" not in output
 
     assert "def h(self: Self, x: int) -> float" in output
 
@@ -293,7 +293,7 @@ def test_class_method_imported(tmp_cwd):
                     '--no-use-multiprocessing', 't.py'], check=True)
     output = Path("m.py").read_text()
     
-    assert "import Self" not in output
+    assert "\nimport Self" not in output
 
     assert "def f(self: Self, n: int) -> int" in output
     assert "import C" not in output
@@ -535,7 +535,7 @@ def test_generate_stubs(tmp_cwd):
     output = Path("m.pyi").read_text()
     # FIXME this assertion is brittle
     assert output == textwrap.dedent("""\
-        from typing import TYPE_CHECKING, Self
+        from typing import Self
         import sys
         from typing import Any
         CONST: int

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -45,27 +45,27 @@ def test_get_full_type():
 
     assert "dict[str, str]" == get_full_type({'a': 'b'})
 
-    assert "KeysView[str]" == get_full_type({'a':0, 'b':1}.keys())
-    assert "ValuesView[int]" == get_full_type({'a':0, 'b':1}.values())
-    assert "ItemsView[str, int]" == get_full_type({'a':0, 'b':1}.items())
+    assert "typing.KeysView[str]" == get_full_type({'a':0, 'b':1}.keys())
+    assert "typing.ValuesView[int]" == get_full_type({'a':0, 'b':1}.values())
+    assert "typing.ItemsView[str, int]" == get_full_type({'a':0, 'b':1}.items())
 
-    assert "KeysView[Never]" == get_full_type(dict().keys())
-    assert "ValuesView[Never]" == get_full_type(dict().values())
-    assert "ItemsView[Never, Never]" == get_full_type(dict().items())
+    assert "typing.KeysView[typing.Never]" == get_full_type(dict().keys())
+    assert "typing.ValuesView[typing.Never]" == get_full_type(dict().values())
+    assert "typing.ItemsView[typing.Never, typing.Never]" == get_full_type(dict().items())
 
     assert "set[str]" == get_full_type({'a', 'b'})
-    assert "set[Never]" == get_full_type(set())
+    assert "set[typing.Never]" == get_full_type(set())
 
     o : Any = range(10)
     assert "range" == get_full_type(o)
     assert 0 == next(iter(o)), "changed state"
 
     o = iter(range(10))
-    assert "Iterator[int]" == get_full_type(o)
+    assert "typing.Iterator[int]" == get_full_type(o)
     assert 0 == next(o), "changed state"
 
     o = iter([0,1])
-    assert "Iterator[Any]" == get_full_type(o)
+    assert "typing.Iterator[typing.Any]" == get_full_type(o)
     assert 0 == next(o), "changed state"
 
     o = enumerate([0,1])
@@ -77,7 +77,7 @@ def test_get_full_type():
     assert 0 == next(o), "changed state"
 
     o = reversed([0,1])
-    assert "Iterator[Any]" == get_full_type(o)
+    assert "typing.Iterator[typing.Any]" == get_full_type(o)
     assert 1 == next(o), "changed state"
 
     o = zip([0,1], ['a','b'])
@@ -89,41 +89,41 @@ def test_get_full_type():
     assert 0 == next(o), "changed state"
 
     o = iter({0, 1})
-    assert "Iterator[Any]" == get_full_type(o)
+    assert "typing.Iterator[typing.Any]" == get_full_type(o)
     assert 0 == next(o), "changed state"
 
     o = iter({0:0, 1:1})
-    assert "Iterator[Any]" == get_full_type(o)
+    assert "typing.Iterator[typing.Any]" == get_full_type(o)
     assert 0 == next(o), "changed state"
 
     o = iter({0:0, 1:1}.items())
-    assert "Iterator[Any]" == get_full_type(o)
+    assert "typing.Iterator[typing.Any]" == get_full_type(o)
     assert (0, 0) == next(o), "changed state"
 
     o = iter({0:0, 1:1}.values())
-    assert "Iterator[Any]" == get_full_type(o)
+    assert "typing.Iterator[typing.Any]" == get_full_type(o)
     assert 0 == next(o), "changed state"
 
     o = iter({0:0, 1:1}.keys())
-    assert "Iterator[Any]" == get_full_type(o)
+    assert "typing.Iterator[typing.Any]" == get_full_type(o)
     assert 0 == next(o), "changed state"
 
     o = iter({0:0, 1:1}.items())
-    assert "Iterator[Any]" == get_full_type(o)
+    assert "typing.Iterator[typing.Any]" == get_full_type(o)
     assert (0, 0) == next(o), "changed state"
 
     o = iter({0:0, 1:1}.values())
-    assert "Iterator[Any]" == get_full_type(o)
+    assert "typing.Iterator[typing.Any]" == get_full_type(o)
     assert 0 == next(o), "changed state"
 
     o = (i for i in range(10))
-    assert "Generator[Any, Any, Any]" == get_full_type(o)
+    assert "typing.Generator[typing.Any, typing.Any, typing.Any]" == get_full_type(o)
     assert 0 == next(o), "changed state"
 
     Point = namedtuple('Point', ['x', 'y'])
-    assert "Point" == get_full_type(Point(1,1))
+    assert f"{__name__}.Point" == get_full_type(Point(1,1))
 
-    assert "IterableClass" == get_full_type(IterableClass())
+    assert f"{__name__}.IterableClass" == get_full_type(IterableClass())
     assert "super" == get_full_type(super(IterableClass))
 
     assert "slice" == get_full_type(slice(0, 5, 1))
@@ -134,8 +134,8 @@ def test_get_full_type():
         for i in range(start):
             yield i
 
-    assert "AsyncGenerator[Any, Any]" == get_full_type(async_range(10))
-    assert "AsyncGenerator[Any, Any]" == get_full_type(aiter(async_range(10)))
+    assert "typing.AsyncGenerator[typing.Any, typing.Any]" == get_full_type(async_range(10))
+    assert "typing.AsyncGenerator[typing.Any, typing.Any]" == get_full_type(aiter(async_range(10)))
 
 
 @pytest.mark.filterwarnings("ignore:coroutine .* never awaited")
@@ -144,14 +144,14 @@ def test_get_full_type_coro():
         import asyncio
         await asyncio.sleep(1)
 
-    assert "Coroutine[Any, Any, Any]" == get_full_type(coro())
+    assert "typing.Coroutine[typing.Any, typing.Any, typing.Any]" == get_full_type(coro())
 
 
 @pytest.mark.skipif(importlib.util.find_spec('numpy') is None, reason='missing module numpy')
 def test_get_full_type_dtype():
     import numpy as np
 
-    assert "numpy.ndarray[Any, numpy.dtypes.Float64DType]" == get_full_type(np.array([], np.float64))
+    assert "numpy.ndarray[typing.Any, numpy.dtypes.Float64DType]" == get_full_type(np.array([], np.float64))
 
 
 class NamedTupleClass:
@@ -178,7 +178,7 @@ def test_adjusted_full_type():
     class Bar:
         pass
 
-    assert "Self" == get_adjusted_full_type(Foo(), Foo)
-    assert f"Foo" == get_adjusted_full_type(Foo())
+    assert "typing.Self" == get_adjusted_full_type(Foo(), Foo)
+    assert f"{__name__}.Foo" == get_adjusted_full_type(Foo())
 
-    assert f"test_typing.test_adjusted_full_type.<locals>.Bar" == get_adjusted_full_type(Bar())
+    assert f"{__name__}.test_adjusted_full_type.<locals>.Bar" == get_adjusted_full_type(Bar())


### PR DESCRIPTION
It also improves "from typing" and "if TYPE_CHECKING" statement handling and also handles `__main__`-defined types.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
