### PR TITLE
Fixed Type Eval Bug

### DIFF
--- a/righttyper/righttyper_runtime.py
+++ b/righttyper/righttyper_runtime.py
@@ -287,6 +287,7 @@ def _is_instance(obj: object, types: tuple[type, ...]) -> type|None:
 
     return None
 
+
 def get_full_type(value: Any, /, use_jaxtyping: bool = False, depth: int = 0) -> TypeInfo:
     """
     get_full_type takes a value (an instance) as input and returns a string representing its type.


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Modifies the `get_full_type` function so that it handles errors correctly.

In particular, when evaluating the type of a collection, if an error is thrown, then it is assumed to be a collection of `never`, which is also the behavior for empty collections.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
