### PR TITLE
Adds test type exclusion and mock resolution, bugfixes and other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ Options:
   --all-files                     Process any files encountered, including
                                   libraries (except for those specified in
                                   --include-files)
-  --include-files TEXT            Process only files matching the given
+  --include-files PATTERN         Process only files matching the given
                                   pattern.
-  --include-functions TEXT        Only annotate functions matching the given
+  --include-functions PATTERN     Only annotate functions matching the given
                                   pattern.
   --infer-shapes                  Produce tensor shape annotations (compatible
                                   with jaxtyping).
@@ -143,18 +143,28 @@ Options:
   --container-sample-limit INTEGER
                                   Number of container elements to sample.
                                   [default: 1000]
-  --type-depth-limit TEXT         Maximum depth (types within types) for
+  --type-depth-limit [INTEGER|none]
+                                  Maximum depth (types within types) for
                                   generic types; 'none' to disable.  [default:
                                   none]
   --python-version [3.9|3.10|3.11|3.12|3.13]
                                   Python version for which to emit
                                   annotations.  [default: 3.12]
-  --use-top-pct INTEGER RANGE     Only use the X% most common call traces.
+  --use-top-pct PCT               Only use the PCT% most common call traces.
                                   [default: 80; 1<=x<=100]
   --only-collect                  Rather than immediately process collect
                                   data, save it to righttyper.rt. You can
                                   later process using RightTyper's "process"
                                   command.
+  --exclude-types TYPE_NAME       Exclude or replace with "typing.Any" types
+                                  whose full name starts with the given
+                                  string; pass "" to clear/disable.  [default:
+                                  pytest., _pytest., py.test., test_]
+  --resolve-mocks TYPE_NAME       Attempt to resolve mock types whose full
+                                  name starts with the given string to non-
+                                  test types; pass "" to clear/disable.
+                                  [default: test_, unittest.mock.]
   --help                          Show this message and exit.
+
 ```
 

--- a/README.md
+++ b/README.md
@@ -158,13 +158,18 @@ Options:
                                   command.
   --exclude-types TYPE_NAME       Exclude or replace with "typing.Any" types
                                   whose full name starts with the given
-                                  string; pass "" to clear/disable.  [default:
-                                  pytest., _pytest., py.test., test_]
+                                  string. Can be passed multiple times.
+                                  [default: pytest., _pytest., py.test.,
+                                  test_]
+  --no-exclude-types              Do not exclude types.
   --resolve-mocks TYPE_NAME       Attempt to resolve mock types whose full
                                   name starts with the given string to non-
-                                  test types; pass "" to clear/disable.
+                                  test types. Can be passed multiple times.
                                   [default: test_, unittest.mock.]
+  --no-resolve-mocks              Do not attempt to resolve mock types.
+  --use-typing-never / --no-use-typing-never
+                                  Whether to emit typing.Never.  [default:
+                                  use-typing-never]
   --help                          Show this message and exit.
-
 ```
 

--- a/righttyper/logger.py
+++ b/righttyper/logger.py
@@ -1,0 +1,10 @@
+import logging
+
+logger = logging.getLogger(__name__.split('.')[0])
+logger.setLevel(logging.INFO)
+logger.propagate = False    # excludes other packages' messages
+
+_handler = logging.FileHandler(logger.name + '.log')
+_handler.setFormatter(logging.Formatter("[%(filename)s:%(lineno)s] %(message)s"))
+
+logger.addHandler(_handler)

--- a/righttyper/options.py
+++ b/righttyper/options.py
@@ -27,6 +27,7 @@ class Options:
     inline_generics: bool = False
     only_update_annotations: bool = False
     use_top_pct: int = 80
-    exclude_types_from: Sequence[str] = ('pytest.', 'unittest.', 'test_')
+    exclude_types_from: Sequence[str] = ('pytest.', '_pytest.', 'py.test.', 'test_')
+    resolve_mocks_from: Sequence[str] = ('pytest.', '_pytest.', 'py.test.', 'test_')
 
 options = Options()

--- a/righttyper/options.py
+++ b/righttyper/options.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Sequence
 
 @dataclass
 class Options:
@@ -26,5 +27,6 @@ class Options:
     inline_generics: bool = False
     only_update_annotations: bool = False
     use_top_pct: int = 80
