### PR TITLE
Fixes issue #77, adds tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ righttyper.egg-info/
 */__pycache__/
 .venv
 venv
+righttyper.log

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -145,7 +145,6 @@ class Observations:
             is_async_generator=bool(code.co_flags & inspect.CO_ASYNC_GENERATOR),
             is_generator=bool(code.co_flags & inspect.CO_GENERATOR)
         )
-        print(self.pending_samples[(CodeId(id(code)), frame_id)])
 
 
     def record_yield(self, code: CodeType, frame_id: FrameId, yield_type: TypeInfo) -> bool:

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -139,11 +139,13 @@ class Observations:
         """Records a function start."""
 
         # print(f"record_start {code.co_qualname} {arg_types}")
+        is_async = bool(code.co_flags & (inspect.CO_ASYNC_GENERATOR | inspect.CO_COROUTINE))
         self.pending_samples[(CodeId(id(code)), frame_id)] = Sample(
             arg_types,
             self_type=self_type,
-            is_async_generator=bool(code.co_flags & inspect.CO_ASYNC_GENERATOR),
-            is_generator=bool(code.co_flags & inspect.CO_GENERATOR)
+            is_async=is_async,
+            is_generator=bool(code.co_flags & inspect.CO_GENERATOR) \
+                or (is_async and (code.co_flags & inspect.CO_ASYNC_GENERATOR))
         )
 
 

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -142,8 +142,10 @@ class Observations:
         self.pending_samples[(CodeId(id(code)), frame_id)] = Sample(
             arg_types,
             self_type=self_type,
-            is_async=bool(code.co_flags & (inspect.CO_ASYNC_GENERATOR|inspect.CO_COROUTINE))
+            is_async_generator=bool(code.co_flags & inspect.CO_ASYNC_GENERATOR),
+            is_generator=bool(code.co_flags & inspect.CO_GENERATOR)
         )
+        print(self.pending_samples[(CodeId(id(code)), frame_id)])
 
 
     def record_yield(self, code: CodeType, frame_id: FrameId, yield_type: TypeInfo) -> bool:

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -139,13 +139,11 @@ class Observations:
         """Records a function start."""
 
         # print(f"record_start {code.co_qualname} {arg_types}")
-        is_async = bool(code.co_flags & (inspect.CO_ASYNC_GENERATOR | inspect.CO_COROUTINE))
         self.pending_samples[(CodeId(id(code)), frame_id)] = Sample(
             arg_types,
             self_type=self_type,
-            is_async=is_async,
-            is_generator=bool(code.co_flags & inspect.CO_GENERATOR) \
-                or (is_async and (code.co_flags & inspect.CO_ASYNC_GENERATOR))
+            is_async=bool(code.co_flags & (inspect.CO_ASYNC_GENERATOR | inspect.CO_COROUTINE)),
+            is_generator=bool(code.co_flags & (inspect.CO_ASYNC_GENERATOR | inspect.CO_GENERATOR)),
         )
 
 

--- a/righttyper/righttyper_types.py
+++ b/righttyper/righttyper_types.py
@@ -147,7 +147,7 @@ class Sample:
     args: tuple[TypeInfo, ...]
     yields: set[TypeInfo] = field(default_factory=set)
     returns: TypeInfo = NoneTypeInfo
-    is_async_generator: bool = False
+    is_async: bool = False
     is_generator: bool = False
     self_type: TypeInfo | None = None
 
@@ -155,13 +155,13 @@ class Sample:
     def process(self) -> tuple[TypeInfo, ...]:
         retval = self.returns
 
-        if self.is_async_generator:
+        if self.is_async and self.is_generator:
             # FIXME need send type
             y = TypeInfo.from_set(self.yields)
             s = AnyTypeInfo
             retval = TypeInfo("typing", "AsyncGenerator", (y, s))
 
-        if self.is_generator:
+        elif self.is_generator:
 
             y = TypeInfo.from_set(self.yields)
 

--- a/righttyper/righttyper_types.py
+++ b/righttyper/righttyper_types.py
@@ -155,22 +155,14 @@ class Sample:
     def process(self) -> tuple[TypeInfo, ...]:
         retval = self.returns
 
-        if self.is_async and self.is_generator:
+        if self.is_generator:
             # FIXME need send type
             y = TypeInfo.from_set(self.yields)
             s = AnyTypeInfo
-            retval = TypeInfo("typing", "AsyncGenerator", (y, s))
 
