### PR TITLE
Dynamic README adjustment of URLs during packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ ignore_missing_imports = true
 [build-system]
 requires = [
     "setuptools>=61.0",
+    "tomli; python_version < '3.11'" # tomllib alternative
 ]
 build-backend = "setuptools.build_meta"
 
@@ -40,7 +41,7 @@ version = "0.1.0"
 
 [project]
 name = "righttyper"
-dynamic = ["version"]
+dynamic = ["version", "readme"]
 authors = [
   { name="Emery Berger", email="emerydb@amazon.com" },
   { name="Juan Altmayer Pizzorno", email="jpizzorno@umass.edu" },
@@ -54,7 +55,6 @@ dependencies = [
 ]
 	 
 description = "A fast runtime type hint assistant for Python code."
-readme = "README.md"
 requires-python = ">=3.12"
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -83,3 +83,7 @@ righttyper = "righttyper.righttyper:main"
 markers = [
     'dont_run_mypy'
 ]
+
+[project.urls]
+"Homepage" = "https://github.com/RightTyper/RightTyper"
+"Repository" = "https://github.com/RightTyper/RightTyper"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import setuptools
 import sys
 import os
+import re
 from pathlib import Path
 
 try:
@@ -19,7 +20,25 @@ def get_version():
     )
 
 
+def get_url():
+    return tomllib.loads(Path("pyproject.toml").read_text())['project']['urls']['Repository']
+
+
+def long_description():
+    text = Path("README.md").read_text(encoding="utf-8")
+
+    # Rewrite any relative paths to version-specific absolute paths,
+    # so that they work from within PyPI
+    sub = r'\1' + get_url() + "/blob/v" + get_version() + r'/\2'
+    text = re.sub(r'(src=")((?!https?://))', sub, text)
+    text = re.sub(r'(\[.*?\]\()((?!https?://))', sub, text)
+
+    return text
+
+
 setuptools.setup(
     packages=['righttyper'],
     version=get_version(),
+    long_description=long_description(),
+    long_description_content_type="text/markdown",
 )


### PR DESCRIPTION
Changed to adjust README dynamically during packaging, so that relative URLs can be used (and things still work in pypi).
Relative URLs are important to keeping images consistent with versions, especially as the repo is anonymized, etc.;

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
