### PR TITLE
Fixes missing overload handling

### DIFF
--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -1177,6 +1177,9 @@ def run(
     else:
         raise click.UsageError("Either -m/--module must be provided, or a script be passed.")
 
+    if ignore_annotations and only_update_annotations:
+        raise click.UsageError("Options --ignore-annotations and --only-update-annotations are mutually exclusive.")
+
     if infer_shapes:
         # Check for required packages for shape inference
         found_package = defaultdict(bool)

--- a/righttyper/unified_transformer.py
+++ b/righttyper/unified_transformer.py
@@ -1,6 +1,7 @@
 import typing
 import builtins
 import collections.abc as abc
+from dataclasses import dataclass
 import libcst as cst
 import libcst.matchers as cstm
 from libcst.metadata import MetadataWrapper, PositionProvider
@@ -11,8 +12,17 @@ from righttyper.righttyper_types import (
     FuncId,
     FuncAnnotation,
     FunctionName,
-    TypeInfo,
+    TypeInfo
 )
+
+
+@dataclass(eq=True, frozen=True)
+class ExtendedFunctionDef:
+    # The list of CST elements before the actual `FunctionDef` node which are
+    # associated with that node
+    prefix: typing.Sequence[cst.SimpleStatementLine | cst.BaseCompoundStatement]
+    # The primary `FunctionDef` node
+    primary: cst.FunctionDef
 
 
 _BUILTIN_TYPES : frozenset[str] = frozenset({
@@ -114,7 +124,7 @@ class UnifiedTransformer(cst.CSTTransformer):
         self.inline_generics = inline_generics
         self.has_future_annotations = False
         self.module_name = module_name
-        self.change_list: list[tuple[FunctionName, cst.FunctionDef, cst.FunctionDef]] = []
+        self.change_list: list[tuple[FunctionName, ExtendedFunctionDef, ExtendedFunctionDef]] = []
 
         # TODO Ideally we'd use TypeInfo.module and avoid this as well as _module_for
         def iter_types(t: TypeInfo):
@@ -246,6 +256,17 @@ class UnifiedTransformer(cst.CSTTransformer):
         
         return (updated_ann, tr.generics)
                     
+    def _is_overload(self, decorator: cst.Decorator):
+        """Test if the given decorator is an `@overload` decorator.
+        
+        Note that this is not a perfect test -- it is based on `self.aliases`
+        and only handles global includes and aliases thereof."""
+        if isinstance(decorator.decorator, cst.Name):
+            return decorator.decorator.value == self.aliases["typing.overload"]
+        if isinstance(decorator.decorator, cst.Attribute) and isinstance(decorator.decorator.value, cst.Name):
+            typing_alias = self.aliases["typing"] if "typing" in self.aliases else "typing"
+            return decorator.decorator.value.value == typing_alias and decorator.decorator.attr.value == "overload"
+        return False
 
     def visit_Module(self, node: cst.Module) -> bool:
         # Initialize mutable members here, just in case transformer gets reused
@@ -287,6 +308,16 @@ class UnifiedTransformer(cst.CSTTransformer):
         )
 
         self.module_generic_index = 1
+
+        # Since overloads must be consecutive, we don't need to keep track of
+        # multiple concurrent overloaded functions within each namespace.
+
+        # The current list of overloads that have been collected in each scope.
+        # Note that this is a stack since namespaces can be nested
+        # (e.g. classes).
+        self.overload_stack: list[list[cst.FunctionDef]] = [[]]
+        # The current list of overloaded function names that are in each scope.
+        self.overload_name_stack: list[str] = [""]
 
         return True
 
@@ -346,6 +377,8 @@ class UnifiedTransformer(cst.CSTTransformer):
         name_source = list_rindex(self.name_stack, '<locals>') # neg. index of last function, or 0 (for globals)
         self.name_stack.append(node.name.value)
         self.used_names.append(self.used_names[name_source] | used_names(node))
+        self.overload_stack.append([])
+        self.overload_name_stack.append("")
         return True
 
     def leave_ClassDef(self, orig_node: cst.ClassDef, updated_node: cst.ClassDef) -> cst.ClassDef:
@@ -353,12 +386,16 @@ class UnifiedTransformer(cst.CSTTransformer):
         self.known_names.add(".".join(self.name_stack))
         self.name_stack.pop()
         self.used_names.pop()
+        self.overload_stack.pop()
+        self.overload_name_stack.pop()
         return updated_node
 
     def visit_FunctionDef(self, node: cst.FunctionDef) -> bool:
         name_source = list_rindex(self.name_stack, '<locals>') # neg. index of last function, or 0 (for globals)
         self.name_stack.extend([node.name.value, "<locals>"])
         self.used_names.append(self.used_names[name_source] | used_names(node))
+        self.overload_stack.append([])
+        self.overload_name_stack.append("")
         return True
 
     def _get_annotation_expr(self, annotation: TypeInfo) -> cst.BaseExpression:
@@ -432,11 +469,13 @@ class UnifiedTransformer(cst.CSTTransformer):
 
     def leave_FunctionDef(
             self, original_node: cst.FunctionDef, updated_node: cst.FunctionDef
-    ) -> cst.FunctionDef | cst.FlattenSentinel:
+    ) -> cst.FunctionDef | cst.FlattenSentinel | cst.RemovalSentinel:
         name = ".".join(self.name_stack[:-1])
         self.name_stack.pop()
         self.name_stack.pop()
         self.used_names.pop()
+        self.overload_stack.pop()
+        self.overload_name_stack.pop()
 
         first_line = min(
             self.get_metadata(PositionProvider, node).start.line
@@ -444,9 +483,31 @@ class UnifiedTransformer(cst.CSTTransformer):
         )
         key = FuncId(Filename(self.filename), first_line, FunctionName(name))
 
+        # If we encounter a function whose name doesn't match the current
+        # overload sequence, we discard the overload stack and update the
+        # current overload sequence.
+        # This also has the side effect of cleaning up orphan overload
+        # signatures, which is good.
+        if name != self.overload_name_stack[-1]:
+            self.overload_stack[-1] = []
+            self.overload_name_stack[-1] = name
+
+        is_overload = any(self._is_overload(decorator)
+                          for decorator in updated_node.decorators)
+
+        # If our function is an overload signature, we append it to the overload
+        # list.
+        # NOTE: This check technically misses if @overload is aliased or used as
+        # the result of an expression, but not even mypy handles that.
+        if is_overload:
+            self.overload_stack[-1].append(original_node)
+            return cst.RemoveFromParent()
+
         if ann := typing.cast(FuncAnnotation, self.type_annotations.get(key)):  # cast to make mypy happy
-            pre_function = []
+            pre_function: list[cst.SimpleStatementLine | cst.BaseCompoundStatement] = []
             argmap: dict[str, TypeInfo] = {aname: atype for aname, atype in ann.args}
+            overloads = self.overload_stack[-1]
+            self.overload_stack[-1] = []
 
             # Do existing annotations overlap with typevar args/return ?
             typevar_overlap = not self.override_annotations and (
@@ -457,12 +518,12 @@ class UnifiedTransformer(cst.CSTTransformer):
                         argmap[par.name.value].is_typevar()
                         for par in typing.cast(typing.Iterator[cst.Param], cstm.findall(updated_node.params, cstm.Param()))
                     )
-                )
+            )
 
             del argmap
 
             # We don't yet support merging type_parameters
