### PR TITLE
Fixes typing of self-references

### DIFF
--- a/righttyper/righttyper_runtime.py
+++ b/righttyper/righttyper_runtime.py
@@ -603,7 +603,7 @@ def get_value_type(
             t is zip
             and (l := first_referent()) is not None
             and type(l) is tuple
-            and all(isinstance(s, abc.Iterator) for s in l)
+            and all(isinstance(s, abc.Iterator) for s in l)  # note a generator also IS-A abc.Iterator
         ):
             zip_sources = tuple(recurse(s) for s in l)
             args = (

--- a/righttyper/righttyper_runtime.py
+++ b/righttyper/righttyper_runtime.py
@@ -557,7 +557,7 @@ def get_value_type(
     elif isinstance(value, CoroutineType):
         return type_for_generator(value, abc.Coroutine, value.cr_frame, value.cr_code)
     elif isinstance(value, type) and value is not type:
-        return TypeInfo("", "type", args=(get_type_name(value, depth+1),))
+        return TypeInfo("", "type", args=(get_type_name(value, depth+1),), type_obj=t)
     elif t.__module__ == "builtins":
         if t is NoneType:
             return NoneTypeInfo


### PR DESCRIPTION
- fixed self-references in Python 3.9 and 3.10 being typed with subclasses;
- fixed incorrect typing for Python 3.11+ when the exact same type was a self-reference in one sample, but not another;

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution under the terms of your choice.
