### PR TITLE
Backed out glob approach

### DIFF
--- a/righttyper/righttyper_utils.py
+++ b/righttyper/righttyper_utils.py
@@ -152,13 +152,13 @@ def skip_this_file(
             filename.startswith("<")
             or filename.startswith("/Library")
             or filename.startswith("/opt/homebrew/")
-            or "/site-packages/" in filename
+            or os.sep + "site-packages" + os.sep in filename
             or "righttyper.py" in filename
             or script_dir not in os.path.abspath(filename)
         )
     if include_files_pattern:
         should_skip = should_skip or not re.search(
-            glob_translate_to_regex(include_files_pattern), filename
+            include_files_pattern, filename
         )
     return should_skip
 


### PR DESCRIPTION
*Issue #, if available:*

Another update to https://github.com/RightTyper/RightTyper/issues/65

*Description of changes:*

Updates https://github.com/RightTyper/RightTyper/commit/cb578340a219dda74109efbcfea561dc6af20eb3; backs out the use of glob, which turns out to have issues with file separators. Maintains the addition of multiple function matchers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
