### PR TITLE
Fixes KeyError occurring when a type claims to stem from a nonexistent module.

### DIFF
--- a/righttyper/righttyper_runtime.py
+++ b/righttyper/righttyper_runtime.py
@@ -267,7 +267,7 @@ def search_type(t: type) -> tuple[str, str] | None:
 
         return None
 
-    if (f := find_in(t.__module__, sys.modules[t.__module__])):
+    if (m := sys.modules.get(t.__module__)) and (f := find_in(t.__module__, m)):
         return normalize_module_name(f[0]), f[1]
 
     # TODO if runpy is done running the module/script, sys.modules['__main__'] may

--- a/righttyper/righttyper_runtime.py
+++ b/righttyper/righttyper_runtime.py
@@ -497,16 +497,13 @@ def get_value_type(
         return ref[0] if len(ref) else None
 
 
-    try:
-        # using getattr or hasattr here can lead to problems when __getattr__ is overriden
-        orig = object.__getattribute__(value, "__orig_class__")
+    # using getattr or hasattr here can lead to problems when __getattr__ is overridden
+    if (orig := inspect.getattr_static(value, "__orig_class__", None)):
         return TypeInfo(orig.__module__, orig.__qualname__,
                         tuple(
                             TypeInfo.from_type(a) for a in orig.__args__
                         )
                )
-    except AttributeError:
-        pass
 
     t = type(value)
     if t is RandomDict:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3325,11 +3325,13 @@ def test_generalize_union_return_not_typevar():
 
 @pytest.mark.dont_run_mypy # unnecessary 
 def test_object_overridden_getattr():
-    # Derived from tqdm.utils.ObjectWrapper: sometimes calls to getattr() lead to infinite recursion
+    # Sometimes dynamic attribute lookups have side effects or, as in the case of
+    # tqdm and rich tests, lead to infinite recursions as their __getattr__ call getattr()
+    # on the same object.
     t = textwrap.dedent("""\
         class Thing:
             def __getattr__(self, name):
-                raise AttributeError
+                raise RuntimeError()
 
         def f(t):
             pass

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,4 +1,4 @@
-from righttyper.righttyper_types import TypeInfo, NoneTypeInfo, AnyTypeInfo, Sample
+from righttyper.righttyper_types import TypeInfo, NoneTypeInfo, AnyTypeInfo, Sample, UnknownTypeInfo
 from righttyper.typeinfo import merged_types, generalize
 import righttyper.righttyper_runtime as rt
 import collections.abc as abc
@@ -158,6 +158,13 @@ def test_value_type_iterator(init, name, nextv):
 ])
 def test_type_name_iterator(init, name):
     assert name == str(rt.get_type_name(type(eval(init))))
+
+
+def test_type_name_not_in_sys_modules():
+    t = type('myType', (object,), dict())
+    t.__module__ = 'doesntexist'
+
+    assert rt.get_type_name(t) is UnknownTypeInfo
 
 
 @pytest.mark.filterwarnings("ignore:coroutine .* never awaited")


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
