### PR TITLE
202503-1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,3 +76,7 @@ shapes = [
 [project.scripts]
 righttyper = "righttyper.righttyper:main"
 
+[tool.pytest.ini_options]
+markers = [
+    'dont_run_mypy'
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,11 +45,13 @@ authors = [
   { name="Emery Berger", email="emerydb@amazon.com" },
   { name="Juan Altmayer Pizzorno", email="jpizzorno@umass.edu" },
 ]
-dependencies = [ "libcst >= 1.2.0",
-		 "click >= 8.1.7",
-		 "rich >= 13.7.1",
-		 "wcmatch >= 10.0",
-		 ]
+dependencies = [
+    "libcst >= 1.2.0",
+    "click >= 8.1.7",
+    "rich >= 13.7.1",
+    "wcmatch >= 10.0",
+    "typeshed_client"
+]
 	 
 description = "A fast runtime type hint assistant for Python code."
 readme = "README.md"

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -946,9 +946,9 @@ def main(
         setup_tool_id()
         register_monitoring_callbacks(
             enter_handler,
-            call_handler,
             return_handler,
             yield_handler,
+            call_handler,
         )
         sys.monitoring.restart_events()
         alarm.start()

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -259,13 +259,12 @@ class Observations:
                     if (ann := mk_annotation(node.code_id)):
                         func_info = self.functions_visited[node.code_id]
                         if node.name == 'Callable':
-                            # TODO: fix callable arguments being strings
                             return TypeInfo('typing', 'Callable', args=(
-                                "[" + ", ".join(
-                                    str(a[1])
-                                    for a in ann.args[int(node.is_bound):]
-                                    if a[0] not in (func_info.varargs, func_info.kwargs)
-                                ) + "]",
+                                TypeInfo.list([
+                                    a[1] for a in ann.args[int(node.is_bound):]
+                                ])
+                                if not (func_info.varargs or func_info.kwargs) else
+                                ...,
                                 ann.retval
                             ))
                         elif node.name in ('Generator', 'AsyncGenerator'):

--- a/righttyper/righttyper_runtime.py
+++ b/righttyper/righttyper_runtime.py
@@ -132,7 +132,7 @@ def type_from_annotations(func: abc.Callable) -> TypeInfo:
     try:
         signature = inspect.signature(func)
         hints = get_type_hints(func)
-    except ValueError:
+    except (ValueError, NameError):
         signature = None
         hints = None
 

--- a/righttyper/righttyper_runtime.py
+++ b/righttyper/righttyper_runtime.py
@@ -403,6 +403,13 @@ def get_value_type(value: Any, *, use_jaxtyping: bool = False, depth: int = 0) -
         return get_value_type(v, use_jaxtyping=use_jaxtyping, depth=depth+1)
 
 
+    if (orig := getattr(value, "__orig_class__", None)):
+        return TypeInfo(orig.__module__, orig.__qualname__,
+                        tuple(
+                            TypeInfo.from_type(a) for a in orig.__args__
+                        )
+               )
+
     if isinstance(value, dict):
         t = dict if isinstance(value, RandomDict) else type(value)
         args = (TypeInfo("typing", "Never"), TypeInfo("typing", "Never"))

--- a/righttyper/righttyper_runtime.py
+++ b/righttyper/righttyper_runtime.py
@@ -337,13 +337,14 @@ def find_function(
         visited.add(class_obj)
 
         for obj in class_obj.__dict__.values():
-            if isinstance(obj, (FunctionType, classmethod)):
+            if inspect.isclass(obj):
+                if (f := find_in_class(obj)):
+                    return f
+
+            elif isinstance(obj, (abc.Callable, classmethod)):
                 if (obj := unwrap(obj)) and getattr(obj, "__code__", None) is code:
                     return obj
 
-            elif inspect.isclass(obj):
-                if (f := find_in_class(obj)):
-                    return f
 
         return None
 
@@ -352,13 +353,14 @@ def find_function(
         dicts = itertools.chain(caller_frame.f_back.f_locals.values(), dicts)
 
     for obj in dicts:
-        if isinstance(obj, FunctionType):
+        if inspect.isclass(obj):
+            if (f := find_in_class(obj)):
+                return f
+
+        elif isinstance(obj, abc.Callable):
             if (obj := unwrap(obj)) and getattr(obj, "__code__", None) is code:
                 return obj
 
-        elif inspect.isclass(obj):
-            if (f := find_in_class(obj)):
-                return f
 
     return None
 

--- a/righttyper/righttyper_runtime.py
+++ b/righttyper/righttyper_runtime.py
@@ -341,7 +341,7 @@ def find_function(
                 if (f := find_in_class(obj)):
                     return f
 
-            elif isinstance(obj, (abc.Callable, classmethod)):
+            elif isinstance(obj, (abc.Callable, classmethod)):  # type: ignore[arg-type]
                 if (obj := unwrap(obj)) and getattr(obj, "__code__", None) is code:
                     return obj
 
@@ -357,7 +357,7 @@ def find_function(
             if (f := find_in_class(obj)):
                 return f
 
-        elif isinstance(obj, abc.Callable):
+        elif isinstance(obj, abc.Callable):  # type: ignore[arg-type]
             if (obj := unwrap(obj)) and getattr(obj, "__code__", None) is code:
                 return obj
 

--- a/righttyper/righttyper_runtime.py
+++ b/righttyper/righttyper_runtime.py
@@ -400,7 +400,9 @@ def get_value_type(value: Any, *, use_jaxtyping: bool = False, depth: int = 0) -
         return get_value_type(v, use_jaxtyping=use_jaxtyping, depth=depth+1)
 
 
-    if (orig := getattr(value, "__orig_class__", None)):
+    # using getattr or hasattr here leads to max. recursion errors with tqdm and rich
+    if '__orig_class__' in getattr(value, "__dict__", {}):
+        orig = value.__orig_class__
         return TypeInfo(orig.__module__, orig.__qualname__,
                         tuple(
                             TypeInfo.from_type(a) for a in orig.__args__

--- a/righttyper/righttyper_runtime.py
+++ b/righttyper/righttyper_runtime.py
@@ -390,7 +390,7 @@ def get_value_type(value: Any, *, use_jaxtyping: bool = False, depth: int = 0) -
                 hints = get_type_hints(f)
                 if 'return' in hints:
                     return hint2type(hints['return']).replace(code_id=CodeId(id(code)))
-            except ValueError:
+            except:
                 pass
 
         return TypeInfo.from_type(type_obj, module="typing", code_id=CodeId(id(code)))

--- a/righttyper/righttyper_tool.py
+++ b/righttyper/righttyper_tool.py
@@ -11,18 +11,18 @@ _EVENTS = frozenset(
         sys.monitoring.events.PY_START,
         sys.monitoring.events.PY_RETURN,
         sys.monitoring.events.PY_YIELD,
-        sys.monitoring.events.CALL,
+#        sys.monitoring.events.CALL,
     }
 )
 
 
 def register_monitoring_callbacks(
     enter_function: Callable[[CodeType, int], Any],
-    call_handler: Callable[[CodeType, int, object, object], Any],
     exit_function: Callable[[CodeType, int, Any], object],
     yield_function: Callable[[CodeType, int, Any], object],
+    call_handler: Callable[[CodeType, int, object, object], Any],
 ) -> None:
-    """Set up tracking for all enters, calls, exits, and yields."""
+    """Set up tracking for all enters, exits, yields, and calls."""
     event_set = 0
     for event in _EVENTS:
         event_set |= event
@@ -31,12 +31,12 @@ def register_monitoring_callbacks(
 
     fns: dict[Any, Callable[..., Any]] = {
         sys.monitoring.events.PY_START: enter_function,
-        sys.monitoring.events.CALL: call_handler,
         sys.monitoring.events.PY_RETURN: exit_function,
         sys.monitoring.events.PY_YIELD: yield_function,
+        sys.monitoring.events.CALL: call_handler,
     }
 
-    for event in fns:
+    for event in _EVENTS:
         sys.monitoring.register_callback(
             TOOL_ID,
             event,

--- a/righttyper/righttyper_types.py
+++ b/righttyper/righttyper_types.py
@@ -149,12 +149,22 @@ class ArgInfo:
     default: TypeInfo|None
 
 
+@dataclass
+class FunctionDescriptor:
+    """Describes a function by name; stands in for a FunctionType where the function
+       is a wrapper_descriptor (or possibly other objects), lacking __module__
+    """
+    __module__: str
+    __qualname__: str
+
+
 @dataclass(eq=True, frozen=True)
 class FuncInfo:
     func_id: FuncId
     args: tuple[ArgInfo, ...]
     varargs: ArgumentName|None
     kwargs: ArgumentName|None
+    overrides: types.FunctionType|FunctionDescriptor|None
 
 
 

--- a/righttyper/righttyper_types.py
+++ b/righttyper/righttyper_types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace, field
-from typing import NewType, TypeVar, Self, TypeAlias, List
+from typing import NewType, TypeVar, Self, TypeAlias, List, Iterator
 import collections.abc as abc
 import types
 
@@ -100,11 +100,12 @@ class TypeInfo:
         if len(s) == 1:
             return next(iter(s))
 
-        def expand_unions(t: "TypeInfo") -> "Iterator[TypeInfo]":
+        def expand_unions(t: "TypeInfo") -> Iterator["TypeInfo"]:
             # don't merge unions designated as typevars, or the typevar gets lost.
             if t.type_obj is types.UnionType and not t.typevar_index:
                 for a in t.args:
-                    yield from expand_unions(a)
+                    if isinstance(a, TypeInfo):
+                        yield from expand_unions(a)
             else:
                 yield t
 

--- a/righttyper/righttyper_types.py
+++ b/righttyper/righttyper_types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace, field
-from typing import NewType, TypeVar, Self, TypeAlias
+from typing import NewType, TypeVar, Self, TypeAlias, List
 import collections.abc as abc
 import types
 
@@ -99,6 +99,16 @@ class TypeInfo:
 
         if len(s) == 1:
             return next(iter(s))
+
+        def expand_unions(t: "TypeInfo") -> "Iterator[TypeInfo]":
+            # don't merge unions designated as typevars, or the typevar gets lost.
+            if t.type_obj is types.UnionType and not t.typevar_index:
+                for a in t.args:
+                    yield from expand_unions(a)
+            else:
+                yield t
+
+        s = {ex for t in s for ex in expand_unions(t)}
 
         return TypeInfo(
             module='types',

--- a/righttyper/typeinfo.py
+++ b/righttyper/typeinfo.py
@@ -9,6 +9,8 @@ from types import EllipsisType
 
 class SimplifyGeneratorsTransformer(TypeInfo.Transformer):
     def visit(self, node: TypeInfo) -> TypeInfo:
+        node = super().visit(node)
+
         if (
             node.module == "typing"
             and node.name == "Generator"
@@ -17,8 +19,8 @@ class SimplifyGeneratorsTransformer(TypeInfo.Transformer):
             and node.args[2] == NoneTypeInfo
         ):
             return TypeInfo("typing", "Iterator", (node.args[0],))
-        
-        return super().visit(node)
+
+        return node
 
 
 def merged_types(typeinfoset: set[TypeInfo]) -> TypeInfo:

--- a/righttyper/typeinfo.py
+++ b/righttyper/typeinfo.py
@@ -2,6 +2,7 @@ from typing import Sequence, Iterator, cast
 from .righttyper_types import TypeInfo, TYPE_OBJ_TYPES, NoneTypeInfo
 from .righttyper_utils import get_main_module_fqn
 from collections import Counter
+import collections.abc as abc
 from types import EllipsisType
 
 
@@ -12,8 +13,7 @@ class SimplifyGeneratorsTransformer(TypeInfo.Transformer):
         node = super().visit(node)
 
         if (
-            node.module == "typing"
-            and node.name == "Generator"
+            node.type_obj is abc.Generator
             and len(node.args) == 3
             and node.args[1] == NoneTypeInfo
             and node.args[2] == NoneTypeInfo

--- a/righttyper/typeinfo.py
+++ b/righttyper/typeinfo.py
@@ -2,6 +2,7 @@ from typing import Sequence, Iterator, cast
 from .righttyper_types import TypeInfo, TYPE_OBJ_TYPES, NoneTypeInfo
 from .righttyper_utils import get_main_module_fqn
 from collections import Counter
+from types import EllipsisType
 
 
 # TODO integrate these into TypeInfo?
@@ -92,13 +93,12 @@ def generalize_jaxtyping(samples: Sequence[tuple[TypeInfo, ...]]) -> Sequence[tu
         return (
             t.module == 'jaxtyping' and
             len(t.args) == 2 and
-            isinstance(t.args[1], str) and
-            t.args[1][0] in ('"', "'") and t.args[1][-1] == t.args[1][0]
+            isinstance(t.args[1], str)
         )
 
     def get_dims(t: TypeInfo) -> Sequence[str]:
         # str type already checked by is_jaxtyping_array
-        return cast(str, t.args[1])[1:-1].split()  # space separated dimensions within quotes
+        return cast(str, t.args[1]).split()  # space separated dimensions
 
     # Get the set of dimensions seen for each consistent jaxtyping array
     dimensions = {
@@ -130,7 +130,7 @@ def generalize_jaxtyping(samples: Sequence[tuple[TypeInfo, ...]]) -> Sequence[tu
             results.append([
                 s[argno].replace(args=(
                         s[argno].args[0],
-                        f"\"{' '.join(dims)}\""
+                        f"{' '.join(dims)}"
                     )
                 )
                 for s, dims in zip(samples, tdims)
@@ -164,9 +164,9 @@ def generalize(samples: Sequence[tuple[TypeInfo, ...]]) -> list[TypeInfo]|None:
     # various types seen for each argument.
     transposed = list(zip(*samples))
 
-    def is_homogeneous_generic(types: tuple[TypeInfo, ...]) -> bool:
-        """Whether the set only contains instances of a single, consistent generic type
-           whose arguments are also all TypeInfo.
+    def is_homogeneous(types: tuple[TypeInfo, ...]) -> bool:
+        """Whether the tuple only contains instances of a single, consistent generic type
+           whose arguments are all either TypeInfo or ellipsis.
         """
         if not types:
             return False
@@ -175,44 +175,51 @@ def generalize(samples: Sequence[tuple[TypeInfo, ...]]) -> list[TypeInfo]|None:
 
         return (
             all(
-                all(isinstance(a, TypeInfo) for a in t.args)
+                isinstance(t, TypeInfo) and
+                all(isinstance(a, (TypeInfo, EllipsisType)) for a in t.args)
                 for t in types
             )
             and all(
                 t.module == first.module and
                 t.name == first.name and
                 len(t.args) == len(first.args) and
-                all(isinstance(a, TypeInfo) for a in t.args)
+                all((a is Ellipsis) == (first.args[i] is Ellipsis) for i, a in enumerate(t.args))
                 for t in types[1:]
             )
         )
 
-    def expand_generics(types: tuple[TypeInfo, ...]) -> Iterator[tuple[TypeInfo, ...]]:
+    def expand_types(types: tuple[TypeInfo, ...]) -> Iterator[tuple[TypeInfo, ...]]:
+        """Given a tuple of types used in an argument or return value, extracts the
+           various type patterns enclosed in those type's arguments.
+        """
         yield types
 
-        if is_homogeneous_generic(types):
+        if is_homogeneous(types):
             for i in range(len(types[0].args)):
-                # cast dropping 'str' is checked by is_homogeneous_generic
-                yield from expand_generics(cast(tuple[TypeInfo, ...], tuple(t.args[i] for t in types)))
+                if types[0].args[i] is not Ellipsis:
+                    yield from expand_types(cast(tuple[TypeInfo, ...], tuple(t.args[i] for t in types)))
 
     # Count the number of times a type usage pattern occurs, as we only want to generalize
     # if one occurs more than once (in more than one argument).
     occurrences: Counter[tuple[TypeInfo, ...]] = Counter()
     for types in transposed:
-        occurrences.update([s for s in expand_generics(types)])
+        occurrences.update([s for s in expand_types(types)])
 
     typevars: dict[tuple[TypeInfo, ...], TypeInfo] = {}
 
     # Rebuild the argument list, defining and replacing type patterns with a type variable.
     def rebuild(types: tuple[TypeInfo, ...]) -> TypeInfo:
-        if is_homogeneous_generic(types):
+        # if the types look compatible, try to replace them with a single one using variable(s)
+        if is_homogeneous(types):
             args = tuple(
-                rebuild(cast(tuple[TypeInfo, ...], tuple(t.args[i] for t in types)))
+                rebuild(tuple(cast(TypeInfo, t.args[i]) for t in types))
+                if types[0].args[i] is not Ellipsis else Ellipsis
                 for i in range(len(types[0].args))
             )
 
             return SimplifyGeneratorsTransformer().visit(types[0].replace(args=args))
 
+        # replace type sequence with a variable
         if occurrences[types] > 1:
             if types not in typevars:
                 typevars[types] = TypeInfo.from_set(
@@ -222,6 +229,5 @@ def generalize(samples: Sequence[tuple[TypeInfo, ...]]) -> list[TypeInfo]|None:
             return typevars[types]
 
         return merged_types(set(types))
-
 
     return [rebuild(types) for types in transposed]

--- a/righttyper/unified_transformer.py
+++ b/righttyper/unified_transformer.py
@@ -465,9 +465,10 @@ class UnifiedTransformer(cst.CSTTransformer):
                             ])
                         )))
 
-                    updated_node = updated_node.with_changes(type_parameters=cst.TypeParameters(
-                        params=our_params
-                    ))
+                    if our_params:
+                        updated_node = updated_node.with_changes(type_parameters=cst.TypeParameters(
+                            params=our_params
+                        ))
 
                 else:
                     for generic in generics.values():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+@pytest.hookimpl(tryfirst=True, wrapper=True)
+def pytest_runtest_makereport(item, call):
+    """Saves the test result for use within a fixture teardown."""
+    report = yield
+    item._report = report
+    return report

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -150,6 +150,30 @@ def test_callable_annotation_errors():
     assert "def g() -> Callable:" in output
 
 
+@pytest.mark.dont_run_mypy # fails because of SomethingUnknown
+def test_generator_annotation_errors():
+    t = textwrap.dedent("""\
+        from __future__ import annotations
+        from collections.abc import Generator
+
+        def f() -> Generator[SomethingUnknown, None, None]:
+            yield 1
+
+        def g(x):
+            pass
+
+        g(f())
+        """)
+
+    Path("t.py").write_text(t)
+
+    subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
+                    '--no-use-multiprocessing', 't.py'], check=True)
+    output = Path("t.py").read_text()
+
+    assert "def g(x: Generator) -> None" in output
+
+
 def test_callable_from_annotation_none_return():
     t = textwrap.dedent("""\
         def f() -> None:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -999,7 +999,9 @@ def test_function_type_future_annotations():
     assert 'def baz(h: Callable[[int], int], x: int) -> int:' in output # bound method
 
 
-@pytest.mark.dont_run_mypy  # FIXME FunctionType != Callable
+# TODO this leads to an error: FunctionType IS-A Callable, so typing baz's g as
+# a Callable is too general. Should we be narrowing baz's g to FunctionType ?
+@pytest.mark.dont_run_mypy
 def test_function_type_in_annotation():
     Path("t.py").write_text(textwrap.dedent("""\
         from types import FunctionType

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -127,6 +127,29 @@ def test_callable_from_annotation_generic_alias():
     assert "def g() -> Callable[[], list[int]]:" in output
 
 
+@pytest.mark.dont_run_mypy # fails because of SomethingUnknown
+def test_callable_annotation_errors():
+    t = textwrap.dedent("""\
+        from __future__ import annotations
+
+        def f(x: SomethingUnknown) -> None:
+            pass
+
+        def g():
+            return f
+
+        g()
+        """)
+
+    Path("t.py").write_text(t)
+
+    subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
+                    '--no-use-multiprocessing', 't.py'], check=True)
+    output = Path("t.py").read_text()
+
+    assert "def g() -> Callable:" in output
+
+
 def test_callable_from_annotation_none_return():
     t = textwrap.dedent("""\
         def f() -> None:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1090,9 +1090,18 @@ def test_generator_from_annotation():
 
     subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files', 't.py'], check=True)
     output = Path("t.py").read_text()
+    code = cst.parse_module(output)
 
     # we know it's from the annotation because we never observed an 'int' yield
-    assert "def g(f: Generator[int|str, None, None]) -> None" in output
+    assert (
+        get_function(code, 'g', body=False) == textwrap.dedent("""\
+            def g(f: Generator[int|str, None, None]) -> None: ...
+        """)
+        or 
+        get_function(code, 'g', body=False) == textwrap.dedent("""\
+            def g(f: Iterator[int|str]) -> None: ...
+        """)
+    )
 
 
 def test_generator_ignore_annotation():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import pytest
 import importlib.util
 import re
+from test_transformer import get_function
+import libcst as cst
 
 
 @pytest.fixture(scope='function')
@@ -393,7 +395,7 @@ def test_inner_function():
     assert "def g(y: int) -> int" in output
 
 
-def test_class_method():
+def test_method():
     t = textwrap.dedent("""\
         class C:
             def f(self, n):
@@ -422,7 +424,7 @@ def test_class_method():
     assert "def h(self: Self, x: int) -> float" in output
 
 
-def test_class_method_imported():
+def test_method_imported():
     Path("m.py").write_text(textwrap.dedent("""\
         class C:
             def f(self, n):
@@ -456,6 +458,361 @@ def test_class_method_imported():
     assert "def g(x: int) -> float" in output
     assert "def h(self: Self, x: int) -> float" in output
     assert "import gC" not in output
+
+
+def test_method_overriding():
+    t = textwrap.dedent("""\
+        class A:
+            def foo(self, x):
+                return x/2
+
+        class B(A):
+            def foo(self, x):
+                return int(x//2)
+
+        A().foo(1.0)
+        B().foo(10)
+        """)
+
+    Path("t.py").write_text(t)
+
+    subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
+                    '--no-use-multiprocessing', 't.py'], check=True)
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+
+    assert get_function(code, 'A.foo', body=False) == textwrap.dedent("""\
+        def foo(self: Self, x: float) -> float: ...
+    """)
+
+    # contravariant for parameters, covariant for return value;
+    # so that while 'x' must not be 'int', but the return value may be 'int'
+    assert get_function(code, 'B.foo', body=False) == textwrap.dedent("""\
+        def foo(self: Self, x: float|int) -> int: ...
+    """)
+
+
+def test_method_overriding_init_irrelevant():
+    t = textwrap.dedent("""\
+        class A:
+            def __init__(self, x):
+                pass
+
+        class B(A):
+            def __init__(self):
+                super().__init__('x')
+                pass
+
+        A(1)
+        B()
+        """)
+
+    Path("t.py").write_text(t)
+
+    subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
+                    '--no-sampling', 't.py'], check=True)
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+
+    assert get_function(code, 'A.__init__', body=False) == textwrap.dedent("""\
+       def __init__(self: Self, x: int|str) -> None: ...
+    """)
+
+    assert get_function(code, 'B.__init__', body=False) == textwrap.dedent("""\
+        def __init__(self: Self) -> None: ...
+    """)
+
+
+def test_method_overriding_new_irrelevant():
+    t = textwrap.dedent("""\
+        class A:
+            def __new__(cls, x: int):
+                return super().__new__(cls)
+
+        class B(A):
+            def __new__(cls, x):
+                return super().__new__(cls, 0)
+
+        B("")
+        """)
+
+    Path("t.py").write_text(t)
+
+    subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
+                    '--no-sampling', 't.py'], check=True)
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+
+    assert get_function(code, 'B.__new__', body=False) == textwrap.dedent("""\
+        def __new__(cls: type[Self], x: str) -> Self: ...
+    """)
+
+
+def test_method_overriding_classmethod():
+    t = textwrap.dedent("""\
+        class A:
+            @classmethod
+            def foo(cls, x):
+                pass
+
+        class B(A):
+            @classmethod
+            def foo(cls, x):
+                pass
+
+        A.foo('')
+        B.foo(1)
+        """)
+
+    Path("t.py").write_text(t)
+
+    subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
+                    '--no-sampling', 't.py'], check=True)
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+
+    assert get_function(code, 'A.foo', body=False) == textwrap.dedent("""\
+        @classmethod
+        def foo(cls: type[Self], x: str) -> None: ...
+    """)
+
+    # Somewhat unexpectedly, @classmethod matters for LSP (I think because they
+    # are also available in subclasses).  At least according to mypy 1.15.0.
+    assert get_function(code, 'B.foo', body=False) == textwrap.dedent("""\
+        @classmethod
+        def foo(cls: type[Self], x: int|str) -> None: ...
+    """)
+
+
+def test_method_overriding_private():
+    t = textwrap.dedent("""\
+        class A:
+            def __foo(self, x):
+                return x/2
+
+            def _bar(self, x):
+                return x/2
+
+        class B(A):
+            def __foo(self, x):
+                return int(x//2)
+
+            def _bar(self, x):
+                return int(x//2)
+
+        A()._A__foo(1.0)    # type: ignore[attr-defined]
+        A()._bar(1.0)
+        B()._B__foo(10)     # type: ignore[attr-defined]
+        B()._bar(10)
+        """)
+
+    Path("t.py").write_text(t)
+
+    subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
+                    '--no-use-multiprocessing', 't.py'], check=True)
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+
+    assert get_function(code, 'A.__foo', body=False) == textwrap.dedent("""\
+        def __foo(self: Self, x: float) -> float: ...
+    """)
+
+    assert get_function(code, 'A._bar', body=False) == textwrap.dedent("""\
+        def _bar(self: Self, x: float) -> float: ...
+    """)
+
+    assert get_function(code, 'B.__foo', body=False) == textwrap.dedent("""\
+        def __foo(self: Self, x: int) -> int: ...
+    """)
+
+    assert get_function(code, 'B._bar', body=False) == textwrap.dedent("""\
+        def _bar(self: Self, x: float|int) -> int: ...
+    """)
+
+
+def test_method_overriding_method_called_indirectly():
+    Path("t.py").write_text(textwrap.dedent("""\
+        class A:
+            def foo(self, x):
+                return self
+
+        class B(A):
+            def bar(self, x):
+                self.foo(x)
+
+        o = B()
+        o.bar(1)
+    """))
+
+    subprocess.run([sys.executable, '-m', 'righttyper', '--output-files', '--overwrite',
+                    '--no-sampling', '--no-use-multiprocessing', 't.py'],
+                   check=True)
+
+    assert "def foo(self: Self, x: int) -> Self:" in Path("t.py").read_text()
+
+
+def test_method_overriding_arg_names_change():
+    Path("t.py").write_text(textwrap.dedent("""\
+        class C:
+            def foo(self, a: float, b: float, *, c: str) -> tuple[float, str]:
+                return (a/b, c)
+
+        class D(C):
+            def foo(self, x, y, *, d=None, c) -> tuple[float, str]:
+                return (0.0, '')
+
+
+        o = D()
+        o.foo(1, 2.0, d=4, c='*')
+    """))
+
+    subprocess.run([sys.executable, '-m', 'righttyper', '--output-files', '--overwrite',
+                    '--no-sampling', '--no-use-multiprocessing', 't.py'],
+                   check=True)
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+
+    assert get_function(code, 'D.foo', body=False) == textwrap.dedent("""\
+        def foo(self: Self, x: float|int, y: float, *, d: int|None=None, c: str) -> tuple[float, str]: ...
+    """)
+
+
+def test_method_overriding_annotation():
+    t = textwrap.dedent("""\
+        class A:
+            def foo(self, x: float) -> float:
+                return x/2
+
+        class B(A):
+            def foo(self, x):
+                return int(x//2)
+
+        B().foo(10)
+        """)
+
+    Path("t.py").write_text(t)
+
+    subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
+                    '--no-use-multiprocessing', 't.py'], check=True)
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+
+    # contravariant for parameters, covariant for return value;
+    # so that while 'x' must not be 'int', but the return value may be 'int'
+    assert get_function(code, 'B.foo', body=False) == textwrap.dedent("""\
+        def foo(self: Self, x: float|int) -> int: ...
+    """)
+
+
+def test_method_overriding_annotation_ignored():
+    t = textwrap.dedent("""\
+        class A:
+            def foo(self, x: float) -> float:
+                return x/2
+
+        class B(A):
+            def foo(self, x):
+                return int(x//2)
+
+        A().foo(10)
+        B().foo(10)
+        """)
+
+    Path("t.py").write_text(t)
+
+    subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
+                    '--ignore-annotations', 't.py'], check=True)
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+
+    # TODO int|int is silly
+    assert get_function(code, 'B.foo', body=False) == textwrap.dedent("""\
+        def foo(self: Self, x: int|int) -> int: ...
+    """)
+
+
+@pytest.mark.dont_run_mypy # fails because of SomethingUnknown
+def test_method_overriding_annotation_errors():
+    t = textwrap.dedent("""\
+        from __future__ import annotations
+
+        class A:
+            def foo(self, x: SomethingUnknown) -> float:
+                return x/2
+
+        class B(A):
+            def foo(self, x):
+                return int(x//2)
+
+        B().foo(10)
+        """)
+
+    Path("t.py").write_text(t)
+
+    subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
+                    '--no-use-multiprocessing', 't.py'], check=True)
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+
+    assert get_function(code, 'B.foo', body=False) == textwrap.dedent("""\
+        def foo(self: Self, x: int) -> int: ...
+    """)
+
+
+def test_method_overriding_typeshed():
+    t = textwrap.dedent("""\
+        class C:
+            def __eq__(self, other):
+                if not isinstance(other, C):
+                    return False
+                return self is other
+
+        C() == C()
+        """)
+
+    Path("t.py").write_text(t)
+
+    subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
+                    '--no-use-multiprocessing', 't.py'], check=True)
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+
+    assert get_function(code, 'C.__eq__', body=False) == textwrap.dedent("""\
+        def __eq__(self: Self, other: object|Self) -> bool: ...
+    """)
+
+    assert "\nimport Self" not in output
+
+
+@pytest.mark.dont_run_mypy  # this results in incompatible signatures... TODO could we resolve it?
+def test_method_overriding_different_signature():
+    t = textwrap.dedent("""\
+        class A:
+            def foo(self, x):
+                pass
+
+        class B(A):
+            def foo(self, y, z):
+                pass
+
+        A().foo(1)
+        B().foo(1.0, 2)
+        """)
+
+    Path("t.py").write_text(t)
+
+    subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
+                    '--no-sampling', 't.py'], check=True)
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+
+    assert get_function(code, 'A.foo', body=False) == textwrap.dedent("""\
+       def foo(self: Self, x: int) -> None: ...
+    """)
+
+    assert get_function(code, 'B.foo', body=False) == textwrap.dedent("""\
+        def foo(self: Self, y: float, z: int) -> None: ...
+    """)
 
 
 def test_class_name_imported():