-            if not typevar_overlap and updated_node.type_parameters is None:
+            if (overloads == [] or self.override_annotations) and not typevar_overlap and updated_node.type_parameters is None:
                 ann, generics = self._process_generics(ann)
 
                 if self.inline_generics:
@@ -503,12 +564,13 @@ class UnifiedTransformer(cst.CSTTransformer):
                 def leave_Param(vself, node: cst.Param, updated_node: cst.Param) -> cst.Param:
                     return self._process_parameter(updated_node, ann)
 
-            updated_node = updated_node.with_changes(params=updated_node.params.visit(ParamChanger()))
+            if overloads == [] or self.override_annotations:
+                updated_node = updated_node.with_changes(params=updated_node.params.visit(ParamChanger()))
 
             should_update_ret = (
             (self.only_update_annotations and updated_node.returns is not None)
             or (not self.only_update_annotations and (updated_node.returns is None or self.override_annotations))
-            )
+            ) and (overloads == [] or self.override_annotations)
             if should_update_ret:
                 if self._is_valid(ann.retval):
                     annotation_expr = self._get_annotation_expr(ann.retval)
@@ -534,8 +596,14 @@ class UnifiedTransformer(cst.CSTTransformer):
                     body=updated_node.body.with_changes(
                         header=cst.TrailingWhitespace()))
 
-            # FIXME this doesn't capture any non-inline typevar definitions
-            self.change_list.append((key.func_name, original_node, updated_node))
+
+            # TODO Generate new overloads.
+            # If any override_annotations is set, wipe the existing overloads
+            # and remake them.
+            original_overloads = overloads
+            if self.override_annotations:
+                overloads = []
+            pre_function.extend(overloads)
 
             if pre_function:
                 leading_lines = updated_node.leading_lines
