### PR TITLE
Changes the logic for `--include-files` and `--include-functions`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ authors = [
 dependencies = [ "libcst >= 1.2.0",
 		 "click >= 8.1.7",
 		 "rich >= 13.7.1",
+		 "wcmatch >= 10.0",
 		 ]
 	 
 description = "A fast runtime type hint assistant for Python code."

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -9,6 +9,7 @@ import os
 import runpy
 import signal
 import sys
+
 import collections.abc as abc
 from collections import defaultdict
 from dataclasses import dataclass, field
@@ -63,9 +64,9 @@ from righttyper.righttyper_utils import (
 @dataclass
 class Options:
     script_dir: str = ""
-    include_files_regex: str = ""
+    include_files_pattern: str = ""
     include_all: bool = False
-    include_functions_regex: str = ""
+    include_functions_pattern: str = ""
     target_overhead: float = 5.0
     infer_shapes: bool = False
     ignore_annotations: bool = False
@@ -219,8 +220,8 @@ def enter_function(code: CodeType, offset: int) -> Any:
         code,
         options.script_dir,
         options.include_all,
-        options.include_files_regex,
-        options.include_functions_regex
+        options.include_files_pattern,
+        options.include_functions_pattern
     ):
         return sys.monitoring.DISABLE
 
@@ -264,8 +265,8 @@ def call_handler(
             code,
             options.script_dir,
             options.include_all,
-            options.include_files_regex,
-            options.include_functions_regex,
+            options.include_files_pattern,
+            options.include_functions_pattern,
         ):
             sys.monitoring.set_local_events(
                 TOOL_ID,
@@ -333,8 +334,8 @@ def exit_function_worker(
         code,
         options.script_dir,
         options.include_all,
-        options.include_files_regex,
-        options.include_functions_regex
+        options.include_files_pattern,
+        options.include_functions_pattern
     ):
         return sys.monitoring.DISABLE
 
@@ -554,7 +555,7 @@ def process_all_files() -> list[SignatureChanges]:
             t.file_name,
             options.script_dir,
             options.include_all,
-            options.include_files_regex
+            options.include_files_pattern
         )
     )
 
@@ -671,12 +672,12 @@ class CheckModule(click.ParamType):
 @click.option(
     "--include-files",
     type=str,
-    help="Include only files matching the given regex pattern.",
+    help="Include only files matching the given pattern.",
 )
 @click.option(
     "--include-functions",
-    type=str,
-    help="Only annotate functions matching the given regex pattern.",
+    multiple=True,
+    help="Only annotate functions matching the given pattern.",
 )
 @click.option(
     "--infer-shapes",
@@ -764,7 +765,7 @@ def main(
     args: list[str],
     all_files: bool,
     include_files: str,
-    include_functions: str,
+    include_functions: tuple[str],
     type_coverage_by_directory: str,
     type_coverage_by_file: str,
     type_coverage_summary: str,
@@ -838,9 +839,9 @@ def main(
 
     debug_print_set_level(verbose)
     options.script_dir = os.path.dirname(os.path.realpath(script))
-    options.include_files_regex = include_files
+    options.include_files_pattern = include_files
     options.include_all = all_files
-    options.include_functions_regex = include_functions
+    options.include_functions_pattern = include_functions
     options.target_overhead = target_overhead
     options.infer_shapes = infer_shapes
     options.ignore_annotations = ignore_annotations

--- a/righttyper/righttyper_runtime.py
+++ b/righttyper/righttyper_runtime.py
@@ -3,6 +3,7 @@ import os
 import random
 import re
 import sys
+
 import collections.abc as abc
 from functools import cache
 from itertools import islice
@@ -22,7 +23,7 @@ from righttyper.righttyper_types import (
     TypeInfoSet,
     TypeInfo
 )
-from righttyper.righttyper_utils import skip_this_file, get_main_module_fqn
+from righttyper.righttyper_utils import skip_this_file, get_main_module_fqn, glob_translate_to_regex
 
 
 def sample_from_collection(value: abc.Collection[T]|abc.Iterator[T], depth = 0) -> T:
@@ -70,8 +71,8 @@ def should_skip_function(
     code: CodeType,
     script_dir: str,
     include_all: bool,
-    include_files_regex: str,
-    include_functions_regex: str
+    include_files_pattern: str,
+    include_functions_pattern: list[str]
 ) -> bool:
     if (
         code.co_name.startswith("<")
@@ -79,9 +80,9 @@ def should_skip_function(
             code.co_filename,
             script_dir,
             include_all,
-            include_files_regex,
+            include_files_pattern,
         )
-        or (include_functions_regex and not re.search(include_functions_regex, code.co_name))
+        or (include_functions_pattern and all([not re.search(glob_translate_to_regex(pattern), code.co_name) for pattern in include_functions_pattern]))
         or "righttyper" + os.sep in code.co_filename
     ):
         return True

--- a/righttyper/righttyper_utils.py
+++ b/righttyper/righttyper_utils.py
@@ -1,11 +1,12 @@
 import logging
-import os
 import re
+import os
+import sys
+
 from functools import cache
 from typing import Any, Final, cast, Iterator
 import itertools
 from pathlib import Path
-import sys
 
 from righttyper.righttyper_types import (
     ArgInfo,
@@ -26,6 +27,16 @@ _SAMPLING_INTERVAL = 0.01
 _DEBUG_PRINT: bool = False
 
 logger = logging.getLogger("righttyper")
+
+
+def glob_translate_to_regex(r):
+    if sys.version_info < (3, 13):
+        # glob.translate not available until 3.13; use wcmatch's implementation
+        from wcmatch import glob
+        return glob.translate(r)[0][0]
+    else:
+        import glob
+        return glob.translate(r)
 
 
 def reset_sampling_interval() -> None:
@@ -129,10 +140,10 @@ def skip_this_file(
     filename: str,
     script_dir: str,
     include_all: bool,
-    include_files_regex: str,
+    include_files_pattern: str,
 ) -> bool:
     debug_print(
-        f"checking skip_this_file: {script_dir=}, {filename=}, {include_files_regex=}"
+        f"checking skip_this_file: {script_dir=}, {filename=}, {include_files_pattern=}"
     )
     if include_all:
         should_skip = False
@@ -145,9 +156,9 @@ def skip_this_file(
             or "righttyper.py" in filename
             or script_dir not in os.path.abspath(filename)
         )
-    if include_files_regex:
+    if include_files_pattern:
         should_skip = should_skip or not re.search(
-            include_files_regex, filename
+            glob_translate_to_regex(include_files_pattern), filename
         )
     return should_skip
 


### PR DESCRIPTION
Changes `--include-files` and `--include-functions` to use glob-style matching rather than regular expressions, which should be more intuitive (if less powerful). Also allows `--include-functions` to be specified multiple times to allow matching more than one function pattern at a time; might make sense to provide the same functionality for `--include-files`.

*Issue #, if available:*
https://github.com/RightTyper/RightTyper/issues/65

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
