### PR TITLE
Implements AST-based generator `send`/`asend` instrumentation

### DIFF
--- a/righttyper/ast_instrument.py
+++ b/righttyper/ast_instrument.py
@@ -3,9 +3,9 @@ import ast
 
 
 SEND_HANDLER = "send_handler"
-SEND_WRAPPER = "___rt_wrap_send"
+SEND_WRAPPER = "rt___wrap_send"
 ASEND_HANDLER = "asend_handler"
-ASEND_WRAPPER = "___rt_wrap_asend"
+ASEND_WRAPPER = "rt___wrap_asend"
 
 
 class GeneratorSendTransformer(ast.NodeTransformer):
@@ -50,7 +50,7 @@ class GeneratorSendTransformer(ast.NodeTransformer):
     def visit_Call(self: Self, node: ast.Call) -> ast.Call:
         self.generic_visit(node)
         if isinstance(node.func, ast.Attribute) and node.func.attr in ("send", "asend"):
-            is_sync = node.func.attr == "send"
+            is_sync = (node.func.attr == "send")
             new_node = ast.Call(
                 func=ast.Name(id=SEND_WRAPPER if is_sync else ASEND_WRAPPER, ctx=ast.Load()),
                 args=[

--- a/righttyper/ast_instrument.py
+++ b/righttyper/ast_instrument.py
@@ -1,0 +1,70 @@
+import ast
+
+
+SEND_HANDLER = "send_handler"
+SEND_WRAPPER = "___rt_wrap_send"
+ASEND_HANDLER = "asend_handler"
+ASEND_WRAPPER = "___rt_wrap_asend"
+
+
+class GeneratorSendTransformer(ast.NodeTransformer):
+    def after_from_future(self, node: ast.Module) -> int:
+        return next(reversed([
+            i+1
+            for i, n in enumerate(node.body)
+            if isinstance(n, ast.ImportFrom)
+            if n.module == '__future__'
+        ]), 0)
+
+
+    def visit_Module(self, node):
+        node = self.generic_visit(node)
+
+        for wrapper, handler in ((SEND_WRAPPER, SEND_HANDLER), (ASEND_WRAPPER, ASEND_HANDLER)):
+            if any(
+                isinstance(n, ast.Call) and
+                isinstance(n.func, ast.Name) and
+                n.func.id == wrapper
+                for n in ast.walk(node)
+            ):
+                new_import = ast.ImportFrom(
+                    module="righttyper.righttyper",
+                    names=[
+                        ast.alias(name=handler, asname=wrapper)
+                    ],
+                    level=0
+                )
+
+                index = self.after_from_future(node)
+
+                for n in ast.walk(new_import):
+                    n.lineno = n.end_lineno = 0
+                    n.col_offset = n.end_col_offset = 0
+
+                node.body[index:index] = [new_import]
+
+        return node
+
+
+    def visit_Call(self, node):
+        self.generic_visit(node)
+        if isinstance(node.func, ast.Attribute) and node.func.attr in ("send", "asend"):
+            is_sync = node.func.attr == "send"
+            new_node = ast.Call(
+                func=ast.Name(id=SEND_WRAPPER if is_sync else ASEND_WRAPPER, ctx=ast.Load()),
+                args=[
+                    node.func.value,
+                    *node.args
+                ],
+                keywords=node.keywords
+            )
+
+            for n in ast.walk(new_node):
+                n.lineno = node.lineno
+                n.end_lineno = node.end_lineno
+                n.col_offset = node.col_offset
+                n.end_col_offset = node.end_col_offset
+
+            return new_node
+
+        return node

--- a/righttyper/ast_instrument.py
+++ b/righttyper/ast_instrument.py
@@ -1,3 +1,4 @@
+from typing import Self
 import ast
 
 
@@ -17,7 +18,7 @@ class GeneratorSendTransformer(ast.NodeTransformer):
         ]), 0)
 
 
-    def visit_Module(self, node):
+    def visit_Module(self: Self, node: ast.Module) -> ast.Module:
         node = self.generic_visit(node)
 
         for wrapper, handler in ((SEND_WRAPPER, SEND_HANDLER), (ASEND_WRAPPER, ASEND_HANDLER)):
@@ -46,7 +47,7 @@ class GeneratorSendTransformer(ast.NodeTransformer):
         return node
 
 
-    def visit_Call(self, node):
+    def visit_Call(self: Self, node: ast.Call) -> ast.Call:
         self.generic_visit(node)
         if isinstance(node.func, ast.Attribute) and node.func.attr in ("send", "asend"):
             is_sync = node.func.attr == "send"
@@ -68,3 +69,7 @@ class GeneratorSendTransformer(ast.NodeTransformer):
             return new_node
 
         return node
+
+
+def instrument(m: ast.Module) -> ast.Module:
+    return GeneratorSendTransformer().visit(m)