@@ -548,9 +616,15 @@ class UnifiedTransformer(cst.CSTTransformer):
                     pre_function[0] = pre_function[0].with_changes(leading_lines=leading_lines[:first_comment])
                     updated_node = updated_node.with_changes(leading_lines=leading_lines[first_comment:])
 
-                return cst.FlattenSentinel([*pre_function, updated_node])
+            original_function_def = ExtendedFunctionDef(original_overloads, original_node)
+            updated_function_def = ExtendedFunctionDef(pre_function, updated_node)
+            self.change_list.append((key.func_name, original_function_def, updated_function_def))
+            
+            return cst.FlattenSentinel([*pre_function, updated_node]) if pre_function else updated_node
 
-        return updated_node
+        overloads = self.overload_stack[-1]
+        self.overload_stack[-1] = []
+        return cst.FlattenSentinel([*overloads, updated_node]) if overloads else updated_node
 
     # ConstructImportTransformer logic
     def leave_Module(
@@ -807,7 +881,7 @@ def list_rindex(lst: list, item: object) -> int:
         return 0
 
 
-def format_signature(f: cst.FunctionDef) -> str:
+def format_signature(f: ExtendedFunctionDef) -> str:
     """Formats the signature of a function."""
 
     class BodyRemover(cst.CSTTransformer):
@@ -823,8 +897,10 @@ def format_signature(f: cst.FunctionDef) -> str:
         ) -> cst.RemovalSentinel:
             return cst.RemoveFromParent()
 
-    bodyless = typing.cast(cst.FunctionDef, f.visit(BodyRemover()))
-    sig = cst.Module([bodyless]).code.strip()
+    # Here, we remove the body from the primary function and convert the whole
+    # sequence (prefix, primary) into a string
+    bodyless = typing.cast(cst.FunctionDef, f.primary.visit(BodyRemover()))
+    sig = cst.Module([*f.prefix, bodyless]).code.strip()
 
     # It's easier to let libcst generate "pass" for an empty body and then remove it
     # than to find a way to have it emit a bodyless function...

--- a/righttyper/unified_transformer.py
+++ b/righttyper/unified_transformer.py
@@ -604,8 +604,8 @@ class UnifiedTransformer(cst.CSTTransformer):
             original_overloads = overloads
             if self.override_annotations:
                 overloads = []      # overloads are annotations, so wipe them
+                # TODO Generate new overloads.
 
-            # TODO Generate new overloads.
             pre_function.extend(overloads)
 
             if pre_function:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7,9 +7,11 @@ import importlib.util
 import re
 import libcst as cst
 
-from test_transformer import get_function as t_get_function
+from test_transformer import (get_function as t_get_function,
+                              get_function_all as t_get_function_all)
 from functools import partial
 get_function = partial(t_get_function, body=False)
+get_function_all = partial(t_get_function_all, body=False)
 
 
 @pytest.fixture(scope='function')
@@ -3779,7 +3781,7 @@ def test_numeric_hierarchy(tmp_cwd):
 
     assert "def foo(x: float) -> None:" in output
 
