### PR TITLE
Fixes sampling for Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-13 ]
+        os: [ ubuntu-latest, macos-13, windows-latest ]
         python: [ '3.12', '3.13' ]
 
     steps:

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -552,7 +552,7 @@ def in_instrumentation_code() -> bool:
 def restart_sampling() -> None:
     """
     Measures the instrumentation overhead, restarting event delivery
-    when it drops below the target overhead.
+    if it lies below the target overhead.
     """
     # Walk the stack to see if righttyper instrumentation is running (and thus instrumentation).
     # We use this information to estimate instrumentation overhead, and put off restarting
@@ -566,8 +566,7 @@ def restart_sampling() -> None:
         sample_count_instrumentation / sample_count_total
     )
     if instrumentation_overhead <= options.target_overhead / 100.0:
-        # Instrumentation overhead remains low enough; restart instrumentation.
-        # Restart the system monitoring events
+        # Instrumentation overhead is low enough: restart instrumentation.
         sys.monitoring.restart_events()
 
 
@@ -857,7 +856,7 @@ class CheckModule(click.ParamType):
     "--signal-wakeup/--thread-wakeup",
     default=not platform.system() == "Windows",
     hidden=platform.system() == "Windows",
-    help="Whether to use signal-based wakeups or thead-based wakeups"
+    help="Whether to use signal-based wakeups or thead-based wakeups."
 )
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
 def main(

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -96,11 +96,6 @@ class Options:
 options = Options()
 
 
-instrumentation_overhead = 0.0
-alpha = 0.9
-sample_count_instrumentation = 0.0
-sample_count_total = 0.0
-
 logger = logging.getLogger("righttyper")
 
 @dataclass
@@ -531,6 +526,14 @@ def process_function_arguments(
     )
 
 
+instrumentation_functions_code = {
+    enter_handler.__code__,
+    call_handler.__code__,
+    return_handler.__code__,
+    yield_handler.__code__,
+    send_handler.__code__
+}
+
 def in_instrumentation_code() -> bool:
     for frame in sys._current_frames().values():
         
@@ -551,6 +554,10 @@ def in_instrumentation_code() -> bool:
     return False
 
 
+instrumentation_overhead = 0.0
+sample_count_instrumentation = 0.0
+sample_count_total = 0.0
+
 def restart_sampling() -> None:
     """
     Measures the instrumentation overhead, restarting event delivery
@@ -570,15 +577,6 @@ def restart_sampling() -> None:
     if instrumentation_overhead <= options.target_overhead / 100.0:
         # Instrumentation overhead is low enough: restart instrumentation.
         sys.monitoring.restart_events()
-
-
-instrumentation_functions_code = {
-    enter_handler.__code__,
-    call_handler.__code__,
-    return_handler.__code__,
-    yield_handler.__code__,
-    send_handler.__code__
-}
 
 
 def execute_script_or_module(

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -551,12 +551,8 @@ def in_instrumentation_code() -> bool:
 
 def restart_sampling() -> None:
     """
-    This function handles the task of clearing the seen functions.
-    Called when a timer signal is received.
-
-    Args:
-        _signum: The signal number
-        _frame: The current stack frame
+    Measures the instrumentation overhead, restarting event delivery
+    when it drops below the target overhead.
     """
     # Walk the stack to see if righttyper instrumentation is running (and thus instrumentation).
     # We use this information to estimate instrumentation overhead, and put off restarting
@@ -573,8 +569,6 @@ def restart_sampling() -> None:
         # Instrumentation overhead remains low enough; restart instrumentation.
         # Restart the system monitoring events
         sys.monitoring.restart_events()
-    else:
-        pass
 
 
 instrumentation_functions_code = {

--- a/righttyper/righttyper_alarm.py
+++ b/righttyper/righttyper_alarm.py
@@ -1,0 +1,67 @@
+import signal
+import threading
+from types import FrameType
+from typing import Callable, Self
+from time import sleep
+from abc import ABC, abstractmethod
+
+class Alarm(ABC):
+
+    @abstractmethod
+    def __init__(self: Self, func: Callable[[], None], time: float) -> None:
+        pass
+    
+    @abstractmethod
+    def start(self: Self) -> None:
+        pass
+
+    @abstractmethod
+    def stop(self: Self) -> None:
+        pass
+
+
+class SignalAlarm(Alarm):
+
+    def __init__(self: Self, func: Callable[[], None], time: float) -> None:
+        self.func = func
+        self.time = time
+
+
+    def start(self: Self) -> None:
+        def wrapped(sig: int, frame: FrameType|None):
+            self.func()
+            signal.setitimer(signal.ITIMER_REAL, self.time)
+
+        signal.signal(signal.SIGALRM, wrapped)
+        signal.setitimer(signal.ITIMER_REAL, self.time)
+
+
+    def stop(self: Self) -> None:
+        signal.signal(signal.SIGALRM, signal.SIG_IGN)
+        signal.setitimer(signal.ITIMER_REAL, 0)
+
+
+class ThreadAlarm(Alarm):
+
+    def __init__(self: Self, func: Callable[[], None], time: float) -> None:
+        self.func = func
+        self.time = time
+        self.stop_event = threading.Event()
+        self.thread: threading.Thread|None = None;
+
+    
+    def start(self: Self) -> None:
+        def thread(stop_event: threading.Event):
+            while not stop_event.is_set():
+                self.func()
+                sleep(self.time)
+
+        self.thread = threading.Thread(target=thread, args=(self.stop_event,))
+        self.thread.start()
+
+
+    def stop(self: Self) -> None:
+        assert isinstance(self.thread, threading.Thread), "Attempted to stop a timer that has not been started"
+        
+        self.stop_event.set()
+        self.thread.join()

--- a/righttyper/righttyper_alarm.py
+++ b/righttyper/righttyper_alarm.py
@@ -5,8 +5,8 @@ from typing import Callable, Self
 from time import sleep
 from abc import ABC, abstractmethod
 
-class Alarm(ABC):
 
+class Alarm(ABC):
     @abstractmethod
     def __init__(self: Self, func: Callable[[], None], time: float) -> None:
         pass
@@ -21,7 +21,6 @@ class Alarm(ABC):
 
 
 class SignalAlarm(Alarm):
-
     def __init__(self: Self, func: Callable[[], None], time: float) -> None:
         self.func = func
         self.time = time
@@ -42,12 +41,11 @@ class SignalAlarm(Alarm):
 
 
 class ThreadAlarm(Alarm):
-
     def __init__(self: Self, func: Callable[[], None], time: float) -> None:
         self.func = func
         self.time = time
         self.stop_event = threading.Event()
-        self.thread: threading.Thread|None = None;
+        self.thread: threading.Thread|None = None
 
     
     def start(self: Self) -> None:

--- a/righttyper/righttyper_tool.py
+++ b/righttyper/righttyper_tool.py
@@ -54,19 +54,6 @@ def reset_monitoring() -> None:
     except ValueError:
         pass
 
-    signal.signal(signal.SIGALRM, signal.SIG_IGN)
-    signal.setitimer(signal.ITIMER_REAL, 0)
-
-
-def setup_timer(
-    func: Callable[[int, FrameType|None], None],
-) -> None:
-    signal.signal(signal.SIGALRM, func)
-    signal.setitimer(
-        signal.ITIMER_REAL,
-        0.01,
-    )
-
 
 def setup_tool_id() -> None:
     global TOOL_ID

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -697,13 +697,15 @@ def test_send_not_generator():
     t = textwrap.dedent("""\
         class C:
             def send(self, x):
-                return str(x)
+                return float(x)
 
             def asend(self, x):
-                return str(x)
+                return int(x)
 
-        print(C().send(10))
-        print(C().asend(10.0))
+        print([
+            C().send(10),
+            C().asend(10.0)
+        ])
         """)
 
     Path("t.py").write_text(t)
@@ -712,12 +714,12 @@ def test_send_not_generator():
                        '--no-use-multiprocessing', 't.py'],
                        check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
-    assert '10\n10.0\n' in str(p.stdout, 'utf-8')
+    assert "[10.0, 10]" in str(p.stdout, 'utf-8')
 
     output = Path("t.py").read_text()
 
-    assert "def send(self: Self, x: int) -> str:" in output
-    assert "def asend(self: Self, x: float) -> str:" in output
+    assert "def send(self: Self, x: int) -> float:" in output
+    assert "def asend(self: Self, x: float) -> int:" in output
 
 
 def test_send_bound():


### PR DESCRIPTION
*Issue #, if available:* #82

*Description of changes:* Adds two types of alarms, a signal-based one and a thread-based one. Adds a cli option for unix to switch between the two, forces Windows to use the thread-based alarm.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