--- a/righttyper/ast_instrument.py
+++ b/righttyper/ast_instrument.py
@@ -36,13 +36,9 @@ class GeneratorSendTransformer(ast.NodeTransformer):
                     level=0
                 )
 
+                ast.fix_missing_locations(new_import)
+
                 index = self.after_from_future(node)
-
-                for n in ast.walk(new_import):
-                    if "lineno" in n._attributes:
-                        n.lineno = n.end_lineno = 0         # type: ignore
-                        n.col_offset = n.end_col_offset = 0 # type: ignore
-
                 node.body[index:index] = [new_import]
 
         return node
@@ -62,13 +58,8 @@ class GeneratorSendTransformer(ast.NodeTransformer):
                 keywords=node.keywords
             )
 
-            for n in ast.walk(new_node):
-                if "lineno" in n._attributes:
-                    n.lineno = node.lineno          # type: ignore
-                    n.end_lineno = node.end_lineno  # type: ignore
-                    n.col_offset = node.col_offset  # type: ignore
-                    n.end_col_offset = node.end_col_offset # type: ignore
-
+            ast.copy_location(new_node, node)
+            ast.fix_missing_locations(new_node)
             return new_node
 
         return node

--- a/righttyper/loader.py
+++ b/righttyper/loader.py
@@ -11,7 +11,7 @@ import sys
 import sysconfig
 import typing
 
-from righttyper.ast_instrument import GeneratorSendTransformer
+from righttyper.ast_instrument import instrument
 
 class RightTyperLoader(Loader):
     def __init__(self, orig_loader: Loader, filename: Path):
@@ -29,7 +29,7 @@ class RightTyperLoader(Loader):
 
     def get_code(self, name=None):   # expected by pyrun
         tree = ast.parse(self.filename.read_bytes())
-        tree = GeneratorSendTransformer().visit(tree)
+        tree = instrument(tree)
         return compile(tree, str(self.filename), "exec")
 
     def exec_module(self, module):

--- a/righttyper/loader.py
+++ b/righttyper/loader.py
@@ -1,7 +1,8 @@
 import ast
-from importlib.abc import MetaPathFinder, Loader
+from importlib.abc import MetaPathFinder, Loader, ExecutionLoader, PathEntryFinder
 from importlib import machinery
 from importlib.resources.abc import TraversableResources
+import importlib.util
 import functools
 from pathlib import Path
 import sys
@@ -11,35 +12,44 @@ import typing
 
 from righttyper.ast_instrument import instrument
 
-class RightTyperLoader(Loader):
-    def __init__(self, orig_loader: Loader, filename: Path):
-        self.orig_loader = orig_loader  # original loader we're wrapping
-        self.filename = filename
+class RightTyperLoader(ExecutionLoader):
+    def __init__(self, fullname: str, path: Path, orig_loader: Loader|None=None):
+        self.fullname = fullname
+        self.path = path.resolve()
+        self.orig_loader = orig_loader
 
     # for compability with loaders supporting resources, used e.g. by sklearn
     def get_resource_reader(self, fullname: str) -> TraversableResources|None:
-        if hasattr(self.orig_loader, 'get_resource_reader'):
+        if self.orig_loader and hasattr(self.orig_loader, 'get_resource_reader'):
             return self.orig_loader.get_resource_reader(fullname)
         return None
 
-    def create_module(self, spec):
-        return self.orig_loader.create_module(spec)
+    def get_filename(self, fullname: str) -> str:
+        return str(self.path)
 
-    def get_code(self, name=None):   # expected by pyrun
-        tree = ast.parse(self.filename.read_bytes())
+    def get_source(self, fullname: str) -> str:
+        return str(self.path.read_bytes(), "utf-8")
+
+    def get_code(self, fullname: str) -> types.CodeType:
+        tree = ast.parse(self.get_source(fullname))
         tree = instrument(tree)
-        return compile(tree, str(self.filename), "exec")
+        return compile(tree, str(self.path), "exec")
+
+    def create_module(self, spec):
+        if self.orig_loader:
+            return self.orig_loader.create_module(spec)
+        return None
 
     def exec_module(self, module):
-        exec(self.get_code(), module.__dict__)
+        exec(self.get_code(''), module.__dict__)
 
 
 class RightTyperMetaPathFinder(MetaPathFinder):
     def __init__(self: typing.Self) -> None:
-        self._pylib_paths = (
-            Path(sysconfig.get_path("stdlib")).resolve(),
-            Path(sysconfig.get_path("purelib")).resolve(),
-        )
+        self._pylib_paths = {
+            Path(sysconfig.get_path(p)).resolve()
+            for p in ('stdlib', 'platstdlib', 'purelib', 'platlib')
+        }
 
 
     @functools.cache
@@ -72,14 +82,38 @@ class RightTyperMetaPathFinder(MetaPathFinder):
                 spec.origin != 'built-in' and
                 not isinstance(spec.loader, machinery.ExtensionFileLoader) and
                 (filename := Path(spec.origin)).exists() and