@@ -574,7 +931,7 @@ def test_default_inner_function():
     assert "def g(y: int|str='0') -> int" in output
 
 
-def test_default_class_method():
+def test_default_method():
     t = textwrap.dedent("""\
         class C:
             def f(self, n=5):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1313,8 +1313,25 @@ def test_self():
     assert 'def baz(me: Self) -> Self:' in output
 
 
-@pytest.mark.xfail(reason="Doesn't currently work")
-def test_self_with_wrapped_method():
+def test_cached_function():
+    Path("t.py").write_text(textwrap.dedent("""\
+        import functools
+
+        @functools.cache
+        def foo(x=None):
+            return x/2 if x else 0
+
+        foo(1)
+    """))
+
+    subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
+                    '--no-use-multiprocessing', 't.py'], check=True)
+
+    output = Path("t.py").read_text()
+    assert 'def foo(x: int|None=None) -> float:' in output
+
+
+def test_self_with_cached_method():
     Path("t.py").write_text(textwrap.dedent("""\
         import functools
 

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -57,10 +57,18 @@ def find_function(m: cst.Module, name: str) -> tuple[cst.FunctionDef, int]|None:
     return v.found
 
 
-def get_function(m: cst.Module, funcname: str) -> str|None:
+def get_function(m: cst.Module, funcname: str, body=True) -> str|None:
     """Returns the given function as a string, if found in 'm'"""
     if (f := find_function(m, funcname)):
-        return cst.Module([f[0]]).code.lstrip('\n')
+        if body:
+            return cst.Module([f[0]]).code.lstrip('\n')
+
+        return cst.Module([
+                f[0].with_changes(
+                    body=cst.SimpleStatementSuite([cst.Expr(cst.Ellipsis())]),
+                    leading_lines=[]
+                )
+            ]).code
 
     return None
 

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -390,7 +390,7 @@ def test_transform_unknown_type_as_string():
                     [
                         (ArgumentName('x'), TypeInfo.from_type(int, module='')),
                         (ArgumentName('y'), TypeInfo.from_set({
-                            TypeInfo(module='x.y', name='Something', args=('"quoted"',)),
+                            TypeInfo(module='x.y', name='Something', args=('quoted',)),
                             NoneTypeInfo
                         }))
                     ],

--- a/tests/test_typeinfo.py
+++ b/tests/test_typeinfo.py
@@ -73,21 +73,6 @@ def test_generalize_first_same_then_different():
     assert generalize(samples) == ['bool|int', 'bool|int']
 
 
-@pytest.mark.skip(reason="still checking whether mypy/pyright agree")
-def test_generalize_doesnt_push_union_into_parameters():
-    samples = [
-        (ti('str'), ti('list', args=(ti('bool'),))),
-        (ti('str'), ti('list', args=(ti('int'),))),
-    ]
-    assert generalize(samples) == ['str', 'list[bool]|list[int]']
-
-    samples = [
-        (ti('list', args=(ti('str'),)), ti('list', args=(ti('bool'),))),
-        (ti('list', args=(ti('str'),)), ti('list', args=(ti('int'),))),
-    ]
-    assert generalize(samples) == ['list[str]', 'list[bool]|list[int]']
-
-
 def test_generalize_mixed_with_constant_types():
     samples = [
         (ti('int'), ti('str'), ti('int')),

--- a/tests/test_typeinfo.py
+++ b/tests/test_typeinfo.py
@@ -162,7 +162,7 @@ def test_generalize_with_ellipsis():
 
 
 def test_generalize_callable():
-    samples = [
+    samples: list[tuple[TypeInfo, ...]] = [
         (ti('Callable', args=(TypeInfo.list([ti('int'), ti('int')]), ti('int'))),),
         (ti('Callable', args=(TypeInfo.list([ti('str'), ti('str')]), ti('str'))),),
     ]

--- a/tests/test_typeinfo.py
+++ b/tests/test_typeinfo.py
@@ -1,6 +1,7 @@
 from righttyper.righttyper_types import TypeInfo
 import righttyper.typeinfo
 from typing import Any
+import pytest
 
 
 def ti(name: str, **kwargs) -> TypeInfo:
@@ -72,6 +73,21 @@ def test_generalize_first_same_then_different():
     assert generalize(samples) == ['bool|int', 'bool|int']
 
 
+@pytest.mark.skip(reason="still checking whether mypy/pyright agree")
+def test_generalize_doesnt_push_union_into_parameters():
+    samples = [
+        (ti('str'), ti('list', args=(ti('bool'),))),
+        (ti('str'), ti('list', args=(ti('int'),))),
+    ]
+    assert generalize(samples) == ['str', 'list[bool]|list[int]']
+
+    samples = [
+        (ti('list', args=(ti('str'),)), ti('list', args=(ti('bool'),))),
+        (ti('list', args=(ti('str'),)), ti('list', args=(ti('int'),))),
+    ]
+    assert generalize(samples) == ['list[str]', 'list[bool]|list[int]']
+
+
 def test_generalize_mixed_with_constant_types():
     samples = [
         (ti('int'), ti('str'), ti('int')),
@@ -137,23 +153,45 @@ def test_generalize_generic_within_args():
     assert generalize(samples) == ['tuple[T1]', 'list[T1]']
 
 
+def test_generalize_with_ellipsis():
+    samples = [
+        (ti('int'), ti('tuple', args=(ti('int'), ...))),
+        (ti('float'), ti('tuple', args=(ti('float'), ...))),
+    ]
+    assert generalize(samples) == ['T1', 'tuple[T1, ...]']
+
+
+def test_generalize_callable():
+    samples = [
+        (ti('Callable', args=(TypeInfo.list([ti('int'), ti('int')]), ti('int'))),),
+        (ti('Callable', args=(TypeInfo.list([ti('str'), ti('str')]), ti('str'))),),
+    ]
+    assert generalize(samples) == ['Callable[[T1, T1], T1]']
+
+    samples = [
+        (ti('int'), ti('Callable', args=(..., ti('int'))),),
+        (ti('str'), ti('Callable', args=(..., ti('str'))),),
+    ]
+    assert generalize(samples) == ['T1', 'Callable[..., T1]']
+
+
 def test_generalize_generic_with_string():
     samples: Any = [
-        (ti('int'), ti('X', args=(ti('int'), '"foo"'))),
-        (ti('bool'), ti('X', args=(ti('bool'), '"bar"'))),
+        (ti('int'), ti('X', args=(ti('int'), 'foo'))),
+        (ti('bool'), ti('X', args=(ti('bool'), 'bar'))),
     ]
     assert generalize(samples) == ['bool|int', 'X[bool, "bar"]|X[int, "foo"]']
 
     # first has a string, others don't
     samples = [
-        (ti('int'), ti('X', args=(ti('int'), '"foo"'))),
+        (ti('int'), ti('X', args=(ti('int'), 'foo'))),
         (ti('bool'), ti('X', args=(ti('bool'), ti('bool')))),
     ]
     assert generalize(samples) == ['bool|int', 'X[bool, bool]|X[int, "foo"]']
 
     samples = [
-        (ti('X', args=(ti('int'), '"foo"')),),
-        (ti('X', args=(ti('bool'), '"bar"')),),
+        (ti('X', args=(ti('int'), 'foo')),),
+        (ti('X', args=(ti('bool'), 'bar')),),
     ]
     assert generalize(samples) == ['X[bool, "bar"]|X[int, "foo"]']
 
@@ -164,12 +202,12 @@ def test_generalize_jaxtyping_dimensions():
             TypeInfo('', 'int'),
             TypeInfo('jaxtyping', 'Float64', args=(
                     TypeInfo('np', 'ndarray'),
-                    '"10 20"'
+                    '10 20'
                 )
             ),
             TypeInfo('jaxtyping', 'Float64', args=(
                     TypeInfo('np', 'ndarray'),
-                    '"20"'
+                    '20'
                 )
             )
         ),
@@ -177,12 +215,12 @@ def test_generalize_jaxtyping_dimensions():
             TypeInfo('', 'int'),
             TypeInfo('jaxtyping', 'Float64', args=(
                     TypeInfo('np', 'ndarray'),
-                    '"10 10"'
+                    '10 10'
                 )
             ),
             TypeInfo('jaxtyping', 'Float64', args=(
                     TypeInfo('np', 'ndarray'),
-                    '"10"'
+                    '10'
                 )
             )
         )
@@ -198,12 +236,12 @@ def test_generalize_jaxtyping_single_sample():
             TypeInfo('', 'int'),
             TypeInfo('jaxtyping', 'Float64', args=(
                     TypeInfo('np', 'ndarray'),
-                    '"10 20"'
+                    '10 20'
                 )
             ),
             TypeInfo('jaxtyping', 'Float64', args=(
                     TypeInfo('np', 'ndarray'),
-                    '"20"'
+                    '20'
                 )
             )
         ),

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -3,7 +3,7 @@ from righttyper.typeinfo import merged_types, generalize, find_superclass
 import righttyper.righttyper_runtime as rt
 import collections.abc as abc
 from collections import namedtuple
-from typing import Any, Callable, get_type_hints, Union, Optional, TypeVar, List, Literal
+from typing import Any, Callable, get_type_hints, Union, Optional, TypeVar, List, Literal, cast
 import pytest
 import importlib
 import types
@@ -471,7 +471,7 @@ def test_hint2type_typevar():
     t = rt.hint2type(T)
     assert t == TypeInfo(module=__name__, name='T')
 
-    t = rt.hint2type(List[T])
+    t = rt.hint2type(List[T])   # type: ignore[valid-type]
     assert t == TypeInfo.from_type(list, module='', args=(TypeInfo(module=__name__, name='T'),))
 
 
@@ -500,7 +500,7 @@ def test_hint2type_ellipsis():
 
 def test_hint2type_list():
     t = rt.hint2type(abc.Callable[[], None]) 
-    assert t == TypeInfo.from_type(abc.Callable, args=(
+    assert t == TypeInfo.from_type(cast(type, abc.Callable), args=(
         TypeInfo.list([]),
         NoneTypeInfo
     ))
@@ -508,7 +508,7 @@ def test_hint2type_list():
 
 def test_hint2type_string():
     t = rt.hint2type(Literal["a", "b"])
-    assert t == TypeInfo.from_type(Literal, args=(
+    assert t == TypeInfo.from_type(cast(type, Literal), args=(
         "a",
         "b"
     ))

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,7 +1,7 @@
 from righttyper.righttyper_types import TypeInfo, NoneTypeInfo, AnyTypeInfo, Sample
 from righttyper.typeinfo import merged_types, generalize
 import righttyper.righttyper_runtime as rt
-from collections.abc import Iterable
+import collections.abc as abc
 from collections import namedtuple
 from typing import Any, Callable, get_type_hints
 import pytest
@@ -16,7 +16,7 @@ def type_from_annotations(*args, **kwargs) -> str:
     return str(rt.type_from_annotations(*args, **kwargs))
 
 
-class IterableClass(Iterable):
+class IterableClass(abc.Iterable):
     def __iter__(self):
         return None
 
@@ -382,7 +382,7 @@ def test_merged_types_superclass_bare_type():
 str_ti = TypeInfo("", "str", type_obj=str)
 int_ti = TypeInfo("", "int", type_obj=int)
 bool_ti = TypeInfo("", "bool", type_obj=bool)
-generator_ti = lambda *a: TypeInfo("typing", "Generator", tuple(a))
+generator_ti = lambda *a: TypeInfo.from_type(abc.Generator, module="typing", args=tuple(a))
 iterator_ti = lambda *a: TypeInfo("typing", "Iterator", tuple(a))
 union_ti = lambda *a: TypeInfo("types", "UnionType", tuple(a), type_obj=types.UnionType)
 

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -21,6 +21,9 @@ class IterableClass(Iterable):
         return None
 
 
+class MyGeneric[A, B, C](dict): pass
+
+
 def test_get_value_type():
     assert NoneTypeInfo is rt.get_value_type(None)
 
@@ -151,6 +154,9 @@ def test_get_value_type():
 
     assert "typing.AsyncGenerator" == get_value_type(async_range(10))
     assert "typing.AsyncGenerator" == get_value_type(aiter(async_range(10)))
+
+    assert f"{__name__}.MyGeneric[builtins.int, builtins.str, builtins.bool]" == \
+            get_value_type(MyGeneric[int, str, bool]())
 
 
 @pytest.mark.filterwarnings("ignore:coroutine .* never awaited")


### PR DESCRIPTION
- added generic type argument introspection (and typing);
- extended `Collection` based type argument to `defaultdict`, `OrderedDict`, `ChainMap`, `frozenset`, `deque` and `Counter`;
- added type argument support for `re.Pattern` and `re.Match`;
- added incorporating method argument types from parent classes when typing overriding methods, to avoid type narrowing contrary to Liskov's substitution principle;
- fixed typing for classes that inherit from dict, list, set, or tuple;
- fixed `Callable` typing for functions that use varargs or kwargs;
- fixed `--inline-generics` when no type variables are needed;
- fixed `typing.Self` being used out of class context;
- fixed `typing.Self` typing for `__...` private methods and attributes;
- lowered introspection overhead;
- many internal and test improvements;

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution under the terms of your choice.