+    exclude_types_from: Sequence[str] = ('pytest.', 'unittest.', 'test_')
 
 options = Options()

--- a/righttyper/options.py
+++ b/righttyper/options.py
@@ -27,7 +27,7 @@ class Options:
     inline_generics: bool = False
     only_update_annotations: bool = False
     use_top_pct: int = 80
-    exclude_types_from: Sequence[str] = ('pytest.', '_pytest.', 'py.test.', 'test_')
-    resolve_mocks_from: Sequence[str] = ('pytest.', '_pytest.', 'py.test.', 'test_')
+    exclude_types_from: Sequence[str] = ('pytest', '_pytest', 'py.test', 'test_')
+    resolve_mocks_from: Sequence[str] = ('test_',)
 
 options = Options()

--- a/righttyper/options.py
+++ b/righttyper/options.py
@@ -27,7 +27,7 @@ class Options:
     inline_generics: bool = False
     only_update_annotations: bool = False
     use_top_pct: int = 80
-    exclude_types_from: Sequence[str] = ('pytest', '_pytest', 'py.test', 'test_')
-    resolve_mocks_from: Sequence[str] = ('test_',)
+    exclude_types: tuple[str, ...] = ('pytest.', '_pytest.', 'py.test.', 'test_')
+    resolve_mocks: tuple[str, ...] = ('test_', 'unittest.mock.')
 
 options = Options()

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -1266,7 +1266,7 @@ def cli(verbose: bool):
           " You can later process using RightTyper's \"process\" command."
 )
 @click.option(
-    "--no-exclude-types-from",
+    "--no-exclude-types",
     "exclude_types_from",
     flag_value=[],
     show_default=False,
@@ -1279,7 +1279,7 @@ def cli(verbose: bool):
     help="""Prefixes for module name prefixes whose types are omitted or replaced with "typing.Any"."""
 )
 @click.option(
-    "--no-resolve-mocks-from",
+    "--no-resolve-mocks",
     "resolve_mocks_from",
     flag_value=[],
     show_default=False,

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -25,7 +25,8 @@ import typing
 from typing import (
     Any,
     TextIO,
-    Self
+    Self,
+    Sequence
 )
 
 import click
@@ -1267,7 +1268,7 @@ def cli(verbose: bool):
 @click.option(
     "--no-exclude-types-from",
     "exclude_types_from",
-    flag_value=[],  # set to empty tuple
+    flag_value=[],
     show_default=False,
     help="Clears the list of module name prefixes whose types are excluded.",
 )
@@ -1275,7 +1276,20 @@ def cli(verbose: bool):
     "--exclude-types-from",
     multiple=True,
     default=options.exclude_types_from,
-    help="""Prefixes for module names whose types are omitted or replaced with "typing.Any"."""
+    help="""Prefixes for module name prefixes whose types are omitted or replaced with "typing.Any"."""
+)
+@click.option(
+    "--no-resolve-mocks-from",
+    "resolve_mocks_from",
+    flag_value=[],
+    show_default=False,
+    help="Clears the list of module name prefixes whose types are subject to mock type resolution.",
+)
+@click.option(
+    "--resolve-mocks-from",
+    multiple=True,
+    default=options.resolve_mocks_from,
+    help="""Prefixes for module name prefixes whose types are subject to mock type resolution."""
 )
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
 def run(
@@ -1303,7 +1317,8 @@ def run(
     use_top_pct: int,
     only_collect: bool,
     type_depth_limit: int|None,
-    exclude_types_from: list[str]
+    exclude_types_from: Sequence[str],
+    resolve_mocks_from: Sequence[str]
 ) -> None:
     """Runs a given script or module, collecting type information."""
 
@@ -1365,6 +1380,7 @@ def run(
     options.use_top_pct = use_top_pct
     options.type_depth_limit = type_depth_limit
     options.exclude_types_from = exclude_types_from
+    options.resolve_mocks_from = resolve_mocks_from
 
     alarm_cls = SignalAlarm if signal_wakeup else ThreadAlarm
     alarm = alarm_cls(restart_sampling, 0.01)

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -74,7 +74,6 @@ from righttyper.typeinfo import (
 from righttyper.righttyper_utils import (
     TOOL_ID,
     TOOL_NAME,
-    debug_print_set_level,
     skip_this_file,
     source_to_module_fqn,
     get_main_module_fqn,
@@ -1105,16 +1104,16 @@ def parse_none_or_ge_zero(value) -> int|None:
     }
 )
 @click.option(
-    "--verbose",
+    "--debug",
     is_flag=True,
-    help="Print diagnostic information.",
+    help="Include diagnostic information in log file.",
 )
 @click.version_option(
     version=importlib.metadata.version(TOOL_NAME),
     prog_name=TOOL_NAME,
 )
-def cli(verbose: bool):
-    debug_print_set_level(verbose)
+def cli(debug: bool):
+    logger.setLevel(logging.DEBUG)
 
 
 def list_and_clear_callback(ctx, param, values):

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -1287,6 +1287,11 @@ def list_and_clear_callback(ctx, param, values):
     metavar="TYPE_NAME",
     help="""Attempt to resolve mock types whose full name starts with the given string to non-test types; pass "" to clear/disable."""
 )
+@click.option(
+    "--use-typing-never/--no-use-typing-never",
+    default=True,
+    help="Whether to emit typing.Never.",
+)
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
 def run(
     script: str,
@@ -1314,7 +1319,8 @@ def run(
     only_collect: bool,
     type_depth_limit: int|None,
     exclude_types: tuple[str],
-    resolve_mocks: tuple[str]
+    resolve_mocks: tuple[str],
+    use_typing_never: bool
 ) -> None:
     """Runs a given script or module, collecting type information."""
 
@@ -1371,7 +1377,7 @@ def run(
     options.container_sample_limit = container_sample_limit
     options.use_typing_union = python_version < (3, 10)
     options.use_typing_self = python_version >= (3, 11)
-    options.use_typing_never = python_version >= (3, 11)
+    options.use_typing_never = python_version >= (3, 11) and use_typing_never
     options.inline_generics = python_version >= (3, 12)
     options.use_top_pct = use_top_pct
     options.type_depth_limit = type_depth_limit

--- a/righttyper/righttyper_process.py
+++ b/righttyper/righttyper_process.py
@@ -11,7 +11,6 @@ from righttyper.righttyper_types import (
     FunctionName,
 )
 from righttyper.righttyper_utils import (
-    debug_print,
     source_to_module_fqn
 )
 from righttyper.unified_transformer import UnifiedTransformer
@@ -86,7 +85,7 @@ def process_file(
     only_update_annotations: bool = False,
     inline_generics: bool = False,
 ) -> SignatureChanges:
-    debug_print(f"process_file: {filename}")
+    logger.debug(f"process_file: {filename}")
     try:
         with open(filename, "r") as file:
             source = file.read()

--- a/righttyper/righttyper_process.py
+++ b/righttyper/righttyper_process.py
@@ -15,8 +15,7 @@ from righttyper.righttyper_utils import (
     source_to_module_fqn
 )
 from righttyper.unified_transformer import UnifiedTransformer
-
-logger = logging.getLogger("righttyper")
+from righttyper.logger import logger
 
 SignatureChanges = tuple[Filename, list[tuple[FunctionName, str, str]]]
 

--- a/righttyper/righttyper_runtime.py
+++ b/righttyper/righttyper_runtime.py
@@ -810,7 +810,6 @@ def get_value_type(
         if (ti := h(value, depth)) is not None:
             return ti
 
-    print(f"*** {t.__module__}.{t.__qualname__}")
     # Is this a spec-based mock?
     if (
         (mock_spec := inspect.getattr_static(value, "_spec_class", None))

--- a/righttyper/righttyper_types.py
+++ b/righttyper/righttyper_types.py
@@ -169,8 +169,8 @@ class TypeInfo:
 
 
 NoneTypeInfo = TypeInfo("", "None", type_obj=types.NoneType)
-UnknownTypeInfo = TypeInfo("typing", "Any")
-AnyTypeInfo = TypeInfo("typing", "Any")
+UnknownTypeInfo = TypeInfo.from_type(typing.Any)
+AnyTypeInfo = TypeInfo.from_type(typing.Any)
 
 
 @dataclass

--- a/righttyper/righttyper_types.py
+++ b/righttyper/righttyper_types.py
@@ -112,7 +112,7 @@ class TypeInfo:
             return NoneTypeInfo
 
         def expand_unions(t: "TypeInfo") -> Iterator["TypeInfo"]:
-            # don't merge unions designated as typevars, or the typevar gets lost.
+            # Don't merge unions designated as typevars, or the typevar gets lost.
             if t.type_obj is types.UnionType and not t.typevar_index:
                 for a in t.args:
                     if isinstance(a, TypeInfo):
@@ -125,7 +125,11 @@ class TypeInfo:
         if len(s) == 1:
             return next(iter(s))
 
-        # delete "Never", as it's unnecessary
+        # If "Any" is present, the union reduces to "Any"
+        if t := next((t for t in s if t.type_obj is typing.Any), None):
+            return t
+
+        # Delete "Never", as it's unnecessary
         s = {t for t in s if t.type_obj is not typing.Never}
 
         return TypeInfo(

--- a/righttyper/righttyper_types.py
+++ b/righttyper/righttyper_types.py
@@ -18,7 +18,7 @@ CodeId = NewType("CodeId", int)     # obtained from id(code) where code is-a Cod
 FrameId = NewType("FrameId", int)   # similarly from id(frame)
 
 
-@dataclass(eq=True, frozen=True)
+@dataclass(eq=True, order=True, frozen=True)
 class FuncId:
     file_name: Filename
     first_code_line: int

--- a/righttyper/righttyper_utils.py
+++ b/righttyper/righttyper_utils.py
@@ -7,13 +7,13 @@ from functools import cache
 from typing import Any, Final
 from pathlib import Path
 
+from righttyper.logger import logger
+
 
 TOOL_ID: int = 3
 TOOL_NAME: Final[str] = "righttyper"
 _SAMPLING_INTERVAL = 0.01
 _DEBUG_PRINT: bool = False
-
-logger = logging.getLogger("righttyper")
 
 
 def glob_translate_to_regex(r):

--- a/righttyper/righttyper_utils.py
+++ b/righttyper/righttyper_utils.py
@@ -13,7 +13,6 @@ from righttyper.logger import logger
 TOOL_ID: int = 3
 TOOL_NAME: Final[str] = "righttyper"
 _SAMPLING_INTERVAL = 0.01
-_DEBUG_PRINT: bool = False
 
 
 def glob_translate_to_regex(r):
@@ -47,15 +46,6 @@ def update_sampling_interval(
     ## FIXME _SAMPLING_INTERVAL *= 1.5
 
 
-def debug_print(args: Any, *varargs: Any, **kwargs: Any) -> None:
-    if _DEBUG_PRINT:
-        print(__file__, args, *varargs, **kwargs)
-
-
-def debug_print_set_level(level: bool) -> None:
-    _DEBUG_PRINT = level
-
-
 def _get_righttyper_path() -> str:
     import importlib.util
     spec = importlib.util.find_spec(__package__)
@@ -85,7 +75,7 @@ def skip_this_file(
     include_all: bool,
     include_files_pattern: str,
 ) -> bool:
-    debug_print(
+    logger.debug(
         f"checking skip_this_file: {script_dir=}, {filename=}, {include_files_pattern=}"
     )
     if include_all:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1236,7 +1236,7 @@ def test_class_name_in_test_subdir(tmp_cwd):
 def test_class_name_excluded(tmp_cwd):
     # The class name is excluded because it comes from a test_ module.
     # It shouldn't be mock resolved because it doesn't inherit from a non-test module
-    (tmp_cwd / "code.py").write_text(textwrap.dedent("""\
+    (tmp_cwd / "mycode.py").write_text(textwrap.dedent("""\
         def f(x):
             pass
 
@@ -1256,7 +1256,7 @@ def test_class_name_excluded(tmp_cwd):
     ))
 
     rt_run('-m', 'pytest', '-s', 'tests')
-    output = (tmp_cwd / "code.py").read_text()
+    output = (tmp_cwd / "mycode.py").read_text()
     code = cst.parse_module(output)
 
     assert get_function(code, 'f') == textwrap.dedent(f"""\
@@ -1265,7 +1265,7 @@ def test_class_name_excluded(tmp_cwd):
 
 
 def test_mock_class_inherited(tmp_cwd):
-    (tmp_cwd / "code.py").write_text(textwrap.dedent("""\
+    (tmp_cwd / "mycode.py").write_text(textwrap.dedent("""\
         class C:
             pass
 
@@ -1292,7 +1292,7 @@ def test_mock_class_inherited(tmp_cwd):
     ))
 
     rt_run('-m', 'pytest', '-s', 'tests')
-    output = (tmp_cwd / "code.py").read_text()
+    output = (tmp_cwd / "mycode.py").read_text()
     code = cst.parse_module(output)
 
     assert get_function(code, 'f') == textwrap.dedent(f"""\
@@ -1301,7 +1301,7 @@ def test_mock_class_inherited(tmp_cwd):
 
 
 def test_mock_with_class_spec(tmp_cwd):
-    (tmp_cwd / "code.py").write_text(textwrap.dedent("""\
+    (tmp_cwd / "mycode.py").write_text(textwrap.dedent("""\
         class C:
             pass
 
@@ -1325,7 +1325,7 @@ def test_mock_with_class_spec(tmp_cwd):
     ))
 
     rt_run('-m', 'pytest', '-s', 'tests')
-    output = (tmp_cwd / "code.py").read_text()
+    output = (tmp_cwd / "mycode.py").read_text()
     code = cst.parse_module(output)
 
     assert get_function(code, 'f') == textwrap.dedent(f"""\
@@ -1338,7 +1338,7 @@ def test_mock_with_class_spec(tmp_cwd):
 
 
 def test_mock_with_obj_spec(tmp_cwd):
-    (tmp_cwd / "code.py").write_text(textwrap.dedent("""\
+    (tmp_cwd / "mycode.py").write_text(textwrap.dedent("""\
         class C:
             pass
 
@@ -1357,7 +1357,7 @@ def test_mock_with_obj_spec(tmp_cwd):
     ))
 
     rt_run('-m', 'pytest', '-s', 'tests')
-    output = (tmp_cwd / "code.py").read_text()
+    output = (tmp_cwd / "mycode.py").read_text()
     code = cst.parse_module(output)
 
     assert get_function(code, 'f') == textwrap.dedent(f"""\

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3582,6 +3582,26 @@ def test_empty_container(python_version, opt):
         """)
 
 
+def test_empty_and_nonempty_container():
+    t = textwrap.dedent("""\
+        def f(x):
+            return len(x)
+
+        f([])
+        f([1])
+        """)
+
+    Path("t.py").write_text(t)
+
+    rt_run('--no-sampling', '--use-typing-never', f'--python-version=3.11', 't.py')
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+
+    assert get_function(code, 'f') == textwrap.dedent("""\
+        def f(x: list[int]) -> int: ...
+    """)
+
+
 def test_container_is_modified():
     t = textwrap.dedent("""\
         def f(x):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1204,7 +1204,7 @@ def test_class_name_in_test(tmp_cwd):
         """
     ))
 
-    rt_run('--exclude-types=""', '--resolve-mocks=""', '-m', 'pytest', '-s', 'tests')
+    rt_run('--no-exclude-types', '--no-resolve-mocks', '-m', 'pytest', '-s', 'tests')
     output = (tmp_cwd / "tests" / "test_foo.py").read_text()
 
     assert "def f(x: C) -> None" in output
@@ -1226,7 +1226,7 @@ def test_class_name_in_test_subdir(tmp_cwd):
         """
     ))
 
-    rt_run('--exclude-types=""', '--resolve-mocks=""', '-m', 'pytest', '-s', 'tests')
+    rt_run('--no-exclude-types', '--no-resolve-mocks', '-m', 'pytest', '-s', 'tests')
     output = (tmp_cwd / "tests" / "sub" / "test_foo.py").read_text()
 
     assert "def f(x: C) -> None" in output

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3556,7 +3556,8 @@ def test_object_with_empty_dir():
 
 
 @pytest.mark.parametrize("python_version", ["3.10", "3.11"])
-def test_empty_container(python_version):
+@pytest.mark.parametrize("opt", ['--use-typing-never', '--no-use-typing-never'])
+def test_empty_container(python_version, opt):
     t = textwrap.dedent("""\
         def f(x):
             return len(x)
@@ -3567,11 +3568,11 @@ def test_empty_container(python_version):
 
     Path("t.py").write_text(t)
 
-    rt_run('--no-sampling', f'--python-version={python_version}', 't.py')
+    rt_run('--no-sampling', opt, f'--python-version={python_version}', 't.py')
     output = Path("t.py").read_text()
     code = cst.parse_module(output)
 
-    if python_version == "3.11":
+    if python_version == "3.11" and opt == '--use-typing-never':
         assert get_function(code, 'f') == textwrap.dedent("""\
             def f(x: dict[Never, Never]|list[Never]) -> int: ...
         """)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1236,7 +1236,7 @@ def test_class_name_in_test_subdir(tmp_cwd):
 def test_class_name_excluded(tmp_cwd):
     # The class name is excluded because it comes from a test_ module.
     # It shouldn't be mock resolved because it doesn't inherit from a non-test module
-    (tmp_cwd / "mycode.py").write_text(textwrap.dedent("""\
+    (tmp_cwd / "m.py").write_text(textwrap.dedent("""\
         def f(x):
             pass
 
@@ -1245,7 +1245,7 @@ def test_class_name_excluded(tmp_cwd):
 
     (tmp_cwd / "tests").mkdir()
     (tmp_cwd / "tests" / "test_foo.py").write_text(textwrap.dedent("""\
-        from code import f
+        from m import f
 
         class C:
             pass
@@ -1256,7 +1256,7 @@ def test_class_name_excluded(tmp_cwd):
     ))
 
     rt_run('-m', 'pytest', '-s', 'tests')
-    output = (tmp_cwd / "mycode.py").read_text()
+    output = (tmp_cwd / "m.py").read_text()
     code = cst.parse_module(output)
 
     assert get_function(code, 'f') == textwrap.dedent(f"""\
@@ -1265,7 +1265,7 @@ def test_class_name_excluded(tmp_cwd):
 
 
 def test_mock_class_inherited(tmp_cwd):
-    (tmp_cwd / "mycode.py").write_text(textwrap.dedent("""\
+    (tmp_cwd / "m.py").write_text(textwrap.dedent("""\
         class C:
             pass
 
@@ -1278,21 +1278,21 @@ def test_mock_class_inherited(tmp_cwd):
 
     (tmp_cwd / "tests").mkdir()
     (tmp_cwd / "tests" / "test_foo.py").write_text(textwrap.dedent("""\
-        import code
+        import m
 
-        class Mock(code.C):
+        class Mock(m.C):
             pass
 
         class Mock2(Mock):
             pass
 
         def test_foo():
-            code.f(Mock2())
+            m.f(Mock2())
         """
     ))
 
     rt_run('-m', 'pytest', '-s', 'tests')
-    output = (tmp_cwd / "mycode.py").read_text()
+    output = (tmp_cwd / "m.py").read_text()
     code = cst.parse_module(output)
 
     assert get_function(code, 'f') == textwrap.dedent(f"""\
@@ -1301,7 +1301,7 @@ def test_mock_class_inherited(tmp_cwd):
 
 
 def test_mock_with_class_spec(tmp_cwd):
-    (tmp_cwd / "mycode.py").write_text(textwrap.dedent("""\
+    (tmp_cwd / "m.py").write_text(textwrap.dedent("""\
         class C:
             pass
 
@@ -1313,19 +1313,19 @@ def test_mock_with_class_spec(tmp_cwd):
 
     (tmp_cwd / "tests").mkdir()
     (tmp_cwd / "tests" / "test_foo.py").write_text(textwrap.dedent("""\
-        import code
+        import m
         import unittest.mock as mock
 
         def test_foo():
-            code.f(mock.Mock(spec=code.C))
+            m.f(mock.Mock(spec=m.C))
 
         def test_bar():
-            code.g(mock.create_autospec(code.C))
+            m.g(mock.create_autospec(m.C))
         """
     ))
 
     rt_run('-m', 'pytest', '-s', 'tests')
-    output = (tmp_cwd / "mycode.py").read_text()
+    output = (tmp_cwd / "m.py").read_text()
     code = cst.parse_module(output)
 
     assert get_function(code, 'f') == textwrap.dedent(f"""\
@@ -1338,7 +1338,7 @@ def test_mock_with_class_spec(tmp_cwd):
 
 
 def test_mock_with_obj_spec(tmp_cwd):
-    (tmp_cwd / "mycode.py").write_text(textwrap.dedent("""\
+    (tmp_cwd / "m.py").write_text(textwrap.dedent("""\
         class C:
             pass
 
@@ -1348,16 +1348,16 @@ def test_mock_with_obj_spec(tmp_cwd):
 
     (tmp_cwd / "tests").mkdir()
     (tmp_cwd / "tests" / "test_foo.py").write_text(textwrap.dedent("""\
-        import code
+        import m
         import unittest.mock as mock
 
         def test_foo():
-            code.f(mock.Mock(spec=code.C()))
+            m.f(mock.Mock(spec=m.C()))
         """
     ))
 
     rt_run('-m', 'pytest', '-s', 'tests')
-    output = (tmp_cwd / "mycode.py").read_text()
+    output = (tmp_cwd / "m.py").read_text()
     code = cst.parse_module(output)
 
     assert get_function(code, 'f') == textwrap.dedent(f"""\

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1204,7 +1204,7 @@ def test_class_name_in_test(tmp_cwd):
         """
     ))
 
-    rt_run('--no-exclude-types-from', '--no-resolve-mocks-from', '-m', 'pytest', '-s', 'tests')
+    rt_run('--exclude-types=""', '--resolve-mocks=""', '-m', 'pytest', '-s', 'tests')
     output = (tmp_cwd / "tests" / "test_foo.py").read_text()
 
     assert "def f(x: C) -> None" in output
@@ -1226,7 +1226,7 @@ def test_class_name_in_test_subdir(tmp_cwd):
         """
     ))
 
-    rt_run('--no-exclude-types-from', '--no-resolve-mocks-from', '-m', 'pytest', '-s', 'tests')
+    rt_run('--exclude-types=""', '--resolve-mocks=""', '-m', 'pytest', '-s', 'tests')
     output = (tmp_cwd / "tests" / "sub" / "test_foo.py").read_text()
 
     assert "def f(x: C) -> None" in output

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1260,7 +1260,7 @@ def test_class_name_excluded(tmp_cwd):
     code = cst.parse_module(output)
 
     assert get_function(code, 'f') == textwrap.dedent(f"""\
-        def f(x: Any) -> None: ...
+        def f(x) -> None: ...
     """)
 
 

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -34,7 +34,9 @@ class IterableClass(abc.Iterable):
 class MyGeneric[A, B](dict): pass
 
 
-def test_get_value_type():
+def test_get_value_type(monkeypatch):
+    monkeypatch.setattr(options.options, 'resolve_mocks_from', [])
+
     assert NoneTypeInfo is rt_get_value_type(None)
 
     assert "bool" == get_value_type(True)
@@ -224,7 +226,9 @@ def test_non_array_with_dtype():
 class NamedTupleClass:
     P = namedtuple('P', [])
 
-def test_get_value_type_namedtuple_nonlocal():
+def test_get_value_type_namedtuple_nonlocal(monkeypatch):
+    monkeypatch.setattr(options.options, 'resolve_mocks_from', [])
+
     # namedtuple's __qualname__ also doesn't contain the enclosing class name...
     assert f"{__name__}.NamedTupleClass.P" == get_value_type(NamedTupleClass.P())
 
@@ -234,7 +238,9 @@ class Decision(Enum):
     MAYBE = 1
     YES = 2
 
-def test_get_value_type_enum():
+def test_get_value_type_enum(monkeypatch):
+    monkeypatch.setattr(options.options, 'resolve_mocks_from', [])
+
     assert f"{__name__}.Decision" == get_value_type(Decision.MAYBE)
 
 
@@ -403,7 +409,9 @@ def test_merged_types_generics():
     ))
 
 
-def test_merged_types_superclass():
+def test_merged_types_superclass(monkeypatch):
+    monkeypatch.setattr(options.options, 'resolve_mocks_from', [])
+
     class A: pass
     class B(A): pass
     class C(B): pass
@@ -454,7 +462,9 @@ def name(t: type):
     return f"{t.__module__}.{t.__qualname__}"
 
 
-def test_merged_types_superclass_checks_attributes():
+def test_merged_types_superclass_checks_attributes(monkeypatch):
+    monkeypatch.setattr(options.options, 'resolve_mocks_from', [])
+
     class A: pass
     class B(A):
         def foo(self): pass
@@ -480,7 +490,9 @@ def test_merged_types_superclass_checks_attributes():
     ))
 
 
-def test_merged_types_superclass_dunder_matters():
+def test_merged_types_superclass_dunder_matters(monkeypatch):
+    monkeypatch.setattr(options.options, 'resolve_mocks_from', [])
+
     class A: pass
     class B(A):
         pass
@@ -505,7 +517,9 @@ def test_merged_types_superclass_bare_type():
     ))
 
 
-def test_merged_types_superclass_multiple_superclasses():
+def test_merged_types_superclass_multiple_superclasses(monkeypatch):
+    monkeypatch.setattr(options.options, 'resolve_mocks_from', [])
+
     class A: pass
     class B(A):
         def foo(self): pass

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -659,6 +659,17 @@ def test_from_set_with_never():
     )
 
 
+def test_from_set_with_any():
+    t = TypeInfo.from_set({
+            TypeInfo.from_type(Any),
+            TypeInfo.from_type(int, module=''),
+            TypeInfo.from_type(str, module='')
+        })
+
+    assert t.fullname() == "typing.Any"
+    assert t.args == ()
+
+
 def test_uniontype():
     assert "int|str" == str(union_ti(int_ti, str_ti))
     assert "types.UnionType" == str(union_ti())

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -35,7 +35,7 @@ class MyGeneric[A, B](dict): pass
 
 
 def test_get_value_type(monkeypatch):
-    monkeypatch.setattr(options.options, 'resolve_mocks_from', [])
+    monkeypatch.setattr(options.options, 'resolve_mocks', ())
 
     assert NoneTypeInfo is rt_get_value_type(None)
 
@@ -227,7 +227,7 @@ class NamedTupleClass:
     P = namedtuple('P', [])
 
 def test_get_value_type_namedtuple_nonlocal(monkeypatch):
-    monkeypatch.setattr(options.options, 'resolve_mocks_from', [])
+    monkeypatch.setattr(options.options, 'resolve_mocks', ())
 
     # namedtuple's __qualname__ also doesn't contain the enclosing class name...
     assert f"{__name__}.NamedTupleClass.P" == get_value_type(NamedTupleClass.P())
@@ -239,7 +239,7 @@ class Decision(Enum):
     YES = 2
 
 def test_get_value_type_enum(monkeypatch):
-    monkeypatch.setattr(options.options, 'resolve_mocks_from', [])
+    monkeypatch.setattr(options.options, 'resolve_mocks', ())
 
     assert f"{__name__}.Decision" == get_value_type(Decision.MAYBE)
 
@@ -410,7 +410,7 @@ def test_merged_types_generics():
 
 
 def test_merged_types_superclass(monkeypatch):
-    monkeypatch.setattr(options.options, 'resolve_mocks_from', [])
+    monkeypatch.setattr(options.options, 'resolve_mocks', ())
 
     class A: pass
     class B(A): pass
@@ -463,7 +463,7 @@ def name(t: type):
 
 
 def test_merged_types_superclass_checks_attributes(monkeypatch):
-    monkeypatch.setattr(options.options, 'resolve_mocks_from', [])
+    monkeypatch.setattr(options.options, 'resolve_mocks', ())
 
     class A: pass
     class B(A):
@@ -491,7 +491,7 @@ def test_merged_types_superclass_checks_attributes(monkeypatch):
 
 
 def test_merged_types_superclass_dunder_matters(monkeypatch):
-    monkeypatch.setattr(options.options, 'resolve_mocks_from', [])
+    monkeypatch.setattr(options.options, 'resolve_mocks', ())
 
     class A: pass
     class B(A):
@@ -518,7 +518,7 @@ def test_merged_types_superclass_bare_type():
 
 
 def test_merged_types_superclass_multiple_superclasses(monkeypatch):
-    monkeypatch.setattr(options.options, 'resolve_mocks_from', [])
+    monkeypatch.setattr(options.options, 'resolve_mocks', ())
 
     class A: pass
     class B(A):


### PR DESCRIPTION
This adds or changes the following flags:
- `--exclude-types`, enabled with a list by default,
- `--no-exclude-types`, to disable it,
- `--resolve-mocks`, enabled with a list by default,
- `--no-resolve-mocks`, to disable it,
- `--use-typing-never/--no-use-typing-never` (default: use it),
- `--debug` replaces `--verbose`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