+                filename.suffix == '.py' and
                 not self._in_python_libs(filename)
             ):
                 # For those that look like we can load, insert our loader
-                spec.loader = RightTyperLoader(spec.loader, filename)
+                spec.loader = RightTyperLoader(fullname, filename, spec.loader)
 
             return spec
 
         return None
+
+
+class RightTyperPathEntryFinder(PathEntryFinder):
+    def __init__(self, filename):
+        self.filename = filename
+
+    def find_spec(self, fullname: str, target: types.ModuleType|None=None) -> machinery.ModuleSpec|None:
+        # we want to intercept runpy's loading of some script (".py") as __main__
+        if fullname == "__main__":
+            return importlib.util.spec_from_loader(
+                fullname,
+                RightTyperLoader(fullname, Path(self.filename))
+            )
+
+        return None
+
+
+def path_entry_hook(filename: str) -> PathEntryFinder:
+    # we want to intercept runpy's loading of some script (".py") as __main__
+    if filename.endswith(".py"):
+        return RightTyperPathEntryFinder(filename)
+
+    raise ImportError()
 
 
 class ImportManager:
@@ -91,13 +125,10 @@ class ImportManager:
 
     def __enter__(self) -> typing.Self:
         sys.meta_path.insert(0, self.mpf)
+        sys.path_hooks.insert(0, path_entry_hook)
         return self
 
 
     def __exit__(self, *args) -> None:
-        i = 0
-        while i < len(sys.meta_path):
-            if sys.meta_path[i] is self.mpf:
-                sys.meta_path.pop(i)
-                break
-            i += 1
+        sys.meta_path.remove(self.mpf)
+        sys.path_hooks.remove(path_entry_hook)