-        elif self.is_generator:
-
-            y = TypeInfo.from_set(self.yields)
-
-            if self.returns is NoneTypeInfo:
-                # Note that we are unable to differentiate between an implicit "None"
-                # return and an explicit "return None".
-                retval = TypeInfo("typing", "Iterator", (y,))
+            if self.is_async:
+                retval = TypeInfo("typing", "AsyncGenerator", (y, s))
             else:
-                s = AnyTypeInfo # FIXME need send type
                 retval = TypeInfo("typing", "Generator", (y, s, self.returns))
             
         type_data = (*self.args, retval)

--- a/righttyper/righttyper_types.py
+++ b/righttyper/righttyper_types.py
@@ -147,29 +147,32 @@ class Sample:
     args: tuple[TypeInfo, ...]
     yields: set[TypeInfo] = field(default_factory=set)
     returns: TypeInfo = NoneTypeInfo
-    is_async: bool = False
+    is_async_generator: bool = False
+    is_generator: bool = False
     self_type: TypeInfo | None = None
 
 
     def process(self) -> tuple[TypeInfo, ...]:
         retval = self.returns
-        if self.yields:
+
+        if self.is_async_generator:
+            # FIXME need send type
             y = TypeInfo.from_set(self.yields)
-            if self.is_async:
-                # FIXME need send type
-                s = AnyTypeInfo
-                retval = TypeInfo("typing", "AsyncGenerator", (y, s))
+            s = AnyTypeInfo
+            retval = TypeInfo("typing", "AsyncGenerator", (y, s))
+
+        if self.is_generator:
+
+            y = TypeInfo.from_set(self.yields)
+
+            if self.returns is NoneTypeInfo:
+                # Note that we are unable to differentiate between an implicit "None"
+                # return and an explicit "return None".
+                retval = TypeInfo("typing", "Iterator", (y,))
             else:
-                y = TypeInfo.from_set(self.yields)
-
-                if self.returns is NoneTypeInfo:
-                    # Note that we are unable to differentiate between an implicit "None"
-                    # return and an explicit "return None".
-                    retval = TypeInfo("typing", "Iterator", (y,))
-                else:
-                    s = AnyTypeInfo # FIXME need send type
-                    retval = TypeInfo("typing", "Generator", (y, s, self.returns))
-
+                s = AnyTypeInfo # FIXME need send type
+                retval = TypeInfo("typing", "Generator", (y, s, self.returns))
+            
         type_data = (*self.args, retval)
 
         if self.self_type:

--- a/righttyper/typeinfo.py
+++ b/righttyper/typeinfo.py
@@ -1,11 +1,24 @@
 import itertools
 from typing import Sequence, Iterator, cast
-from .righttyper_types import TypeInfo, TYPE_OBJ_TYPES
+from .righttyper_types import TypeInfo, TYPE_OBJ_TYPES, NoneTypeInfo, AnyTypeInfo
 from .righttyper_utils import get_main_module_fqn
 from collections import Counter
 
 
 # TODO integrate these into TypeInfo?
+
+class SimplifyGeneratorsTransformer(TypeInfo.Transformer):
+    def visit(self, node: TypeInfo) -> TypeInfo:
+        if node.module == "typing" \
+            and node.name == "Generator" \
+            and len(node.args) == 3 \
+            and node.args[1] == AnyTypeInfo \
+            and node.args[2] == NoneTypeInfo:
+
+            node = TypeInfo("typing", "Iterator", (node.args[0],))
+        
+        return super().visit(node)
+
 
 def merged_types(typeinfoset: set[TypeInfo]) -> TypeInfo:
     """Attempts to merge types in a set before forming their union."""
@@ -40,6 +53,9 @@ def merged_types(typeinfoset: set[TypeInfo]) -> TypeInfo:
                         )
                     ))
 
+    tr = SimplifyGeneratorsTransformer()
+    typeinfoset = set(map(tr.visit, typeinfoset))
+    
     return TypeInfo.from_set(typeinfoset)
 
 
@@ -204,7 +220,9 @@ def generalize(samples: Sequence[tuple[TypeInfo, ...]]) -> list[TypeInfo]|None:
                 for i in range(len(types[0].args))
             )
 
-            return types[0].replace(args=args)
+            homogenized = types[0].replace(args=args)
+            tr = SimplifyGeneratorsTransformer()
+            return tr.visit(homogenized)
 
         if occurrences[types] > 1:
             if types not in typevars:
@@ -215,5 +233,6 @@ def generalize(samples: Sequence[tuple[TypeInfo, ...]]) -> list[TypeInfo]|None:
             return typevars[types]
 
         return merged_types(set(types))
