### PR TITLE
Adds `--python-version` to select typing features based on Python version, supporting 3.9+

### DIFF
--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -62,6 +62,7 @@ from righttyper.righttyper_types import (
     NoneTypeInfo,
     AnyTypeInfo,
     Sample,
+    UnknownTypeInfo
 )
 from righttyper.typeinfo import (
     merged_types,
@@ -417,11 +418,14 @@ class Observations:
             """Clones the given TypeInfo, clearing all is_self flags."""
             def visit(vself, node: TypeInfo) -> TypeInfo:
                 if node.type_obj is IteratorArg:
+                    assert isinstance(node.args[0], TypeInfo)
                     source = node.args[0]
                     if source.args:
                         if source.type_obj is abc.Callable:
+                            assert isinstance(source.args[1], TypeInfo)
                             return source.args[1]   # Callable return value
                         else:
+                            assert isinstance(source.args[0], TypeInfo)
                             return source.args[0]   # Generator/Iterator yield value
                     return UnknownTypeInfo
 

--- a/righttyper/righttyper_runtime.py
+++ b/righttyper/righttyper_runtime.py
@@ -278,23 +278,23 @@ def search_type(t: type) -> tuple[str, str] | None:
 # but does not name their types publicly.  We here give them names to keep the
 # introspection code more readable. Note that these types may not be exhaustive
 # and may overlap as across Python versions and implementations.
-BYTES_ITER = type(iter(b''))
-BYTEARRAY_ITER = type(iter(bytearray()))
-DICT_KEYITER = type(iter({}))
-DICT_VALUEITER = type(iter({}.values()))
-DICT_ITEMITER = type(iter({}.items()))
-LIST_ITER = type(iter([]))
-LIST_REVERSED_ITER = type(iter(reversed([])))
-RANGE_ITER = type(iter(range(1)))
-LONGRANGE_ITER = type(iter(range(1 << 1000)))
-SET_ITER = type(iter(set()))
-STR_ITER = type(iter(""))
-TUPLE_ITER = type(iter(()))
+BYTES_ITER: type = type(iter(b''))
+BYTEARRAY_ITER: type = type(iter(bytearray()))
+DICT_KEYITER: type = type(iter({}))
+DICT_VALUEITER: type = type(iter({}.values()))
+DICT_ITEMITER: type = type(iter({}.items()))
+LIST_ITER: type = type(iter([]))
+LIST_REVERSED_ITER: type = type(iter(reversed([])))
+RANGE_ITER: type = type(iter(range(1)))
+LONGRANGE_ITER: type = type(iter(range(1 << 1000)))
+SET_ITER: type = type(iter(set()))
+STR_ITER: type = type(iter(""))
+TUPLE_ITER: type = type(iter(()))
 
 class _GetItemDummy:
     def __getitem__(self, n):
         return n
-GETITEM_ITER = type(iter(_GetItemDummy()))
+GETITEM_ITER: type = type(iter(_GetItemDummy()))
 
 
 def get_type_name(obj: type, depth: int = 0) -> TypeInfo:
@@ -452,7 +452,7 @@ def get_value_type(
         return TypeInfo("typing", "Never")
 
     t: type|None
-    args: tuple[TypeInfo, ...]
+    args: tuple[TypeInfo|str|ellipsis, ...]
 
 
     def type_for_generator(

--- a/righttyper/unified_transformer.py
+++ b/righttyper/unified_transformer.py
@@ -106,8 +106,6 @@ class UnifiedTransformer(cst.CSTTransformer):
         inline_generics: bool,
         module_name: str|None,
         module_names: list[str],
-        *,
-        use_self: bool = True
     ) -> None:
         self.filename = filename
         self.type_annotations = type_annotations
@@ -117,7 +115,6 @@ class UnifiedTransformer(cst.CSTTransformer):
         self.module_name = module_name
         self.module_names = sorted(module_names, key=lambda name: -name.count('.'))
         self.change_list: list[tuple[FunctionName, cst.FunctionDef, cst.FunctionDef]] = []
-        self.use_self = use_self
 
     def _module_for(self, name: str) -> tuple[str, str]:
         """Splits a dot name in its module and qualified name parts."""

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -678,8 +678,7 @@ def test_transform_locally_defined_types():
             module_names=[
                 'foo'
             ],
-            inline_generics=False,
-            use_self = False
+            inline_generics=False
         )
 
     code = t.transform_code(code)


### PR DESCRIPTION
Also removes `--inline-generics`, which is now automatically enabled whenever `--python-version` is 3.12+, and fixes a bug preventing type merging code from working in certain cases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