--- a/righttyper/loader.py
+++ b/righttyper/loader.py
@@ -1,0 +1,100 @@
+from typing import TYPE_CHECKING, Self
+if TYPE_CHECKING:
+    import _frozen_importlib
+import ast
+from importlib.abc import MetaPathFinder, Loader
+from importlib import machinery
+from importlib.resources.abc import TraversableResources
+import functools
+from pathlib import Path
+import sys
+import sysconfig
+import typing
+
+from righttyper.ast_instrument import GeneratorSendTransformer
+
+class RightTyperLoader(Loader):
+    def __init__(self, orig_loader: Loader, filename: Path):
+        self.orig_loader = orig_loader  # original loader we're wrapping
+        self.filename = filename
+
+    # for compability with loaders supporting resources, used e.g. by sklearn
+    def get_resource_reader(self, fullname: str) -> TraversableResources|None:
+        if hasattr(self.orig_loader, 'get_resource_reader'):
+            return self.orig_loader.get_resource_reader(fullname)
+        return None
+
+    def create_module(self, spec):
+        return self.orig_loader.create_module(spec)
+
+    def get_code(self, name=None):   # expected by pyrun
+        tree = ast.parse(self.filename.read_bytes())
+        tree = GeneratorSendTransformer().visit(tree)
+        return compile(tree, str(self.filename), "exec")
+
+    def exec_module(self, module):
+        exec(self.get_code(), module.__dict__)
+
+
+class RightTyperMetaPathFinder(MetaPathFinder):
+    def __init__(self: Self) -> None:
+        self._pylib_paths = (
+            Path(sysconfig.get_path("stdlib")).resolve(),
+            Path(sysconfig.get_path("purelib")).resolve(),
+        )
+
+
+    @functools.cache
+    def _in_python_libs(self: "RightTyperMetaPathFinder", filename: Path) -> bool:
+        if any(filename.is_relative_to(p) for p in self._pylib_paths):
+            return True
+
+        return False
+
+
+    def find_spec(self: Self, fullname: str, path: None, target: None=None) -> "_frozen_importlib.ModuleSpec":
+        for f in sys.meta_path:
+            if isinstance(f, __class__) or not hasattr(f, "find_spec"):
+                continue
+
+            spec = f.find_spec(fullname, path, target)
+            if spec is None or spec.loader is None:
+                continue
+
+            # We need a python file to be able to instrument
+            # TODO we could check for isinstance(spec.loader, machinery.SourceFileLoader)
+            # but what about cached bytecode loaders?
+            if (
+                not spec.origin or spec.origin == 'built-in' or
+                isinstance(spec.loader, machinery.ExtensionFileLoader)
+            ):
+                return None
+
+            filename = Path(spec.origin)
+            if filename.exists() and not self._in_python_libs(filename):
+                spec.loader = RightTyperLoader(spec.loader, filename)
+
+            return spec
+
+        return None
+
+
+class ImportManager:
+    """A context manager that enables instrumentation while active."""
+
+    def __init__(self: Self) -> None:
+        self.mpf = RightTyperMetaPathFinder()
+
+
+    def __enter__(self: Self) -> "ImportManager":
+        sys.meta_path.insert(0, self.mpf)
+        return self
+
+
+    def __exit__(self: Self, *args: typing.Any) -> None:
+        i = 0
+        while i < len(sys.meta_path):
+            if sys.meta_path[i] is self.mpf:
+                sys.meta_path.pop(i)
+                break
+            i += 1

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -580,7 +580,7 @@ instrumentation_functions_code = {
 
 def wrap_runpy_to_instrument() -> None:
     """Monkey patches runpy to allow us to instrument the code."""
-    orig_get_code_from_file = runpy._get_code_from_file # type: ignore
+    orig_get_code_from_file = runpy._get_code_from_file # type: ignore[attr-defined]
 
     def rt_get_code_from_file(*args, **kwargs):
         orig_result = orig_get_code_from_file(*args, **kwargs)
@@ -604,7 +604,7 @@ def wrap_runpy_to_instrument() -> None:
 
     # FIXME this is brittle... can we improve on it??
 
-    runpy._get_code_from_file = rt_get_code_from_file # type: ignore
+    runpy._get_code_from_file = rt_get_code_from_file # type: ignore[attr-defined]
 
 
 def execute_script_or_module(

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -275,22 +275,22 @@ class Observations:
 obs = Observations()
 
 
-def send_handler(obj: object, *args, **kwargs) -> Any:
+def send_handler(obj: Any, *args, **kwargs) -> Any:
     if isinstance(obj, GeneratorType) and len(args) == 1:
         obs.record_send(
             obj.gi_code,
-            id(obj.gi_frame),
+            FrameId(id(obj.gi_frame)),
             get_value_type(args[0], use_jaxtyping=options.infer_shapes)
         )
 
     return obj.send(*args, **kwargs)
 
 
-def asend_handler(obj: object, *args, **kwargs) -> Any:
+def asend_handler(obj: Any, *args, **kwargs) -> Any:
     if isinstance(obj, AsyncGeneratorType) and len(args) == 1:
         obs.record_send(
             obj.ag_code,
-            id(obj.ag_frame),
+            FrameId(id(obj.ag_frame)),
             get_value_type(args[0], use_jaxtyping=options.infer_shapes)
         )
 
@@ -580,7 +580,7 @@ instrumentation_functions_code = {
 
 def wrap_runpy_to_instrument() -> None:
     """Monkey patches runpy to allow us to instrument the code."""
-    orig_get_code_from_file = runpy._get_code_from_file
+    orig_get_code_from_file = runpy._get_code_from_file # type: ignore
 
     def rt_get_code_from_file(*args, **kwargs):
         orig_result = orig_get_code_from_file(*args, **kwargs)
@@ -604,7 +604,7 @@ def wrap_runpy_to_instrument() -> None:
 
     # FIXME this is brittle... can we improve on it??
 
-    runpy._get_code_from_file = rt_get_code_from_file
+    runpy._get_code_from_file = rt_get_code_from_file # type: ignore
 
 
 def execute_script_or_module(

--- a/righttyper/righttyper_runtime.py
+++ b/righttyper/righttyper_runtime.py
@@ -105,16 +105,19 @@ def should_skip_function(
 
 
 def type_from_annotations(func: abc.Callable) -> TypeInfo:
-    # Get the signature of the function
-    signature = inspect.signature(func)
-    #print(f"{func=} {signature=}")
+    try:
+        signature = inspect.signature(func)
+    except ValueError:
+        signature = None
 
     args: tuple
 
     # Do we have an annotation?
     if (
-        any(p.annotation is not p.empty for p in signature.parameters.values())
-        or signature.return_annotation is not inspect.Signature.empty
+        signature and (
+            any(p.annotation is not p.empty for p in signature.parameters.values())
+            or signature.return_annotation is not inspect.Signature.empty
+        )
     ):
         # Extract argument types, default to Any if no annotation provided
         arg_types = [

--- a/righttyper/righttyper_runtime.py
+++ b/righttyper/righttyper_runtime.py
@@ -94,7 +94,6 @@ def should_skip_function(
     if (
         skip_file
         or included_in_pattern
-        or "righttyper_" in code.co_filename
     ):
         return True
     if not (code.co_flags & 0x2):

--- a/righttyper/righttyper_types.py
+++ b/righttyper/righttyper_types.py
@@ -146,6 +146,7 @@ class FuncInfo:
 class Sample:
     args: tuple[TypeInfo, ...]
     yields: set[TypeInfo] = field(default_factory=set)
+    sends: set[TypeInfo] = field(default_factory=set)
     returns: TypeInfo = NoneTypeInfo
     is_async: bool = False
     is_generator: bool = False
@@ -156,9 +157,8 @@ class Sample:
         retval = self.returns
 
         if self.is_generator:
-            # FIXME need send type
             y = TypeInfo.from_set(self.yields)
-            s = AnyTypeInfo
+            s = TypeInfo.from_set(self.sends)
 
             if self.is_async:
                 retval = TypeInfo("typing", "AsyncGenerator", (y, s))

--- a/righttyper/righttyper_utils.py
+++ b/righttyper/righttyper_utils.py
@@ -56,6 +56,27 @@ def debug_print_set_level(level: bool) -> None:
     _DEBUG_PRINT = level
 
 
+def _get_righttyper_path() -> str:
+    import importlib.util
+    spec = importlib.util.find_spec(__package__)
+    return str(Path(spec.origin).parent)
+
+RIGHTTYPER_PATH = _get_righttyper_path()
+
+
+def _get_python_libs() -> tuple[str, ...]:
+    import sysconfig
+
+    return tuple(
+        set(
+            sysconfig.get_path(p)
+            for p in ('stdlib', 'platstdlib', 'purelib', 'platlib')
+        )
+    )
+
+PYTHON_LIBS = _get_python_libs()
+
+
 @cache
 def skip_this_file(
     filename: str,
@@ -71,10 +92,9 @@ def skip_this_file(
     else:
         should_skip = (
             filename.startswith("<")
-            or filename.startswith("/Library")
-            or filename.startswith("/opt/homebrew/")
-            or os.sep + "site-packages" + os.sep in filename
-            or "righttyper.py" in filename
+            # FIXME how about packages installed with 'pip install -e' (editable)?
+            or any(filename.startswith(p) for p in PYTHON_LIBS)
+            or filename.startswith(RIGHTTYPER_PATH)
             or script_dir not in os.path.abspath(filename)
         )
     if include_files_pattern:

--- a/righttyper/righttyper_utils.py
+++ b/righttyper/righttyper_utils.py
@@ -59,6 +59,7 @@ def debug_print_set_level(level: bool) -> None:
 def _get_righttyper_path() -> str:
     import importlib.util
     spec = importlib.util.find_spec(__package__)
+    assert spec is not None and spec.origin is not None
     return str(Path(spec.origin).parent)
 
 RIGHTTYPER_PATH = _get_righttyper_path()

--- a/righttyper/typeinfo.py
+++ b/righttyper/typeinfo.py
@@ -1,6 +1,6 @@
 import itertools
 from typing import Sequence, Iterator, cast
-from .righttyper_types import TypeInfo, TYPE_OBJ_TYPES, NoneTypeInfo, AnyTypeInfo
+from .righttyper_types import TypeInfo, TYPE_OBJ_TYPES, NoneTypeInfo
 from .righttyper_utils import get_main_module_fqn
 from collections import Counter
 
@@ -13,7 +13,7 @@ class SimplifyGeneratorsTransformer(TypeInfo.Transformer):
             node.module == "typing"
             and node.name == "Generator"
             and len(node.args) == 3
-            and node.args[1] == AnyTypeInfo
+            and node.args[1] == NoneTypeInfo
             and node.args[2] == NoneTypeInfo
         ):
             return TypeInfo("typing", "Iterator", (node.args[0],))

--- a/tests/test_ast_instrument.py
+++ b/tests/test_ast_instrument.py
@@ -1,7 +1,7 @@
 import ast
 import textwrap
 from righttyper.ast_instrument import (
-    GeneratorSendTransformer,
+    instrument,
     SEND_HANDLER,
     SEND_WRAPPER,
     ASEND_HANDLER,
@@ -23,8 +23,7 @@ def test_wrap_send():
             return x.y.g.send(10)
         """)
 
-    tr = GeneratorSendTransformer()
-    t = tr.visit(t)
+    t = instrument(t)
 
     assert unparse(t) == textwrap.dedent(f"""\
         from righttyper.righttyper import {SEND_HANDLER} as {SEND_WRAPPER}
@@ -42,8 +41,7 @@ def test_wrap_asend():
             return await x.y.g.asend(10)
         """)
 
-    tr = GeneratorSendTransformer()
-    t = tr.visit(t)
+    t = instrument(t)
 
     assert unparse(t) == textwrap.dedent(f"""\
         from righttyper.righttyper import {ASEND_HANDLER} as {ASEND_WRAPPER}
@@ -61,8 +59,7 @@ def test_nothing_to_wrap():
             return x/2
         """)
 
-    tr = GeneratorSendTransformer()
-    t = tr.visit(t)
+    t = instrument(t)
 
     assert unparse(t) == textwrap.dedent(f"""\
         def f(x):
@@ -81,8 +78,7 @@ def test_import_after_from_future():
             return x.send(10)
         """)
 
-    tr = GeneratorSendTransformer()
-    t = tr.visit(t)
+    t = instrument(t)
 
     assert unparse(t) == textwrap.dedent(f"""\
         from __future__ import annotations

--- a/tests/test_ast_instrument.py
+++ b/tests/test_ast_instrument.py
@@ -9,11 +9,11 @@ from righttyper.ast_instrument import (
 )
 
 
-def parse(s: str) -> ast.AST:
+def parse(s: str) -> ast.Module:
     return ast.parse(textwrap.dedent(s))
 
 
-def unparse(t: ast.AST) -> str:
+def unparse(t: ast.Module) -> str:
     return ast.unparse(t) + "\n"
 
 

--- a/tests/test_ast_instrument.py
+++ b/tests/test_ast_instrument.py
@@ -1,0 +1,96 @@
+import ast
+import textwrap
+from righttyper.ast_instrument import (
+    GeneratorSendTransformer,
+    SEND_HANDLER,
+    SEND_WRAPPER,
+    ASEND_HANDLER,
+    ASEND_WRAPPER
+)
+
+
+def parse(s: str) -> ast.AST:
+    return ast.parse(textwrap.dedent(s))
+
+
+def unparse(t: ast.AST) -> str:
+    return ast.unparse(t) + "\n"
+
+
+def test_wrap_send():
+    t = parse("""\
+        def f(x):
+            return x.y.g.send(10)
+        """)
+
+    tr = GeneratorSendTransformer()
+    t = tr.visit(t)
+
+    assert unparse(t) == textwrap.dedent(f"""\
+        from righttyper.righttyper import {SEND_HANDLER} as {SEND_WRAPPER}
+
+        def f(x):
+            return {SEND_WRAPPER}(x.y.g, 10)
+    """)
+
+    compile(t, 'tp.py', 'exec') # ensure it doesn't throw
+
+
+def test_wrap_asend():
+    t = parse("""\
+        async def f(x):
+            return await x.y.g.asend(10)
+        """)
+
+    tr = GeneratorSendTransformer()
+    t = tr.visit(t)
+
+    assert unparse(t) == textwrap.dedent(f"""\
+        from righttyper.righttyper import {ASEND_HANDLER} as {ASEND_WRAPPER}
+
+        async def f(x):
+            return await {ASEND_WRAPPER}(x.y.g, 10)
+    """)
+
+    compile(t, 'tp.py', 'exec') # ensure it doesn't throw
+
+
+def test_nothing_to_wrap():
+    t = parse("""\
+        def f(x):
+            return x/2
+        """)
+
+    tr = GeneratorSendTransformer()
+    t = tr.visit(t)
+
+    assert unparse(t) == textwrap.dedent(f"""\
+        def f(x):
+            return x / 2
+    """)
+
+    compile(t, 'tp.py', 'exec') # ensure it doesn't throw
+
+
+def test_import_after_from_future():
+    t = parse("""\
+        from __future__ import annotations
+        import sys
+
+        def f(x):
+            return x.send(10)
+        """)
+
+    tr = GeneratorSendTransformer()
+    t = tr.visit(t)
+
+    assert unparse(t) == textwrap.dedent(f"""\
+        from __future__ import annotations
+        from righttyper.righttyper import {SEND_HANDLER} as {SEND_WRAPPER}
+        import sys
+
+        def f(x):
+            return {SEND_WRAPPER}(x, 10)
+    """)
+
+    compile(t, 'tp.py', 'exec') # ensure it doesn't throw

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -742,7 +742,6 @@ def test_send_not_generator(tmp_cwd):
     assert "def asend(self: Self, x: float) -> str:" in output
 
 
-@pytest.mark.xfail(reason="Doesn't work yet. Any good ideas?")
 def test_send_bound(tmp_cwd):
     t = textwrap.dedent("""\
         def gen():
@@ -774,7 +773,8 @@ def test_send_bound(tmp_cwd):
     output = Path("t.py").read_text()
 
     assert "def gen() -> Generator[float, int, None]:" in output
-    assert "def f(g: Generator[float, int, None]) -> list[float]" in output
+    # TODO the Callable here is our wrapper for the 'g.send' method... can we do better?
+    assert "def f(s: Callable) -> list[float]" in output
 
 
 def test_coroutine(tmp_cwd):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -552,37 +552,6 @@ def test_generator(tmp_cwd):
     assert "def g(f: Iterator[float|int]) -> None" in output
 
 
-@pytest.mark.xfail(reason="Doesn't work yet")
-def test_generator_send(tmp_cwd):
-    t = textwrap.dedent("""\
-        def gen():
-            sum = 0.0
-            while True:
-                value = yield sum
-                if value is not None:
-                    sum += value
-
-        def f(g):
-            print([
-                g.send(10),
-                g.send(5)
-            ])
-
-        g = gen()
-        next(g) # prime generator
-        f(g)
-        """)
-
-    Path("t.py").write_text(t)
-
-    subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
-                    '--no-use-multiprocessing', 't.py'], check=True)
-    output = Path("t.py").read_text()
-
-    assert "def gen() -> Generator[float, int, None]:" in output
-    assert "def f(f: Generator[float, int, None]) -> None" in output
-
-
 def test_generator_with_return(tmp_cwd):
     t = textwrap.dedent("""\
         def gen():
@@ -610,8 +579,8 @@ def test_generator_with_return(tmp_cwd):
                     '--no-use-multiprocessing', 't.py'], check=True)
     output = Path("t.py").read_text()
 
-    assert "def gen() -> Generator[int, Any, str]:" in output
-    assert "def g(f: Generator[int, Any, str]) -> None" in output
+    assert "def gen() -> Generator[int, None, str]:" in output
+    assert "def g(f: Generator[int, None, str]) -> None" in output
 
 
 @pytest.mark.xfail(reason="Doesn't currently work")
@@ -666,9 +635,81 @@ def test_async_generator(tmp_cwd):
                     '--no-use-multiprocessing', 't.py'], check=True)
     output = Path("t.py").read_text()
 
-    # FIXME should be AsyncGenerator[int, None] or AsyncIterator[int]
-    assert "def gen() -> AsyncGenerator[int, Any]:" in output
-    assert "def g(f: AsyncGenerator[int, Any]) -> None" in output
+    assert "def gen() -> AsyncGenerator[int, None]:" in output
+    assert "def g(f: AsyncGenerator[int, None]) -> None" in output
+
+
+def test_send_generator(tmp_cwd):
+    t = textwrap.dedent("""\
+        def gen():
+            sum = 0.0
+            while True:
+                value = yield sum
+                if value is not None:
+                    sum += value
+
+        def f(g):
+            return [
+                g.send(10),
+                g.send(5)
+            ]
+
+        g = gen()
+        next(g) # prime generator
+        print(f(g))
+        """)
+
+    Path("t.py").write_text(t)
+
+    p = subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
+                       '--no-use-multiprocessing', '-m', 't'],
+                       check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+    assert '[10.0, 15.0]' in str(p.stdout, 'utf-8')
+
+    output = Path("t.py").read_text()
+
+    assert "def gen() -> Generator[float, int, None]:" in output
+    assert "def f(g: Generator[float, int, None]) -> list[float]" in output
+
+
+def test_send_async_generator(tmp_cwd):
+    t = textwrap.dedent("""\
+        import asyncio
+
+        async def gen():
+            sum = 0.0
+            while True:
+                value = yield sum
+                if value is not None:
+                    sum += value
+
+        async def f(g):
+            return [
+                await g.asend(10),
+                await g.asend(5)
+            ]
+
+        async def main():
+            g = gen()
+            await anext(g)
+            print(await f(g))
+
+        asyncio.run(main())
+        """)
+
+    Path("t.py").write_text(t)
+
+    p = subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
+                       '--no-use-multiprocessing', '-m', 't'],
+                       check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+    assert '[10.0, 15.0]' in str(p.stdout, 'utf-8')
+
+    output = Path("t.py").read_text()
+
+    assert "def gen() -> AsyncGenerator[float, int]:" in output
+    assert "def f(g: AsyncGenerator[float, int]) -> list[float]" in output
 
 
 def test_coroutine(tmp_cwd):
@@ -1400,7 +1441,7 @@ def test_generic_yield_generator(tmp_cwd):
     print(output)
     assert 'rt_T1 = TypeVar("rt_T1", int, str)' in output
     assert 'rt_T2 = TypeVar("rt_T2", int, str)' in output
-    assert "def y(a: rt_T1, b: rt_T2) -> Generator[rt_T1, Any, rt_T2]" in output
+    assert "def y(a: rt_T1, b: rt_T2) -> Generator[rt_T1, None, rt_T2]" in output
 
 
 def test_generic_typevar_location(tmp_cwd):
@@ -1834,7 +1875,7 @@ def test_self_yield_generator(tmp_cwd):
     output = Path("t.py").read_text()
 
     print(output)
-    assert "def foo(self: Self) -> Generator[Self, Any, Self]" in output
+    assert "def foo(self: Self) -> Generator[Self, None, Self]" in output
 
 
 def test_self_subtyping(tmp_cwd):
@@ -1915,7 +1956,7 @@ def test_returns_or_yields_generator():
     subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
                     '--no-use-multiprocessing', '--no-sampling', 't.py'], check=True)
     output = Path("t.py").read_text()
-    assert "def test(a: int) -> Generator[int|None, Any, str|None]" in output
+    assert "def test(a: int) -> Generator[int|None, None, str|None]" in output
 
 
 def test_generators_merge_into_iterator():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -639,7 +639,8 @@ def test_async_generator(tmp_cwd):
     assert "def g(f: AsyncGenerator[int, None]) -> None" in output
 
 
-def test_send_generator(tmp_cwd):
+@pytest.mark.parametrize('as_module', [False, True])
+def test_send_generator(tmp_cwd, as_module):
     t = textwrap.dedent("""\
         def gen():
             sum = 0.0
@@ -662,7 +663,8 @@ def test_send_generator(tmp_cwd):
     Path("t.py").write_text(t)
 
     p = subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
-                       '--no-use-multiprocessing', '-m', 't'],
+                       '--no-use-multiprocessing',
+                       *(('-m', 't') if as_module else ('t.py',))],
                        check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
     assert '[10.0, 15.0]' in str(p.stdout, 'utf-8')
@@ -673,7 +675,8 @@ def test_send_generator(tmp_cwd):
     assert "def f(g: Generator[float, int, None]) -> list[float]" in output
 
 
-def test_send_async_generator(tmp_cwd):
+@pytest.mark.parametrize('as_module', [False, True])
+def test_send_async_generator(tmp_cwd, as_module):
     t = textwrap.dedent("""\
         import asyncio
 
@@ -701,7 +704,7 @@ def test_send_async_generator(tmp_cwd):
     Path("t.py").write_text(t)
 
     p = subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
-                       '--no-use-multiprocessing', '-m', 't'],
+                       *(('-m', 't') if as_module else ('t.py',))],
                        check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
     assert '[10.0, 15.0]' in str(p.stdout, 'utf-8')

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1205,6 +1205,26 @@ def test_self(tmp_cwd):
     assert 'def baz(me: Self) -> Self:' in output
 
 
+@pytest.mark.xfail(reason="Doesn't currently work")
+def test_self_with_wrapped_method(tmp_cwd):
+    Path("t.py").write_text(textwrap.dedent("""\
+        import functools
+
+        class C:
+            @functools.cache
+            def foo(self, x):
+                return self
+
+        C().foo(1)
+    """))
+
+    subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
+                    '--no-use-multiprocessing', 't.py'], check=True)
+
+    output = Path("t.py").read_text()
+    assert 'def foo(self: Self, x: int) -> Self:' in output
+
+
 def test_rich_is_messed_up(tmp_cwd):
     # running rich's test suite leaves it unusable... simulate that situation.
     Path("t.py").write_text(textwrap.dedent("""\

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -404,7 +404,6 @@ def test_merged_types_generics_superclass():
 str_ti = TypeInfo("", "str", type_obj=str)
 int_ti = TypeInfo("", "int", type_obj=int)
 bool_ti = TypeInfo("", "bool", type_obj=bool)
-any_ti = AnyTypeInfo
 generator_ti = lambda *a: TypeInfo("typing", "Generator", tuple(a))
 iterator_ti = lambda *a: TypeInfo("typing", "Iterator", tuple(a))
 union_ti = lambda *a: TypeInfo("types", "UnionType", tuple(a), type_obj=types.UnionType)
@@ -444,17 +443,18 @@ def test_sample_process_generator():
         return b
 
     sample = generate_sample(dog, 1, "hi")
-    assert sample == Sample((int_ti, str_ti,), {int_ti}, str_ti, is_generator=True)
-    assert generalize([sample.process()]) == [int_ti, str_ti, generator_ti(int_ti, any_ti, str_ti)]
+    assert sample == Sample((int_ti, str_ti,), {int_ti}, returns=str_ti, is_generator=True)
+    assert generalize([sample.process()]) == [int_ti, str_ti, generator_ti(int_ti, NoneTypeInfo, str_ti)]
+
 
 def test_sample_process_generator_noyield():
     def dog(a, b):
         return b
-        yield a
+        yield 
 
     sample = generate_sample(dog, 1, "hi")
     assert sample == Sample((int_ti, str_ti,), returns=str_ti, is_generator=True)
-    assert generalize([sample.process()]) == [int_ti, str_ti, generator_ti(NoneTypeInfo, any_ti, str_ti)]
+    assert generalize([sample.process()]) == [int_ti, str_ti, generator_ti(NoneTypeInfo, NoneTypeInfo, str_ti)]
 
 
 def test_sample_process_iterator_union():
@@ -483,5 +483,5 @@ def test_sample_process_generator_union():
         return c
 
     sample = generate_sample(dog, 1, "hi", True)
-    assert sample == Sample((int_ti, str_ti, bool_ti,), {int_ti, str_ti}, bool_ti, is_generator=True)
-    assert generalize([sample.process()]) == [int_ti, str_ti, bool_ti, generator_ti(union_ti(int_ti, str_ti), any_ti, bool_ti)]
+    assert sample == Sample((int_ti, str_ti, bool_ti,), yields={int_ti, str_ti}, returns=bool_ti, is_generator=True)
+    assert generalize([sample.process()]) == [int_ti, str_ti, bool_ti, generator_ti(union_ti(int_ti, str_ti), NoneTypeInfo, bool_ti)]


### PR DESCRIPTION
Adds generator `send`/`asend` instrumentation and typing. Also fixes bugs not dynamically detecting Python library and RightTyper paths, as well as a remaining issue from #93.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.