-
+    
 def test_enum_class():
     Path("t.py").write_text(textwrap.dedent("""\
         from enum import Enum
@@ -3816,3 +3818,360 @@ def test_enum_class():
         @classmethod
         def from_str(cls: "type[Decision]", s: str) -> "Decision": ...
     """)
+
+    
+def test_overload_no_ignore_annotations(tmp_cwd):
+    pre_annotation = textwrap.dedent("""\
+        from typing import overload
+
+        @overload
+        def foo(bar: int) -> str:
+            ...
+        @overload
+        def foo(bar: str) -> int:
+            ...
+        def foo(bar):
+            if isinstance(bar, int):
+                return "hello"
+            elif isinstance(bar, str):
+                return 2
+
+        foo(1)
+        foo("world")
+    """)
+    Path("t.py").write_text(pre_annotation)
+    subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
+                    '--no-use-multiprocessing', '--no-sampling', '--only-update-annotations', '-m',
+                    't'],
+                    check=True)
+
+    post_annotation = Path("t.py").read_text()
+    assert pre_annotation == post_annotation
+
+
+def test_overload_ignore_annotations(tmp_cwd):
+    Path("t.py").write_text(textwrap.dedent("""\
+        from typing import overload
+
+        @overload
+        def foo(bar: int) -> str:
+            ...
+        @overload
+        def foo(bar: str) -> int:
+            ...
+        def foo(bar):
+            if isinstance(bar, int):
+                return "hello"
+            elif isinstance(bar, str):
+                return 2
+
+        foo(1)
+        foo("world")
+        """
+    ))
+
+    subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
+                    '--no-use-multiprocessing', '--no-sampling', '--ignore-annotations', '-m', 't'],
+                    check=True)
+
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+
+    function_list = get_function_all(code, "foo")
+
+    # In our current iteration, we need to make sure that foo is annotated and
+    # that the old overloads are deleted.
+    # Since we haven't implemented overload generation, this is done with
+    # unions.
+    assert len(function_list) == 1
+    assert function_list[0].strip() == "def foo(bar: int|str) -> int|str: ..."
+
+
+def test_overload_only_update_annotations(tmp_cwd):
+    pre_annotation = textwrap.dedent("""\
+        from typing import overload
+
+        @overload
+        def foo(bar: int) -> str:
+            ...
+        @overload
+        def foo(bar: str) -> int:
+            ...
+        def foo(bar):
+            if isinstance(bar, int):
+                return "hello"
+            elif isinstance(bar, str):
+                return 2
+
+        foo(1)
+        foo("world")
+    """)
+    Path("t.py").write_text(pre_annotation)
+    subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
+                    '--no-use-multiprocessing', '--no-sampling', '--only-update-annotations', '-m',
+                    't'],
+                    check=True)
+
+    post_annotation = Path("t.py").read_text()
+    assert pre_annotation == post_annotation
+
+
+def test_overload_no_ignore_annotations_generic(tmp_cwd):
+    pre_annotation = textwrap.dedent("""\
+        from typing import overload
+
+        @overload
+        def foo(bar: int) -> int:
+            ...
+        @overload
+        def foo(bar: str) -> str:
+            ...
+        def foo(bar):
+            return bar
+
+        foo(1)
+        foo("world")
+    """)
+    Path("t.py").write_text(pre_annotation)
+    subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
+                    '--no-use-multiprocessing', '--no-sampling', '--only-update-annotations', '-m',
+                    't'],
+                    check=True)
+
+    post_annotation = Path("t.py").read_text()
+    assert pre_annotation == post_annotation
+
+
+def test_overload_ignore_annotations_generic(tmp_cwd):
+    Path("t.py").write_text(textwrap.dedent("""\
+        from typing import overload
+
+        @overload
+        def foo(bar: int) -> int:
+            ...
+        @overload
+        def foo(bar: str) -> str:
+            ...
+        def foo(bar):
+            return bar
+
+        foo(1)
+        foo("world")
+        """
+    ))
+
+    subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
+                    '--no-use-multiprocessing', '--no-sampling', '--ignore-annotations', '-m', 't'],
+                    check=True)
+
+    output = Path("t.py").read_text()
+    print(output)
+    code = cst.parse_module(output)
+
+    function_list = get_function_all(code, "foo")
+
+    # In our current iteration, we need to make sure that foo is annotated and
+    # that the old overloads are deleted.
+    # Since we haven't implemented overload generation, this is done with
+    # unions.
+    assert len(function_list) == 1
+    assert function_list[0].strip() == "def foo[T1: (int, str)](bar: T1) -> T1: ..."
+
+
+def test_overload_only_update_annotations_generic(tmp_cwd):
+    pre_annotation = textwrap.dedent("""\
+        from typing import overload
+
+        @overload
+        def foo(bar: int) -> int:
+            ...
+        @overload
+        def foo(bar: str) -> str:
+            ...
+        def foo(bar):
+            return bar
+
+        foo(1)
+        foo("world")
+    """)
+    Path("t.py").write_text(pre_annotation)
+    subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
+                    '--no-use-multiprocessing', '--no-sampling', '--only-update-annotations', '-m',
+                    't'],
+                    check=True)
+
+    post_annotation = Path("t.py").read_text()
+    assert pre_annotation == post_annotation
+
+
+# Currently, we don't handle multiple aliases of the same module.
+@pytest.mark.xfail()
+def test_overload_alias_multiple(tmp_cwd):
+    Path("t.py").write_text(textwrap.dedent("""\
+        import typing as alias1, typing as alias2
+        from typing import overload as alias3, overload as alias4
+
+        @alias1.overload
+        def foo(x: int, y: int):
+            ...
+        @alias2.overload
+        def foo(x: int, y: str):
+            ...
+        @alias3
+        def foo(x: str, y: int):
+            ...
+        @alias4
+        def foo(x: str, y: str):
+            ...
+        def foo(x, y):
+            pass
+
+        foo(1, 1)
+        foo(1, "a")
+        foo("a", 1)
+        foo("a", "a")
+    """))
+
+    subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
+                    '--no-use-multiprocessing', '--no-sampling', '--ignore-annotations', '-m', 't'],
+                    check=True)
+
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+
+    function_list = get_function_all(code, "foo")
+
+    # In our current iteration, we need to make sure that foo is annotated and
+    # that the old overloads are deleted.
+    # Since we haven't implemented overload generation, this is done with
+    # unions.
+    assert len(function_list) == 1
+    assert function_list[0].strip() == "def foo(x: int|str, y: int|str) -> None: ..."
+
+
+def test_overload_module_alias(tmp_cwd):
+    Path("t.py").write_text(textwrap.dedent("""\
+        import typing as alias
+
+        @alias.overload
+        def foo(x: str, y: int):
+            ...
+        @alias.overload
+        def foo(x: int, y: str):
+            ...
+        def foo(x, y):
+            pass
+
+        foo("1", 1)
+        foo(1, "a")
+    """))
+
+    subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
+                    '--no-use-multiprocessing', '--no-sampling', '--ignore-annotations', '-m', 't'],
+                    check=True)
+
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+
+    function_list = get_function_all(code, "foo")
+
+    # In our current iteration, we need to make sure that foo is annotated and
+    # that the old overloads are deleted.
+    # Since we haven't implemented overload generation, this is done with
+    # unions.
+    assert len(function_list) == 1
+    assert function_list[0].strip() == "def foo(x: int|str, y: int|str) -> None: ..."
+
+
+def test_overload_decorator_alias(tmp_cwd):
+    Path("t.py").write_text(textwrap.dedent("""\
+        from typing import overload as alias
+
+        @alias
+        def foo(x: str, y: int):
+            ...
+        @alias
+        def foo(x: int, y: str):
+            ...
+        def foo(x, y):
+            pass
+
+        foo("1", 1)
+        foo(1, "a")
+    """))
+
+    subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
+                    '--no-use-multiprocessing', '--no-sampling', '--ignore-annotations', '-m', 't'],
+                    check=True)
+
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+
+    function_list = get_function_all(code, "foo")
+
+    # In our current iteration, we need to make sure that foo is annotated and
+    # that the old overloads are deleted.
+    # Since we haven't implemented overload generation, this is done with
+    # unions.
+    assert len(function_list) == 1
+    assert function_list[0].strip() == "def foo(x: int|str, y: int|str) -> None: ..."
+
+
+def test_overload_module_import(tmp_cwd):
+    Path("t.py").write_text(textwrap.dedent("""\
+        import typing
+
+        @typing.overload
+        def foo(x: str, y: int):
+            ...
+        @typing.overload
+        def foo(x: int, y: str):
+            ...
+        def foo(x, y):
+            pass
+
+        foo("1", 1)
+        foo(1, "a")
+    """))
+
+    subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
+                    '--no-use-multiprocessing', '--no-sampling', '--ignore-annotations', '-m', 't'],
+                    check=True)
+
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+
+    function_list = get_function_all(code, "foo")
+
+    # In our current iteration, we need to make sure that foo is annotated and
+    # that the old overloads are deleted.
+    # Since we haven't implemented overload generation, this is done with
+    # unions.
+    assert len(function_list) == 1
+    assert function_list[0].strip() == "def foo(x: int|str, y: int|str) -> None: ..."
+
+
+def test_capture_non_inline_typevar():
+    t = textwrap.dedent("""\
+        ...
+        # comment and emptyline
+        def add(a, b):
+            return a + b
+        add(1, 2)
+        add("a", "b")
+        """)
+
+    Path("t.py").write_text(t)
+
+    subprocess.run([sys.executable, '-m', 'righttyper', '--overwrite', '--output-files',
+                    '--python-version=3.11', '--no-sampling', 't.py'], check=True)
+    output = Path("righttyper.out").read_text()
+
+    res = textwrap.dedent("""\
+        + rt_T1 = TypeVar("rt_T1", int, str)
+          # comment and emptyline
+        - def add(a, b):
+        + def add(a: rt_T1, b: rt_T1) -> rt_T1:
+        """)
+
+    assert res in output


### PR DESCRIPTION
- Fixes RightTyper's lack of `@typing.overload` handling (almost all by @maxwell3025). This does not add overloads, but only fixes RightTyper's behavior with regards to existing overloads;
- Makes `--ignore-annotations` and `--only-update-annotations` mutually exclusive;

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