+
 
     return [rebuild(types) for types in transposed]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1865,6 +1865,7 @@ def test_self_subtyping_reversed(tmp_cwd):
     # The argument isn't Self as (NumberAdd IS-A IntegerAdd) doesn't hold
     assert "def operation(self: Self, rhs: \"NumberAdd\") -> Self:" in output
 
+
 def test_returns_or_yields_generator():
     t = textwrap.dedent("""\
         def test(a):
@@ -1885,6 +1886,7 @@ def test_returns_or_yields_generator():
     output = Path("t.py").read_text()
     assert "def test(a: int) -> Generator[int|None, Any, str|None]" in output
 
+
 def test_generators_merge_into_iterator():
     t = textwrap.dedent("""\
         def test(a):
@@ -1903,4 +1905,3 @@ def test_generators_merge_into_iterator():
                     '--no-use-multiprocessing', '--no-sampling', 't.py'], check=True)
     output = Path("t.py").read_text()
     assert "def test(a: int) -> Iterator[int|str]" in output
-

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,5 +1,5 @@
 from righttyper.righttyper_types import TypeInfo, NoneTypeInfo, AnyTypeInfo, Sample
-from righttyper.typeinfo import merged_types
+from righttyper.typeinfo import merged_types, generalize
 import righttyper.righttyper_runtime as rt
 from collections.abc import Iterable
 from collections import namedtuple
@@ -435,7 +435,7 @@ def test_sample_process_simple():
 
     sample = generate_sample(dog, "hi")
     assert sample == Sample((str_ti,), returns=str_ti)
-    assert sample.process() == (str_ti, str_ti)
+    assert generalize([sample.process()]) == [str_ti, str_ti]
 
 
 def test_sample_process_generator():
@@ -445,7 +445,7 @@ def test_sample_process_generator():
 
     sample = generate_sample(dog, 1, "hi")
     assert sample == Sample((int_ti, str_ti,), {int_ti}, str_ti, is_generator=True)
-    assert sample.process() == (int_ti, str_ti, generator_ti(int_ti, any_ti, str_ti))
+    assert generalize([sample.process()]) == [int_ti, str_ti, generator_ti(int_ti, any_ti, str_ti)]
 
 def test_sample_process_generator_noyield():
     def dog(a, b):
@@ -454,7 +454,7 @@ def test_sample_process_generator_noyield():
 
     sample = generate_sample(dog, 1, "hi")
     assert sample == Sample((int_ti, str_ti,), returns=str_ti, is_generator=True)
-    assert sample.process() == (int_ti, str_ti, generator_ti(NoneTypeInfo, any_ti, str_ti))
+    assert generalize([sample.process()]) == [int_ti, str_ti, generator_ti(NoneTypeInfo, any_ti, str_ti)]
 
 
 def test_sample_process_iterator_union():
@@ -464,7 +464,7 @@ def test_sample_process_iterator_union():
 
     sample = generate_sample(dog, 1, "hi")
     assert sample == Sample((int_ti, str_ti,), yields={int_ti, str_ti}, is_generator=True)
-    assert sample.process() == (int_ti, str_ti, iterator_ti(union_ti(int_ti, str_ti)))
+    assert generalize([sample.process()]) == [int_ti, str_ti, iterator_ti(union_ti(int_ti, str_ti))]
 
 
 def test_sample_process_iterator():
@@ -473,7 +473,7 @@ def test_sample_process_iterator():
 
     sample = generate_sample(dog, "hi")
     assert sample == Sample((str_ti,), yields={str_ti}, is_generator=True)
-    assert sample.process() == (str_ti, iterator_ti((str_ti)))
+    assert generalize([sample.process()]) == [str_ti, iterator_ti((str_ti))]
 
 
 def test_sample_process_generator_union():
@@ -484,4 +484,4 @@ def test_sample_process_generator_union():
 
     sample = generate_sample(dog, 1, "hi", True)
     assert sample == Sample((int_ti, str_ti, bool_ti,), {int_ti, str_ti}, bool_ti, is_generator=True)
-    assert sample.process() == (int_ti, str_ti, bool_ti, generator_ti(union_ti(int_ti, str_ti), any_ti, bool_ti))
+    assert generalize([sample.process()]) == [int_ti, str_ti, bool_ti, generator_ti(union_ti(int_ti, str_ti), any_ti, bool_ti)]


### PR DESCRIPTION
also puts righttyper.log in .gitignore

*Issue #, if available:* #77

*Description of changes:* Keeps track of whether a function returns a generator or not in the Sample class, computes resulting annotation based on that. Also removes is_asnyc in favor of is_async_generator, since we don't actually use is_async unless we already think we're a part of a generator

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.