### PR TITLE
Structural Self detection; remove is_self flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ righttyper.egg-info/
 venv
 righttyper.log
 *.swp
+.mypy_tests_cache*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ classifiers = [
 tests = [
     "pytest",
     "pytest-antilru",
+    "pytest-xdist",
     "mypy",
     "numpy",
     "ml_dtypes",
@@ -85,6 +86,7 @@ shapes = [
 righttyper = "righttyper.righttyper:main"
 
 [tool.pytest.ini_options]
+addopts = "-n auto"
 markers = [
     'dont_run_mypy',
     'mypy_args'

--- a/righttyper/annotation.py
+++ b/righttyper/annotation.py
@@ -10,6 +10,10 @@ class FuncAnnotation:
     varargs: str|None
     kwargs: str|None
     variables: dict[VariableName, TypeInfo]
+    # The defining class of the method, if this annotation is for a method.
+    # Used to substitute typing.Self when copying types across annotations
+    # (cf. clone() and _widen_annotation in observations.py).
+    self_class: TypeInfo | None = None
 
 
 @dataclass(eq=True)

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -33,7 +33,6 @@ def is_homogeneous(types: tuple[TypeInfo, ...] | list[TypeInfo]) -> bool:
             t.module == first.module and
             t.name == first.name and
             t.code_id == first.code_id and
-            t.is_self == first.is_self and
             len(t.args) == len(first.args) and
             all((a is Ellipsis) == (first.args[i] is Ellipsis) for i, a in enumerate(t.args)) and
             # ListTypeInfo args (e.g. Callable param lists) must have the same arity

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -294,11 +294,12 @@ def simplify(typeinfoset: set[TypeInfo]) -> set[TypeInfo]:
             if not any(bc.type_obj is t.type_obj for bc in incomplete_types)
         )
 
-    # Types we support merging
+    # Types we support merging — anything with an __mro__ to walk.
+    # Includes classes whose metaclass is a `type` subclass (e.g., ABCMeta).
     mergeable_types = set(
         t
         for t in simplifiable_types
-        if type(t.type_obj) is type     # we need a type_obj with __mro__ for merging
+        if hasattr(t.type_obj, "__mro__")
     )
 
     other_types |= (simplifiable_types - mergeable_types)

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -14,6 +14,39 @@ from righttyper.options import output_options
 _COVARIANT_TYPES = (tuple, frozenset)
 
 
+def is_homogeneous(types: tuple[TypeInfo, ...] | list[TypeInfo]) -> bool:
+    """Whether the tuple only contains instances of a single, consistent generic type
+       whose arguments are all either TypeInfo or ellipsis.
+    """
+    if not types:
+        return False
+
+    first = types[0]
+
+    return (
+        all(
+            isinstance(t, TypeInfo) and
+            all(isinstance(a, (TypeInfo, EllipsisType)) for a in t.args)
+            for t in types
+        )
+        and all(
+            t.module == first.module and
+            t.name == first.name and
+            t.code_id == first.code_id and
+            t.is_self == first.is_self and
+            len(t.args) == len(first.args) and
+            all((a is Ellipsis) == (first.args[i] is Ellipsis) for i, a in enumerate(t.args)) and
+            # ListTypeInfo args (e.g. Callable param lists) must have the same arity
+            all(
+                len(cast(TypeInfo, t.args[i]).args) == len(cast(TypeInfo, first.args[i]).args)
+                for i in range(len(first.args))
+                if isinstance(first.args[i], ListTypeInfo)
+            )
+            for t in list(types)[1:]
+        )
+    )
+
+
 def merge_similar_generics(typeinfoset: set[TypeInfo]) -> set[TypeInfo]:
     """Merge generics with same container but different type args.
 
@@ -441,38 +474,6 @@ def generalize(samples: Sequence[CallTrace]) -> list[TypeInfo]|None:
     # By transposing the per-argument types, we obtain tuples with all the
     # various types seen for each argument.
     transposed = list(zip(*samples))
-
-    def is_homogeneous(types: tuple[TypeInfo, ...]) -> bool:
-        """Whether the tuple only contains instances of a single, consistent generic type
-           whose arguments are all either TypeInfo or ellipsis.
-        """
-        if not types:
-            return False
-
-        first = types[0]
-
-        return (
-            all(
-                isinstance(t, TypeInfo) and
-                all(isinstance(a, (TypeInfo, EllipsisType)) for a in t.args)
-                for t in types
-            )
-            and all(
-                t.module == first.module and
-                t.name == first.name and
-                t.code_id == first.code_id and
-                t.is_self == first.is_self and
-                len(t.args) == len(first.args) and
-                all((a is Ellipsis) == (first.args[i] is Ellipsis) for i, a in enumerate(t.args)) and
-                # ListTypeInfo args (e.g. Callable param lists) must have the same arity
-                all(
-                    len(cast(TypeInfo, t.args[i]).args) == len(cast(TypeInfo, first.args[i]).args)
-                    for i in range(len(first.args))
-                    if isinstance(first.args[i], ListTypeInfo)
-                )
-                for t in types[1:]
-            )
-        )
 
     # Count the number of times a type usage pattern occurs, as we only want to generalize
     # if one occurs more than once (in more than one argument).

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -805,6 +805,14 @@ class Observations:
                     for var_types in func_info.variables.values():
                         for t in var_types:
                             walk(t)
+                    for arg in func_info.args:
+                        if arg.default is not None:
+                            walk(arg.default)
+                    for override in func_info.overrides:
+                        if override.inline_arg_types:
+                            for it in override.inline_arg_types:
+                                if it is not None:
+                                    walk(it)
                     result.append(code_id)
 
         for code_id in self.func_info.keys():

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -11,9 +11,7 @@ from righttyper.options import output_options
 from righttyper.logger import logger
 from righttyper.generalize import merged_types, generalize, is_homogeneous
 from righttyper.type_transformers import (
-    ClearCodeIdT,
     UnionSizeT,
-    SelfT,
     NeverSayNeverT,
     NoReturnToNeverT,
     ExcludeTestTypesT,
@@ -23,7 +21,7 @@ from righttyper.type_transformers import (
     MakePickleableT,
     LoadTypeObjT
 )
-from righttyper.typeinfo import TypeInfo, TypeInfoArg, NoneTypeInfo, UnknownTypeInfo, CallTrace
+from righttyper.typeinfo import TypeInfo, TypeInfoArg, NoneTypeInfo, UnknownTypeInfo, UnionTypeInfo, CallTrace
 from righttyper.righttyper_types import ArgumentName, VariableName, Filename, CodeId
 from righttyper.annotation import FuncAnnotation, ModuleVars, TraceDistribution
 from righttyper.type_id import PostponedArg0, get_type_name
@@ -119,6 +117,11 @@ class FuncInfo:
 
     def transform_types(self, tr: TypeInfo.Transformer) -> None:
         """Applies the 'tr' transformer to all TypeInfo objects in this object."""
+        if self.defining_class is not None:
+            new_dc = tr.visit(self.defining_class)
+            if new_dc is not self.defining_class:
+                self.defining_class = new_dc
+
         args_prime = tuple(
             ArgInfo(
                 arg.arg_name,
@@ -162,9 +165,14 @@ class FuncInfo:
 
 
         for trace, count in list(self.traces.items()):
-            trace_prime = tuple(tr.visit(t) for t in trace)
+            old_fac = getattr(trace, 'first_arg_class', None)
+            new_fac = tr.visit(old_fac) if old_fac is not None else None
+            trace_prime = CallTrace(
+                [tr.visit(t) for t in trace],
+                first_arg_class=new_fac,
+            )
             # Use identity rather than ==, as only non-essential attributes may have changed
-            if any(old is not new for old, new in zip(trace, trace_prime)):
+            if any(old is not new for old, new in zip(trace, trace_prime)) or old_fac is not new_fac:
                 if logger.level == logging.DEBUG:
                     logger.debug(
                         type(tr).__name__ + " " + self.code_id.func_name +
@@ -225,6 +233,116 @@ def _stamp_self(
         per_trace[trace_idx].replace(args=tuple(new_args_per_trace[trace_idx]))
         for trace_idx in range(len(per_trace))
     ]
+
+
+def _clone_for_context(node: TypeInfo,
+                       source_self_class: TypeInfo | None = None,
+                       dest_self_class: TypeInfo | None = None) -> TypeInfo:
+    """Clone a TypeInfo subtree for use in a different annotation context.
+
+    Substitutes `typing.Self` with the source annotation's concrete `self_class`
+    (if provided), since Self's meaning is local to its source annotation.
+
+    If `dest_self_class` is set AND the source either has no self_class
+    (anonymous, e.g., a lambda) or shares the destination's self_class, also
+    stamp `typing.Self` on leaf nodes whose TypeInfo equals `dest_self_class`.
+    This recovers Self when ResolvingT injects concrete types that align with
+    the destination's receiver — e.g., a lambda capturing self pulled into a
+    method's retval.
+
+    Also clears the legacy is_self=True flag (pending removal of the field).
+    """
+    can_restamp = dest_self_class is not None and (
+        source_self_class is None or source_self_class == dest_self_class
+    )
+    class T(TypeInfo.Transformer):
+        def visit(vself, n: TypeInfo) -> TypeInfo:
+            if (n.type_obj is typing.Self
+                    and source_self_class is not None):
+                return source_self_class
+            if can_restamp and not n.args and n == dest_self_class:
+                return TypeInfo.from_type(typing.Self)
+            return super().visit(n.replace(is_self=False))
+    return T().visit(node)
+
+
+class ResolvingT(TypeInfo.Transformer):
+    """Resolves TypeInfo nodes that carry a `code_id` by substituting the
+    referenced annotation's signature. Also unwraps `PostponedArg0`.
+
+    Used at mk_annotation time (per-trace, with annotations built so far) and
+    at collect_annotations time (over each annotation's args/retval). Cross-
+    annotation `Self` semantics flow through `_clone_for_context` using the
+    source annotation's `self_class` and the destination's `self_class`.
+    """
+    def __init__(self,
+                 annotations: dict["CodeId", "FuncAnnotation"],
+                 func_info: dict["CodeId", "FuncInfo"],
+                 dest_self_class: TypeInfo | None = None):
+        self.annotations = annotations
+        self.func_info = func_info
+        self.dest_self_class = dest_self_class
+
+    def visit(self, node: TypeInfo) -> TypeInfo:
+        pre = node
+        node = super().visit(node)
+
+        if node.code_id and (ann := self.annotations.get(node.code_id)):
+            cl = lambda t: _clone_for_context(t, ann.self_class, self.dest_self_class)
+            if node.type_obj in (abc.Callable, typing.Callable):
+                old_params = (
+                    node.args[0].args
+                    if node.args and isinstance(node.args[0], TypeInfo) and node.args[0].is_list()
+                    else ()
+                )
+                old_retval = node.args[-1] if node.args else UnknownTypeInfo
+
+                def get_old_param(i: int) -> TypeInfoArg:
+                    return old_params[i] if i < len(old_params) else UnknownTypeInfo
+
+                def is_unknown(t: TypeInfoArg) -> bool:
+                    return isinstance(t, TypeInfo) and t.is_unknown
+
+                # FIXME skip 'self'/'cls' by name rather than assuming it's first
+                ann_arg_types = list(ann.args.values())
+                if node.is_bound:
+                    ann_arg_types = ann_arg_types[1:]
+
+                fi = self.func_info.get(node.code_id)
+                use_ann_args = fi is not None and not (
+                    ann.varargs or ann.kwargs
+                    or any(a.default is not None for a in fi.args)
+                )
+                node = node.replace(args=(
+                    TypeInfo.list([
+                        old if not is_unknown(old := get_old_param(i)) else cl(t)
+                        for i, t in enumerate(ann_arg_types)
+                    ]) if use_ann_args else ...,
+                    old_retval if not is_unknown(old_retval) else cl(ann.retval)
+                ))
+            else:
+                node = cl(ann.retval)
+
+        if node.type_obj is PostponedArg0:
+            # e.g. PostponedArg0[Iterator[X]] -> X
+            node = (
+                node.args[0].args[0]
+                if node.args
+                    and isinstance(node.args[0], TypeInfo)
+                    and node.args[0].args
+                    and isinstance(node.args[0].args[0], TypeInfo)
+                else UnknownTypeInfo
+            )
+
+        # Clear code_id once resolved — same job ClearCodeIdT used to do.
+        # Folding it here saves a second tree walk and lets union members
+        # that became equal after clearing dedup in one place.
+        if node.code_id:
+            node = node.replace(code_id=None)
+        if pre is not node and isinstance(node, UnionTypeInfo):
+            node = TypeInfo.from_set(set(node.args), typevar_index=node.typevar_index)
+
+        return node
 
 
 class NormalizeSubtypeT(TypeInfo.Transformer):
@@ -414,24 +532,45 @@ class Observations:
         ) -> None:
             """Widen target's types from sources, mutating target in place.
 
-            merge_args/merge_retval control which parts are widened.
+            merge_args/merge_retval control which parts are widened. Source
+            types are cloned with their own self_class (substituting typing.Self
+            to the concrete class) so cross-class merges are Liskov-correct.
+            After merging, re-stamp typing.Self at positions whose merged value
+            matches target.self_class — recovering Self for nested positions
+            like Callable[[], Self] or parent-retval-from-children's-Self.
             """
             matching = [s for s in sources if len(s.args) == len(target.args)]
             if not matching:
                 return
 
+            def _restamp(merged: TypeInfo) -> TypeInfo:
+                if target.self_class is None:
+                    return merged
+                result = _stamp_self([merged], [target.self_class])
+                return result if isinstance(result, TypeInfo) else result[0]
+
             if merge_args:
                 for i, name in enumerate(target.args):
-                    types: set[TypeInfo] = {list(s.args.values())[i] for s in matching}
+                    # Skip arg0 (self/cls) for methods: the receiver type is
+                    # always exactly target.self_class (or Self), not subject
+                    # to Liskov widening from parent classes.
+                    if i == 0 and target.self_class is not None:
+                        continue
+                    types: set[TypeInfo] = {
+                        _clone_for_context(list(s.args.values())[i], s.self_class)
+                        for s in matching
+                    }
                     if not target.args[name].is_unknown:
-                        types.add(target.args[name])
-                    target.args[name] = merged_types(types)
+                        types.add(_clone_for_context(target.args[name], target.self_class))
+                    target.args[name] = _restamp(merged_types(types))
 
             if merge_retval:
-                ret_types: set[TypeInfo] = {s.retval for s in matching}
+                ret_types: set[TypeInfo] = {
+                    _clone_for_context(s.retval, s.self_class) for s in matching
+                }
                 if not target.retval.is_unknown:
-                    ret_types.add(target.retval)
-                target.retval = merged_types(ret_types)
+                    ret_types.add(_clone_for_context(target.retval, target.self_class))
+                target.retval = _restamp(merged_types(ret_types))
 
         # Phase 2: Upward — propagate children's types to parents.
         for parent_id, child_ids in parent_to_children.items():
@@ -454,11 +593,21 @@ class Observations:
                 merge_args, merge_retval = False, True   # observed concrete
 
             if parent_id not in raw_annotations:
+                # For methods, arg0 (self/cls) is always Self in its own
+                # context — initialize it directly. Widening skips arg0 for
+                # methods, so this is the only place it gets set.
+                _self_ti = TypeInfo.from_type(typing.Self)
+                args = {
+                    a.arg_name: (_self_ti if i == 0 and parent_fi.defining_class is not None
+                                 else UnknownTypeInfo)
+                    for i, a in enumerate(parent_fi.args)
+                }
                 raw_annotations[parent_id] = FuncAnnotation(
-                    args={a.arg_name: UnknownTypeInfo for a in parent_fi.args},
+                    args=args,
                     retval=UnknownTypeInfo,
                     varargs=parent_fi.varargs, kwargs=parent_fi.kwargs,
                     variables={},
+                    self_class=parent_fi.defining_class,
                 )
 
             _widen_annotation(
@@ -478,10 +627,32 @@ class Observations:
 
 
     @staticmethod
-    def mk_annotation(func_info: FuncInfo) -> FuncAnnotation|None:
+    def mk_annotation(func_info: FuncInfo,
+                      annotations: dict[CodeId, FuncAnnotation] | None = None,
+                      func_info_map: dict[CodeId, FuncInfo] | None = None,
+                      ) -> FuncAnnotation|None:
         traces = func_info.most_common_traces()
         if not traces:
             return None
+
+        # Resolve code_id references in traces using already-built annotations.
+        # Topo sort guarantees dependencies are built first, so by the time we
+        # process this trace, any nested Callable/Generator code_ids it contains
+        # have ready annotations. This lets the Self detection below recurse
+        # into resolved types (e.g., a lambda's retval that matches self_class).
+        if annotations:
+            resolver = ResolvingT(
+                annotations,
+                func_info_map or {},
+                dest_self_class=func_info.defining_class,
+            )
+            traces = [
+                CallTrace(
+                    [resolver.visit(t) for t in trace],
+                    first_arg_class=trace.first_arg_class,
+                )
+                for trace in traces
+            ]
 
         # Self detection: if this is a method, structurally stamp typing.Self
         # at positions where the per-trace receiver class matches across all
@@ -527,7 +698,10 @@ class Observations:
                 for m in modified
             ]
 
-            traces = [tuple(m) for m in modified]
+            traces = [
+                CallTrace(m, first_arg_class=t.first_arg_class)
+                for m, t in zip(modified, traces)
+            ]
 
         if (signature := generalize(traces)) is None:
             logger.info(f"Unable to generalize {func_info.code_id}: inconsistent traces.\n" +
@@ -598,23 +772,17 @@ class Observations:
     def collect_annotations(self) -> tuple[dict[CodeId, FuncAnnotation], dict[Filename, ModuleVars], dict[CodeId, list[TraceDistribution]]]:
         """Collects function type annotations from the observed types."""
 
-        # In the code below, clone (rather than link to) types from Callable, Generator, etc.,
-        # clearing is_self, as it may not apply in the new context.
-        def clone(node: TypeInfo) -> TypeInfo:
-            class T(TypeInfo.Transformer):
-                """Clones the given TypeInfo tree, clearing 'is_self',
-                   as the type information may not be equivalent in the new context.
-                """
-                def visit(vself, node: TypeInfo) -> TypeInfo:
-                    return super().visit(node.replace(is_self=False))
+        clone = _clone_for_context
 
-            return T().visit(node)
-
-        annotations: dict[CodeId, FuncAnnotation] = {
-            code_id: annotation
-            for code_id in self.code_id_topo_sort()
-            if (annotation := Observations.mk_annotation(self.func_info[code_id])) is not None
-        }
+        annotations: dict[CodeId, FuncAnnotation] = {}
+        for code_id in self.code_id_topo_sort():
+            annotation = Observations.mk_annotation(
+                self.func_info[code_id],
+                annotations=annotations,
+                func_info_map=self.func_info,
+            )
+            if annotation is not None:
+                annotations[code_id] = annotation
 
         # Merge module variables into ModuleVars (parallel to annotations for functions).
         module_vars: dict[Filename, ModuleVars] = {
@@ -655,77 +823,17 @@ class Observations:
                 _visit_dict(mv.variables, tr, tr_name, f"{module} ")
 
 
-        class ResolvingT(TypeInfo.Transformer):
-            """Resolves types that may not be fully known until observed at runtime."""
-
-            def visit(vself, node: TypeInfo) -> TypeInfo:
-                node = super().visit(node)
-
-                if node.code_id and (ann := annotations.get(node.code_id)):
-                    # for Callable, we also merge arguments from annotations with observed ones.
-                    if node.type_obj in (abc.Callable, typing.Callable):
-                        old_params = (
-                            node.args[0].args
-                            if node.args and isinstance(node.args[0], TypeInfo) and node.args[0].is_list()
-                            else ()
-                        )
-
-                        old_retval = node.args[-1] if node.args else UnknownTypeInfo
-
-                        def get_old_param(i: int) -> TypeInfoArg:
-                            return old_params[i] if i < len(old_params) else UnknownTypeInfo
-
-                        def is_unknown(t: TypeInfoArg) -> bool:
-                            return isinstance(t, TypeInfo) and t.is_unknown
-
-                        # FIXME skip 'self'/'cls' by name rather than assuming it's first
-                        ann_arg_types = list(ann.args.values())
-                        if node.is_bound:
-                            ann_arg_types = ann_arg_types[1:]
-
-                        node = node.replace(args=(
-                            TypeInfo.list([
-                                old if not is_unknown(old := get_old_param(i)) else clone(t)
-                                for i, t in enumerate(ann_arg_types)
-                            ])
-                            if not (ann.varargs or ann.kwargs
-                                   or any(a.default is not None
-                                          for a in self.func_info[node.code_id].args))
-                            else
-                            ...,
-                            old_retval if not is_unknown(old_retval) else clone(ann.retval)
-                        ))
-                    else:
-                        node = clone(ann.retval)
-
-                if node.type_obj is PostponedArg0:
-                    # e.g. PostponedArg0[Iterator[X]] -> X
-                    node = (
-                        node.args[0].args[0]
-                        if node.args
-                            and isinstance(node.args[0], TypeInfo)
-                            and node.args[0].args
-                            and isinstance(node.args[0].args[0], TypeInfo)
-                        else UnknownTypeInfo
-                    )
-
-                return node
-
-        transform_types(ResolvingT())
-
-        # Clear code_id after resolution — it was only needed to look up
-        # the function's observations and should not affect type equality.
-        # This also deduplicates unions whose members became equal after clearing.
-        transform_types(ClearCodeIdT())
-
+        # Resolution may already have run per-trace inside mk_annotation (since
+        # topo sort orders dependencies first), but run a final pass to catch
+        # any code_ids that survived (e.g., variable types that didn't go through
+        # mk_annotation, or cycles).
+        transform_types(ResolvingT(annotations, self.func_info))
 
         # Compute type distributions from traces, resolving code_id references
         # so that Callable/generator types render with their actual signatures.
         type_distributions: dict[CodeId, list[TraceDistribution]] = {}
         if output_options.type_distribution_comments:
-            resolving = ResolvingT()
-            clearing = ClearCodeIdT()
-            resolve = lambda t: clearing.visit(resolving.visit(t))
+            resolve = ResolvingT(annotations, self.func_info).visit
             for func_info in self.func_info.values():
                 if func_info.code_id not in self.wrapper_code_ids:
                     if (dist := func_info.compute_type_distributions(resolve)):

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -254,6 +254,12 @@ def _clone_for_context(node: TypeInfo,
     # source has no self_class, or when source.self_class is the same as or a
     # subclass of dest.self_class — i.e., dest's Self is at least as wide as
     # source's Self in their respective contexts.
+    #
+    # The subclass branch needs live `type_obj` to walk MRO via issubclass.
+    # For `.rt` files where type_obj reloads as None (e.g., classes from
+    # __main__ or unimportable modules), this branch silently fails and the
+    # Self in source gets substituted to source's concrete class. The
+    # annotation is still correct, just less precise (concrete instead of Self).
     keep_self = (
         source_self_class is None
         or (dest_self_class is not None and source_self_class == dest_self_class)
@@ -547,22 +553,26 @@ class Observations:
         ) -> None:
             """Widen target's types from sources, mutating target in place.
 
-            merge_args/merge_retval control which parts are widened. Source
-            types are cloned with their own self_class (substituting typing.Self
-            to the concrete class) so cross-class merges are Liskov-correct.
-            After merging, re-stamp typing.Self at positions whose merged value
-            matches target.self_class — recovering Self for nested positions
-            like Callable[[], Self] or parent-retval-from-children's-Self.
+            Self-handling for cross-class merges:
+
+            - **Source types are cloned** via `_clone_for_context(t,
+              source.self_class, target.self_class)`. Inside clone, `typing.Self`
+              is substituted to source's concrete class UNLESS source's
+              self_class is the same as or a subclass of target's (parent's
+              Self is at least as wide as child's, so it stays as Self).
+
+            - **Target's own types are added as-is** (no clone) — they're
+              already in destination's context.
+
+            arg0 (self/cls) is skipped only when target's arg0 is already
+            non-Unknown — receiver type is fixed by target.self_class. When
+            target's arg0 is Unknown (synthetic parent with no traces),
+            widening fills it in from children; the keep_self rule in clone
+            preserves Self from children's arg0.
             """
             matching = [s for s in sources if len(s.args) == len(target.args)]
             if not matching:
                 return
-
-            def _restamp(merged: TypeInfo) -> TypeInfo:
-                if target.self_class is None:
-                    return merged
-                result = _stamp_self([merged], [target.self_class])
-                return result if isinstance(result, TypeInfo) else result[0]
 
             if merge_args:
                 for i, name in enumerate(target.args):
@@ -584,7 +594,7 @@ class Observations:
                         # target's own type is already in the destination context;
                         # add it directly without cloning (no substitution, no restamp).
                         types.add(target.args[name])
-                    target.args[name] = _restamp(merged_types(types))
+                    target.args[name] = merged_types(types)
 
             if merge_retval:
                 ret_types: set[TypeInfo] = {
@@ -593,7 +603,7 @@ class Observations:
                 }
                 if not target.retval.is_unknown:
                     ret_types.add(target.retval)
-                target.retval = _restamp(merged_types(ret_types))
+                target.retval = merged_types(ret_types)
 
         # Phase 2: Upward — propagate children's types to parents.
         for parent_id, child_ids in parent_to_children.items():
@@ -785,8 +795,6 @@ class Observations:
 
     def collect_annotations(self) -> tuple[dict[CodeId, FuncAnnotation], dict[Filename, ModuleVars], dict[CodeId, list[TraceDistribution]]]:
         """Collects function type annotations from the observed types."""
-
-        clone = _clone_for_context
 
         annotations: dict[CodeId, FuncAnnotation] = {}
         for code_id in self.code_id_topo_sort():

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -249,20 +249,35 @@ def _clone_for_context(node: TypeInfo,
     This recovers Self when ResolvingT injects concrete types that align with
     the destination's receiver — e.g., a lambda capturing self pulled into a
     method's retval.
-
-    Also clears the legacy is_self=True flag (pending removal of the field).
     """
+    # Self carries through the substitution (rather than being concretized) when
+    # source has no self_class, or when source.self_class is the same as or a
+    # subclass of dest.self_class — i.e., dest's Self is at least as wide as
+    # source's Self in their respective contexts.
+    keep_self = (
+        source_self_class is None
+        or (dest_self_class is not None and source_self_class == dest_self_class)
+        or (
+            source_self_class is not None
+            and dest_self_class is not None
+            and isinstance(source_self_class.type_obj, type)
+            and isinstance(dest_self_class.type_obj, type)
+            and issubclass(source_self_class.type_obj, dest_self_class.type_obj)
+        )
+    )
     can_restamp = dest_self_class is not None and (
         source_self_class is None or source_self_class == dest_self_class
     )
     class T(TypeInfo.Transformer):
         def visit(vself, n: TypeInfo) -> TypeInfo:
-            if (n.type_obj is typing.Self
-                    and source_self_class is not None):
-                return source_self_class
+            if n.type_obj is typing.Self:
+                if keep_self:
+                    return n
+                if source_self_class is not None:
+                    return source_self_class
             if can_restamp and not n.args and n == dest_self_class:
                 return TypeInfo.from_type(typing.Self)
-            return super().visit(n.replace(is_self=False))
+            return super().visit(n)
     return T().visit(node)
 
 
@@ -551,25 +566,33 @@ class Observations:
 
             if merge_args:
                 for i, name in enumerate(target.args):
-                    # Skip arg0 (self/cls) for methods: the receiver type is
-                    # always exactly target.self_class (or Self), not subject
-                    # to Liskov widening from parent classes.
-                    if i == 0 and target.self_class is not None:
+                    # Skip arg0 (self/cls) for methods that already have a known
+                    # receiver type: it's always exactly target.self_class (or
+                    # Self), not subject to Liskov widening from parents. If
+                    # target's arg0 is still Unknown (synthetic parent with no
+                    # traces), let widening fill it in from children — the
+                    # post-merge re-stamp will recover Self.
+                    if (i == 0 and target.self_class is not None
+                            and not target.args[name].is_unknown):
                         continue
                     types: set[TypeInfo] = {
-                        _clone_for_context(list(s.args.values())[i], s.self_class)
+                        _clone_for_context(list(s.args.values())[i],
+                                           s.self_class, target.self_class)
                         for s in matching
                     }
                     if not target.args[name].is_unknown:
-                        types.add(_clone_for_context(target.args[name], target.self_class))
+                        types.add(_clone_for_context(target.args[name],
+                                                     target.self_class, target.self_class))
                     target.args[name] = _restamp(merged_types(types))
 
             if merge_retval:
                 ret_types: set[TypeInfo] = {
-                    _clone_for_context(s.retval, s.self_class) for s in matching
+                    _clone_for_context(s.retval, s.self_class, target.self_class)
+                    for s in matching
                 }
                 if not target.retval.is_unknown:
-                    ret_types.add(_clone_for_context(target.retval, target.self_class))
+                    ret_types.add(_clone_for_context(target.retval,
+                                                     target.self_class, target.self_class))
                 target.retval = _restamp(merged_types(ret_types))
 
         # Phase 2: Upward — propagate children's types to parents.
@@ -593,17 +616,8 @@ class Observations:
                 merge_args, merge_retval = False, True   # observed concrete
 
             if parent_id not in raw_annotations:
-                # For methods, arg0 (self/cls) is always Self in its own
-                # context — initialize it directly. Widening skips arg0 for
-                # methods, so this is the only place it gets set.
-                _self_ti = TypeInfo.from_type(typing.Self)
-                args = {
-                    a.arg_name: (_self_ti if i == 0 and parent_fi.defining_class is not None
-                                 else UnknownTypeInfo)
-                    for i, a in enumerate(parent_fi.args)
-                }
                 raw_annotations[parent_id] = FuncAnnotation(
-                    args=args,
+                    args={a.arg_name: UnknownTypeInfo for a in parent_fi.args},
                     retval=UnknownTypeInfo,
                     varargs=parent_fi.varargs, kwargs=parent_fi.kwargs,
                     variables={},

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -381,9 +381,8 @@ class ResolvingT(TypeInfo.Transformer):
                 else UnknownTypeInfo
             )
 
-        # Clear code_id once resolved — same job ClearCodeIdT used to do.
-        # Folding it here saves a second tree walk and lets union members
-        # that became equal after clearing dedup in one place.
+        # Clear code_id once resolved; if children changed, dedup the union
+        # so members that became equal after clearing collapse.
         if node.code_id:
             node = node.replace(code_id=None)
         if pre is not node and isinstance(node, UnionTypeInfo):

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -1,5 +1,6 @@
 import ast
 import typing
+from typing import cast
 import builtins
 from collections import defaultdict, Counter
 import collections.abc as abc
@@ -8,7 +9,7 @@ import logging
 
 from righttyper.options import output_options
 from righttyper.logger import logger
-from righttyper.generalize import merged_types, generalize
+from righttyper.generalize import merged_types, generalize, is_homogeneous
 from righttyper.type_transformers import (
     ClearCodeIdT,
     UnionSizeT,
@@ -25,7 +26,7 @@ from righttyper.type_transformers import (
 from righttyper.typeinfo import TypeInfo, TypeInfoArg, NoneTypeInfo, UnknownTypeInfo, CallTrace
 from righttyper.righttyper_types import ArgumentName, VariableName, Filename, CodeId
 from righttyper.annotation import FuncAnnotation, ModuleVars, TraceDistribution
-from righttyper.type_id import PostponedArg0
+from righttyper.type_id import PostponedArg0, get_type_name
 from righttyper.typeshed import get_typeshed_func_params
 
 
@@ -53,6 +54,10 @@ class FuncInfo:
     overrides: list[OverriddenFunction] = field(default_factory=list)
 
     is_abstract: bool = False
+
+    # The defining class of the method, if this is a method.  Set during
+    # registration from get_self_type's self_replacement.
+    defining_class: TypeInfo | None = None
 
     traces: Counter[CallTrace] = field(default_factory=Counter)
 
@@ -172,6 +177,78 @@ class FuncInfo:
 
         for var_name, var_types in list(self.variables.items()):
             self.variables[var_name] = set(tr.visit(t) for t in var_types)
+
+
+def _stamp_self(
+    per_trace: list[TypeInfo],
+    self_classes: list[TypeInfo],
+) -> TypeInfo | list[TypeInfo]:
+    """Replace nodes that are leaf-equal to the per-trace self_class in EVERY
+    trace with `typing.Self`.
+
+    Returns a single TypeInfo when the position should be uniformly replaced
+    with Self, or a per-trace list of TypeInfos when only nested positions
+    were replaced (or nothing was replaced).
+
+    `self_classes[i]` is the receiver TypeInfo for trace i. Comparison uses
+    TypeInfo equality (structural: module + name) rather than `type_obj is`,
+    so this works even when type_obj reloads as None from a serialized .rt
+    file.
+    """
+    # Leaf match: every trace has matching TypeInfo and no args.
+    if all(t == sc and not t.args
+           for t, sc in zip(per_trace, self_classes)):
+        return TypeInfo.from_type(typing.Self)
+
+    # Recurse if structurally homogeneous across traces.
+    if not is_homogeneous(per_trace):
+        return list(per_trace)
+
+    first = per_trace[0]
+    n_args = len(first.args)
+    # For each arg position, gather the per-trace types.
+    new_args_per_trace: list[list] = [list(t.args) for t in per_trace]
+    for i in range(n_args):
+        col = [t.args[i] for t in per_trace]
+        if all(isinstance(a, TypeInfo) for a in col):
+            sub = _stamp_self([cast(TypeInfo, a) for a in col], self_classes)
+            if isinstance(sub, TypeInfo):
+                # Uniform replacement at this nested position
+                for trace_idx in range(len(per_trace)):
+                    new_args_per_trace[trace_idx][i] = sub
+            else:
+                # Per-trace nested results
+                for trace_idx, replaced in enumerate(sub):
+                    new_args_per_trace[trace_idx][i] = replaced
+        # else: ellipsis or other non-TypeInfo arg — leave as-is
+    return [
+        per_trace[trace_idx].replace(args=tuple(new_args_per_trace[trace_idx]))
+        for trace_idx in range(len(per_trace))
+    ]
+
+
+class NormalizeSubtypeT(TypeInfo.Transformer):
+    """Replace TypeInfos whose type_obj is a strict subtype of `defining_class`
+    with `defining_class` itself (inheritance normalization).
+
+    For single-observation cases this widens the annotation toward the method's
+    defining class (more permissive) instead of leaving the observed subclass.
+    For multi-trace cases, lub's subtype merge produces the same result, so
+    this transformer only changes single-observation outputs.
+
+    TODO consider dropping this if it produces less useful annotations than
+    keeping the literally-observed subtype — the trade-off is permissiveness
+    vs. fidelity to observation.
+    """
+    def __init__(self, defining_class: type):
+        self.defining_class = defining_class
+
+    def visit(self, node: TypeInfo) -> TypeInfo:
+        if (hasattr(node.type_obj, "__mro__")
+                and self.defining_class in cast(type, node.type_obj).__mro__
+                and node.type_obj is not self.defining_class):
+            node = get_type_name(self.defining_class)
+        return super().visit(node)
 
 
 class Observations:
@@ -406,6 +483,52 @@ class Observations:
         if not traces:
             return None
 
+        # Self detection: if this is a method, structurally stamp typing.Self
+        # at positions where the per-trace receiver class matches across all
+        # traces. arg0 and retval get single-trace detection; other args
+        # require >= 2 traces. After stamping, normalize remaining subtypes
+        # of the defining class to defining_class itself.
+        if ((defining_class := func_info.defining_class) is not None
+                and isinstance(defining_class.type_obj, type)):
+            n_positions = len(traces[0])
+            modified = [list(t) for t in traces]
+
+            # Stamp typing.Self only when the output target supports it (3.11+).
+            if output_options.use_typing_self:
+                # Per-trace receiver class is recorded on the CallTrace at trace
+                # time (CallTrace.first_arg_class).  May be None for non-methods
+                # or when the per-trace info wasn't captured.
+                self_classes_ti = [t.first_arg_class for t in traces]
+                if all(sc is not None for sc in self_classes_ti):
+                    self_classes = [cast(TypeInfo, sc) for sc in self_classes_ti]
+                else:
+                    self_classes = []
+                for pos in range(n_positions):
+                    is_arg0 = (pos == 0)
+                    is_retval = (pos == n_positions - 1)
+                    if not (is_arg0 or is_retval) and len(traces) < 2:
+                        continue  # don't stamp Self on non-arg0/retval from single observation
+                    col = [m[pos] for m in modified]
+                    if not all(isinstance(c, TypeInfo) for c in col):
+                        continue
+                    result = _stamp_self([cast(TypeInfo, c) for c in col], self_classes)
+                    if isinstance(result, TypeInfo):
+                        for m in modified:
+                            m[pos] = result
+                    else:
+                        for i, replaced in enumerate(result):
+                            modified[i][pos] = replaced
+
+            # Inheritance widening: replace subtypes of defining_class with defining_class.
+            # Applies regardless of typing.Self availability.
+            normalize = NormalizeSubtypeT(cast(type, defining_class.type_obj))
+            modified = [
+                [normalize.visit(c) if isinstance(c, TypeInfo) else c for c in m]
+                for m in modified
+            ]
+
+            traces = [tuple(m) for m in modified]
+
         if (signature := generalize(traces)) is None:
             logger.info(f"Unable to generalize {func_info.code_id}: inconsistent traces.\n" +
                         f"{[tuple(str(t) for t in s) for s in traces]}")
@@ -428,7 +551,8 @@ class Observations:
             variables={
                 var_name: merged_types(var_types, for_variable=True)
                 for var_name, var_types in func_info.variables.items()
-            }
+            },
+            self_class=func_info.defining_class,
         )
 
         if logger.level == logging.DEBUG:
@@ -594,8 +718,6 @@ class Observations:
         # This also deduplicates unions whose members became equal after clearing.
         transform_types(ClearCodeIdT())
 
-        if output_options.use_typing_self:
-            transform_types(SelfT())
 
         # Compute type distributions from traces, resolving code_id references
         # so that Callable/generator types render with their actual signatures.

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -239,56 +239,78 @@ def _stamp_self(
     ]
 
 
+class _CloneForContextT(TypeInfo.Transformer):
+    """Implements `_clone_for_context`. See that function for parameter semantics."""
+    def __init__(self,
+                 source_self_class: TypeInfo | None,
+                 dest_self_class: TypeInfo | None) -> None:
+        self.source_self_class = source_self_class
+        self.dest_self_class = dest_self_class
+        # Self carries through the substitution (rather than being concretized) when
+        # source has no self_class, or when source.self_class is the same as or a
+        # subclass of dest.self_class — i.e., dest's Self is at least as wide as
+        # source's Self in their respective contexts.
+        #
+        # The subclass branch needs live `type_obj` to walk MRO via issubclass.
+        # For `.rt` files where type_obj reloads as None (e.g., classes from
+        # __main__ or unimportable modules), this branch silently fails and the
+        # Self in source gets substituted to source's concrete class. The
+        # annotation is still correct, just less precise (concrete instead of Self).
+        self.keep_self = (
+            source_self_class is None
+            or (dest_self_class is not None and source_self_class == dest_self_class)
+            or (
+                source_self_class is not None
+                and dest_self_class is not None
+                and isinstance(source_self_class.type_obj, type)
+                and isinstance(dest_self_class.type_obj, type)
+                and issubclass(source_self_class.type_obj, dest_self_class.type_obj)
+            )
+        )
+        self.can_restamp = dest_self_class is not None and (
+            source_self_class is None or source_self_class == dest_self_class
+        )
+
+    def visit(self, n: TypeInfo) -> TypeInfo:
+        if n.type_obj is typing.Self:
+            if self.keep_self:
+                return n
+            if self.source_self_class is not None:
+                return self.source_self_class
+        if self.can_restamp and not n.args and n == self.dest_self_class:
+            return TypeInfo.from_type(typing.Self)
+        return super().visit(n)
+
+
 def _clone_for_context(node: TypeInfo,
                        source_self_class: TypeInfo | None = None,
                        dest_self_class: TypeInfo | None = None) -> TypeInfo:
     """Clone a TypeInfo subtree for use in a different annotation context.
 
-    Substitutes `typing.Self` with the source annotation's concrete `self_class`
-    (if provided), since Self's meaning is local to its source annotation.
+    `source_self_class` is the class that `typing.Self` resolves to in the
+    annotation `node` came from — i.e., the source annotation's `self_class`.
+    None for non-method sources (anonymous functions, lambdas, plain functions).
 
-    If `dest_self_class` is set AND the source either has no self_class
-    (anonymous, e.g., a lambda) or shares the destination's self_class, also
-    stamp `typing.Self` on leaf nodes whose TypeInfo equals `dest_self_class`.
-    This recovers Self when ResolvingT injects concrete types that align with
-    the destination's receiver — e.g., a lambda capturing self pulled into a
-    method's retval.
+    `dest_self_class` is the class that `typing.Self` will resolve to in the
+    annotation `node` is being cloned into — i.e., the destination annotation's
+    `self_class`. None for non-method destinations.
+
+    Both refer to the *meaning of Self* in their respective contexts, not to
+    where the underlying code is lexically defined (which is `defining_class`
+    on FuncInfo). For a freshly-built annotation `defining_class == self_class`,
+    but synthetic annotations (e.g., from `_register_parent_function`) can
+    diverge.
+
+    Behavior:
+    - Substitute `typing.Self` -> `source_self_class` when leaving the source
+      context (Self's meaning is local).
+    - With `dest_self_class` set AND source either anonymous or matching dest,
+      re-stamp leaf nodes whose TypeInfo equals `dest_self_class` as
+      `typing.Self`. This recovers Self when ResolvingT injects concrete types
+      that align with the destination's receiver — e.g., a lambda capturing
+      self pulled into a method's retval.
     """
-    # Self carries through the substitution (rather than being concretized) when
-    # source has no self_class, or when source.self_class is the same as or a
-    # subclass of dest.self_class — i.e., dest's Self is at least as wide as
-    # source's Self in their respective contexts.
-    #
-    # The subclass branch needs live `type_obj` to walk MRO via issubclass.
-    # For `.rt` files where type_obj reloads as None (e.g., classes from
-    # __main__ or unimportable modules), this branch silently fails and the
-    # Self in source gets substituted to source's concrete class. The
-    # annotation is still correct, just less precise (concrete instead of Self).
-    keep_self = (
-        source_self_class is None
-        or (dest_self_class is not None and source_self_class == dest_self_class)
-        or (
-            source_self_class is not None
-            and dest_self_class is not None
-            and isinstance(source_self_class.type_obj, type)
-            and isinstance(dest_self_class.type_obj, type)
-            and issubclass(source_self_class.type_obj, dest_self_class.type_obj)
-        )
-    )
-    can_restamp = dest_self_class is not None and (
-        source_self_class is None or source_self_class == dest_self_class
-    )
-    class T(TypeInfo.Transformer):
-        def visit(vself, n: TypeInfo) -> TypeInfo:
-            if n.type_obj is typing.Self:
-                if keep_self:
-                    return n
-                if source_self_class is not None:
-                    return source_self_class
-            if can_restamp and not n.args and n == dest_self_class:
-                return TypeInfo.from_type(typing.Self)
-            return super().visit(n)
-    return T().visit(node)
+    return _CloneForContextT(source_self_class, dest_self_class).visit(node)
 
 
 class ResolvingT(TypeInfo.Transformer):
@@ -585,7 +607,9 @@ class Observations:
                     # Self), not subject to Liskov widening from parents. If
                     # target's arg0 is still Unknown (synthetic parent with no
                     # traces), let widening fill it in from children — the
-                    # post-merge re-stamp will recover Self.
+                    # keep_self branch in _clone_for_context preserves Self
+                    # from children's arg0 when source.self_class is a subclass
+                    # of target.self_class.
                     if (i == 0 and target.self_class is not None
                             and not target.args[name].is_unknown):
                         continue

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -21,7 +21,7 @@ from righttyper.type_transformers import (
     MakePickleableT,
     LoadTypeObjT
 )
-from righttyper.typeinfo import TypeInfo, TypeInfoArg, NoneTypeInfo, UnknownTypeInfo, UnionTypeInfo, CallTrace
+from righttyper.typeinfo import TypeInfo, TypeInfoArg, UnknownTypeInfo, UnionTypeInfo, CallTrace
 from righttyper.righttyper_types import ArgumentName, VariableName, Filename, CodeId
 from righttyper.annotation import FuncAnnotation, ModuleVars, TraceDistribution
 from righttyper.type_id import PostponedArg0, get_type_name

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -169,7 +169,7 @@ class FuncInfo:
             # transformed another trace's content to match this key, contributing
             # additional count we must carry through this iteration's rebuild.
             count = self.traces[trace]
-            old_fac = getattr(trace, 'first_arg_class', None)
+            old_fac = trace.first_arg_class
             new_fac = tr.visit(old_fac) if old_fac is not None else None
             trace_prime = CallTrace(
                 [tr.visit(t) for t in trace],
@@ -693,15 +693,10 @@ class Observations:
             modified = [list(t) for t in traces]
 
             # Stamp typing.Self only when the output target supports it (3.11+).
+            # For methods, every trace carries first_arg_class (set in
+            # PendingCallTrace.finish() at record time).
             if output_options.use_typing_self:
-                # Per-trace receiver class is recorded on the CallTrace at trace
-                # time (CallTrace.first_arg_class).  May be None for non-methods
-                # or when the per-trace info wasn't captured.
-                self_classes_ti = [t.first_arg_class for t in traces]
-                if all(sc is not None for sc in self_classes_ti):
-                    self_classes = [cast(TypeInfo, sc) for sc in self_classes_ti]
-                else:
-                    self_classes = []
+                self_classes = [cast(TypeInfo, t.first_arg_class) for t in traces]
                 for pos in range(n_positions):
                     is_arg0 = (pos == 0)
                     is_retval = (pos == n_positions - 1)

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -164,7 +164,11 @@ class FuncInfo:
                     override.inline_arg_types = inline_types_prime
 
 
-        for trace, count in list(self.traces.items()):
+        for trace in list(self.traces):
+            # Re-read count from the live counter: an earlier iteration may have
+            # transformed another trace's content to match this key, contributing
+            # additional count we must carry through this iteration's rebuild.
+            count = self.traces[trace]
             old_fac = getattr(trace, 'first_arg_class', None)
             new_fac = tr.visit(old_fac) if old_fac is not None else None
             trace_prime = CallTrace(
@@ -181,7 +185,7 @@ class FuncInfo:
                         str(tuple(str(t) for t in trace_prime))
                     )
                 del self.traces[trace]
-                self.traces[trace_prime] = count
+                self.traces[trace_prime] += count
 
         for var_name, var_types in list(self.variables.items()):
             self.variables[var_name] = set(tr.visit(t) for t in var_types)

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -734,6 +734,21 @@ class Observations:
 
         n_sig_args = len(signature) - 1  # last element is the return type
 
+        # Resolve code_ids in variable types too (they don't go through traces).
+        if annotations:
+            assert resolver is not None  # set above when annotations is provided
+            variables = {
+                var_name: merged_types(
+                    {resolver.visit(t) for t in var_types}, for_variable=True,
+                )
+                for var_name, var_types in func_info.variables.items()
+            }
+        else:
+            variables = {
+                var_name: merged_types(var_types, for_variable=True)
+                for var_name, var_types in func_info.variables.items()
+            }
+
         ann = FuncAnnotation(
             args={
                 arg.arg_name:
@@ -746,10 +761,7 @@ class Observations:
             retval=signature[-1],
             varargs=func_info.varargs,
             kwargs=func_info.kwargs,
-            variables={
-                var_name: merged_types(var_types, for_variable=True)
-                for var_name, var_types in func_info.variables.items()
-            },
+            variables=variables,
             self_class=func_info.defining_class,
         )
 
@@ -777,14 +789,23 @@ class Observations:
         visited = set()
         result = []
 
-        def visit(code_id: CodeId):
+        def walk(t: TypeInfo) -> None:
+            if t.code_id:
+                visit(t.code_id)
+            for a in t.args:
+                if isinstance(a, TypeInfo):
+                    walk(a)
+
+        def visit(code_id: CodeId) -> None:
             if code_id not in visited:
                 visited.add(code_id)
                 if (func_info := self.func_info.get(code_id)):
                     for tr in func_info.traces:
                         for t in tr:
-                            if t.code_id:
-                                visit(t.code_id)
+                            walk(t)
+                    for var_types in func_info.variables.values():
+                        for t in var_types:
+                            walk(t)
                     result.append(code_id)
 
         for code_id in self.func_info.keys():
@@ -807,9 +828,12 @@ class Observations:
                 annotations[code_id] = annotation
 
         # Merge module variables into ModuleVars (parallel to annotations for functions).
+        # Module-scope vars don't go through mk_annotation, so resolve any code_id
+        # references against the just-built annotations here.
+        mv_resolver = ResolvingT(annotations, self.func_info)
         module_vars: dict[Filename, ModuleVars] = {
             filename: ModuleVars({
-                var_name: merged_types(var_types, for_variable=True)
+                var_name: mv_resolver.visit(merged_types(var_types, for_variable=True))
                 for var_name, var_types in var_dict.items()
             })
             for filename, var_dict in self.module_variables.items()
@@ -845,10 +869,7 @@ class Observations:
                 _visit_dict(mv.variables, tr, tr_name, f"{module} ")
 
 
-        # Resolution may already have run per-trace inside mk_annotation (since
-        # topo sort orders dependencies first), but run a final pass to catch
-        # any code_ids that survived (e.g., variable types that didn't go through
-        # mk_annotation, or cycles).
+        # Resolve code_id refs unreachable from topo sort (cycles, self-references).
         transform_types(ResolvingT(annotations, self.func_info))
 
         # Compute type distributions from traces, resolving code_id references

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -581,8 +581,9 @@ class Observations:
                         for s in matching
                     }
                     if not target.args[name].is_unknown:
-                        types.add(_clone_for_context(target.args[name],
-                                                     target.self_class, target.self_class))
+                        # target's own type is already in the destination context;
+                        # add it directly without cloning (no substitution, no restamp).
+                        types.add(target.args[name])
                     target.args[name] = _restamp(merged_types(types))
 
             if merge_retval:
@@ -591,8 +592,7 @@ class Observations:
                     for s in matching
                 }
                 if not target.retval.is_unknown:
-                    ret_types.add(_clone_for_context(target.retval,
-                                                     target.self_class, target.self_class))
+                    ret_types.add(target.retval)
                 target.retval = _restamp(merged_types(ret_types))
 
         # Phase 2: Upward — propagate children's types to parents.

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -401,9 +401,20 @@ class NormalizeSubtypeT(TypeInfo.Transformer):
     For multi-trace cases, lub's subtype merge produces the same result, so
     this transformer only changes single-observation outputs.
 
-    TODO consider dropping this if it produces less useful annotations than
-    keeping the literally-observed subtype — the trade-off is permissiveness
-    vs. fidelity to observation.
+    Example. Given:
+
+        class A:
+            def merge(self, other): ...
+        class B(A): ...
+        A().merge(B())
+
+    The single observed call has `other: B`. `B` is a strict subtype of
+    `A` (the defining class of `merge`), so without this transformer the
+    annotation is `def merge(self, other: "B")` — fidelity to the
+    observation but tighter than the method's actual contract. With it,
+    `B` normalizes to `A`, giving `def merge(self, other: "A")`. With
+    multiple observations Self detection would already produce
+    `other: Self`; this transformer plugs the single-observation gap.
     """
     def __init__(self, defining_class: type):
         self.defining_class = defining_class
@@ -758,19 +769,13 @@ class Observations:
         n_sig_args = len(signature) - 1  # last element is the return type
 
         # Resolve code_ids in variable types too (they don't go through traces).
-        if annotations:
-            assert resolver is not None  # set above when annotations is provided
-            variables = {
-                var_name: merged_types(
-                    {resolver.visit(t) for t in var_types}, for_variable=True,
-                )
-                for var_name, var_types in func_info.variables.items()
-            }
-        else:
-            variables = {
-                var_name: merged_types(var_types, for_variable=True)
-                for var_name, var_types in func_info.variables.items()
-            }
+        variables = {
+            var_name: merged_types(
+                {resolver.visit(t) for t in var_types} if annotations else var_types,
+                for_variable=True,
+            )
+            for var_name, var_types in func_info.variables.items()
+        }
 
         ann = FuncAnnotation(
             args={

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -267,8 +267,12 @@ class _CloneForContextT(TypeInfo.Transformer):
                 and issubclass(source_self_class.type_obj, dest_self_class.type_obj)
             )
         )
-        self.can_restamp = dest_self_class is not None and (
-            source_self_class is None or source_self_class == dest_self_class
+        # Gate Self re-stamping on the same option that gates trace-time
+        # _stamp_self: pre-3.11 targets must not see typing.Self injected here.
+        self.can_restamp = (
+            output_options.use_typing_self
+            and dest_self_class is not None
+            and (source_self_class is None or source_self_class == dest_self_class)
         )
 
     def visit(self, n: TypeInfo) -> TypeInfo:

--- a/righttyper/recorder.py
+++ b/righttyper/recorder.py
@@ -228,7 +228,8 @@ class ObservationsRecorder:
 
 
     def _register_parent_function(
-        self, child_fi: FuncInfo, parent_func: FunctionType, finder: 'OverrideFinder'
+        self, child_fi: FuncInfo, parent_func: FunctionType, finder: 'OverrideFinder',
+        parent_defining_class: TypeInfo | None,
     ) -> None:
         """Registers all ancestor functions that the child overrides.
 
@@ -252,7 +253,8 @@ class ObservationsRecorder:
             parent_arg_info = inspect.ArgInfo(parent_args.args, parent_args.varargs, parent_args.varkw, {})
 
             # Register this parent with no overrides of its own
-            self._register_function(parent_code, parent_func, parent_arg_info, [])
+            self._register_function(parent_code, parent_func, parent_arg_info, [],
+                                    defining_class=parent_defining_class)
             self._code2func_info[parent_code].is_abstract = getattr(parent_func, '__isabstractmethod__', False)
 
             # Find next ancestor in the child's MRO
@@ -260,13 +262,16 @@ class ObservationsRecorder:
             if not result:
                 return
 
-            override, next_func = result
+            override, next_func, next_class = result
             child_fi.overrides.append(override)
 
             if not next_func:
                 return
 
             parent_func = next_func
+            parent_defining_class = (
+                get_type_name(next_class) if next_class is not None else None
+            )
 
 
     def record_start(
@@ -297,7 +302,8 @@ class ObservationsRecorder:
 
             if sti.parent_func is not None and sti.override_finder is not None:
                 child_fi = self._code2func_info[code]
-                self._register_parent_function(child_fi, sti.parent_func, sti.override_finder)
+                self._register_parent_function(child_fi, sti.parent_func,
+                                               sti.override_finder, sti.parent_defining_class)
 
             self._pending_traces[code][id(frame)] = PendingCallTrace(
                 arg_info, code.co_flags, sti.self_type, sti.self_replacement
@@ -744,11 +750,12 @@ class OverrideFinder:
 
     def find_next(
         self, code: CodeType, child_arg_info: inspect.ArgInfo
-    ) -> tuple[OverriddenFunction, FunctionType | None] | None:
+    ) -> tuple[OverriddenFunction, FunctionType | None, type | None] | None:
         """Find the next override of the method in the MRO.
 
-        Returns (overrides, parent_func) or None.  parent_func is None for
-        native/builtin methods.
+        Returns (overrides, parent_func, defining_class) or None.
+        parent_func is None for native/builtin methods.
+        defining_class is the MRO ancestor that defines the override.
         """
         for idx, ancestor in enumerate(self._mro[self._index:]):
             f = unwrap(ancestor.__dict__.get(self._method_name, None))
@@ -762,6 +769,7 @@ class OverrideFinder:
                         get_parent_arg_types(f, child_arg_info)
                     ),
                     f if isinstance(f, FunctionType) else None,
+                    ancestor,
                 )
         return None
 
@@ -773,6 +781,7 @@ class SelfTypeInfo:
     self_replacement: TypeInfo | None = None
     overrides: list[OverriddenFunction] = field(default_factory=list)
     parent_func: FunctionType | None = None
+    parent_defining_class: TypeInfo | None = None  # defining class of parent_func
     override_finder: OverrideFinder | None = None  # for walking the parent chain
 
 
@@ -796,6 +805,7 @@ def get_self_type(
         overrides: list[OverriddenFunction] = []
         parent_func = None
         finder: OverrideFinder | None = None
+        parent_defining_class: TypeInfo | None = None
         if not (
             info.is_property
             or info.name in ('__init__', '__new__')  # irrelevant for Liskov
@@ -805,12 +815,16 @@ def get_self_type(
             if result:
                 overrides = [result[0]]
                 parent_func = result[1]
+                parent_defining_class = (
+                    get_type_name(result[2]) if result[2] is not None else None
+                )
 
         return SelfTypeInfo(
             get_type_name(info.first_arg_class),
             get_type_name(info.defining_class),
             overrides,
             parent_func,
+            parent_defining_class=parent_defining_class,
             override_finder=finder if parent_func else None,
         )
 

--- a/righttyper/recorder.py
+++ b/righttyper/recorder.py
@@ -111,7 +111,7 @@ class PendingCallTrace:
                 retval = TypeInfo.from_type(abc.AsyncGenerator, args=(y, s))
             else:
                 retval = TypeInfo.from_type(abc.Generator, args=(y, s, retval))
-            
+
         # Arguments may change value (and, in particular, empty containers may be added to)
         # during the function execution, so we sample a 2nd time at the end.
         args_now = self._get_arg_types(self.arg_info)
@@ -123,28 +123,7 @@ class PendingCallTrace:
             retval
         )
 
-        if self.self_type and self.self_replacement:
-            self_type = self.self_type
-            self_replacement = self.self_replacement
-
-            class SelfTransformer(TypeInfo.Transformer):
-                """Replaces 'self' types with the type of the class that defines them,
-                   also setting is_self for possible later replacement with typing.Self."""
-
-                def visit(vself, node: TypeInfo) -> TypeInfo:
-                    if (
-                        hasattr(node.type_obj, "__mro__")
-                        and self_type.type_obj in cast(type, node.type_obj).__mro__
-                    ):
-                        node = self_replacement.replace(is_self=True)
-
-                    return super().visit(node)
-
-
-            tr = SelfTransformer()
-            type_data = (*(tr.visit(arg) for arg in type_data),)
-
-        return type_data
+        return CallTrace(type_data, first_arg_class=self.self_type)
 
 
 class ObservationsRecorder:
@@ -203,7 +182,8 @@ class ObservationsRecorder:
         code: CodeType,
         function: CallableWithCode|None,
         arg_info: inspect.ArgInfo,
-        overrides: list[OverriddenFunction]
+        overrides: list[OverriddenFunction],
+        defining_class: TypeInfo|None = None,
     ) -> None:
         """Registers a function if not already known."""
 
@@ -242,6 +222,7 @@ class ObservationsRecorder:
                 ArgumentName(arg_info.varargs) if arg_info.varargs else None,
                 ArgumentName(arg_info.keywords) if arg_info.keywords else None,
                 overrides=overrides,
+                defining_class=defining_class,
             )
             self._obs.func_info[func_info.code_id] = func_info
 
@@ -311,7 +292,8 @@ class ObservationsRecorder:
         # call, as the new dictionary is created for the new scope.
         if (code.co_flags & inspect.CO_NEWLOCALS):
             sti = get_self_type(code, arg_info)
-            self._register_function(code, find_function(frame, code), arg_info, sti.overrides)
+            self._register_function(code, find_function(frame, code), arg_info,
+                                    sti.overrides, defining_class=sti.self_replacement)
 
             if sti.parent_func is not None and sti.override_finder is not None:
                 child_fi = self._code2func_info[code]
@@ -395,7 +377,8 @@ class ObservationsRecorder:
         sti = get_self_type(wrapped_code, synthetic_arg_info)
 
         # Register the wrapped function if not already known
-        self._register_function(wrapped_code, wrapped, synthetic_arg_info, sti.overrides)
+        self._register_function(wrapped_code, wrapped, synthetic_arg_info,
+                                sti.overrides, defining_class=sti.self_replacement)
 
         pending = PendingCallTrace(synthetic_arg_info, wrapped_code.co_flags, sti.self_type, sti.self_replacement)
         self._pending_wrapped_traces[wrapped_code][id(frame)] = pending

--- a/righttyper/recorder.py
+++ b/righttyper/recorder.py
@@ -1,7 +1,7 @@
 import inspect
 import builtins
 from dataclasses import dataclass, field
-from types import CodeType, FrameType, FunctionType, MethodType, GeneratorType
+from types import CodeType, FrameType, FunctionType, GeneratorType
 from collections import defaultdict
 import collections.abc as abc
 from pathlib import Path
@@ -9,7 +9,7 @@ import logging
 from righttyper.logger import logger
 from righttyper.righttyper_types import ArgumentName, VariableName, Filename, CodeId, CallableWithCode, cast_not_None
 from righttyper.typeinfo import TypeInfo, NoneTypeInfo, UnknownTypeInfo, CallTrace
-from typing import Final, Any, NewType, overload, cast
+from typing import Final, Any, NewType, overload
 import typing
 from righttyper.observations import Observations, FuncInfo, OverriddenFunction, ArgInfo
 from righttyper.variable_capture import code2variables
@@ -19,7 +19,7 @@ from righttyper.righttyper_utils import (
     detected_test_files, detected_test_modules, is_test_module,
     normalize_module_name, unwrap
 )
-from righttyper.type_id import find_function, get_value_type, get_type_name, hint2type, PostponedArg0
+from righttyper.type_id import find_function, get_value_type, get_type_name, hint2type
 from righttyper.righttyper_tool import field_class_init_codes
 from righttyper.typemap import TypeMap, AdjustTypeNamesT, CheckTypeNamesT
 

--- a/righttyper/recorder.py
+++ b/righttyper/recorder.py
@@ -61,7 +61,6 @@ class PendingCallTrace:
         arg_info: inspect.ArgInfo,
         co_flags: int,
         self_type: TypeInfo|None,
-        self_replacement: TypeInfo|None
     ) -> None:
         self.arg_info = arg_info
         self.args_start = self._get_arg_types(arg_info)
@@ -70,7 +69,6 @@ class PendingCallTrace:
         self.is_async = bool(co_flags & (inspect.CO_ASYNC_GENERATOR | inspect.CO_COROUTINE))
         self.is_generator=bool(co_flags & (inspect.CO_ASYNC_GENERATOR | inspect.CO_GENERATOR))
         self.self_type = self_type
-        self.self_replacement = self_replacement
 
 
     @staticmethod
@@ -306,7 +304,7 @@ class ObservationsRecorder:
                                                sti.override_finder, sti.parent_defining_class)
 
             self._pending_traces[code][id(frame)] = PendingCallTrace(
-                arg_info, code.co_flags, sti.self_type, sti.self_replacement
+                arg_info, code.co_flags, sti.self_type
             )
 
             if run_options.propagate_wrapped_types:
@@ -386,7 +384,7 @@ class ObservationsRecorder:
         self._register_function(wrapped_code, wrapped, synthetic_arg_info,
                                 sti.overrides, defining_class=sti.self_replacement)
 
-        pending = PendingCallTrace(synthetic_arg_info, wrapped_code.co_flags, sti.self_type, sti.self_replacement)
+        pending = PendingCallTrace(synthetic_arg_info, wrapped_code.co_flags, sti.self_type)
         self._pending_wrapped_traces[wrapped_code][id(frame)] = pending
 
 

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -48,7 +48,7 @@ from righttyper.atomic import AtomicCounter
 
 
 PKL_FILE_NAME = TOOL_NAME+"-{N}.rt"
-PKL_FILE_VERSION = 6
+PKL_FILE_VERSION = 7
 
 
 rec = ObservationsRecorder()

--- a/righttyper/type_transformers.py
+++ b/righttyper/type_transformers.py
@@ -48,15 +48,6 @@ class UnionSizeT(TypeInfo.Transformer):
         return node
 
 
-class SelfT(TypeInfo.Transformer):
-    """Renames types to typing.Self according to is_self."""
-    def visit(vself, node: TypeInfo) -> TypeInfo:
-        if node.is_self:
-            return TypeInfo.from_type(typing.Self)
-
-        return super().visit(node)
-
-
 class NeverSayNeverT(TypeInfo.Transformer):
     """Removes uses of typing.Never, replacing them with typing.Any"""
     def visit(vself, node: TypeInfo) -> TypeInfo:

--- a/righttyper/type_transformers.py
+++ b/righttyper/type_transformers.py
@@ -10,29 +10,6 @@ import logging
 from righttyper.logger import logger
 
 
-class ClearCodeIdT(TypeInfo.Transformer):
-    """Clear code_id and deduplicate any unions that had code_id-inflated members.
-
-    code_id distinguishes different callables during tracing but should not
-    affect the final annotation. After clearing, previously-distinct Callable
-    members of a union become equal and are deduplicated via from_set().
-    """
-    def visit(self, node: TypeInfo) -> TypeInfo:
-        pre = node
-        node = super().visit(node)  # returns identical node iff no arg changed
-
-        if node.code_id:
-            node = node.replace(code_id=None)
-
-        # Clearing code_ids on union members may collapse previously-distinct
-        # members into equal ones, so rebuild the union to let from_set() dedup
-        # them.
-        if pre is not node and isinstance(node, UnionTypeInfo):
-            return TypeInfo.from_set(set(node.args), typevar_index=node.typevar_index)
-
-        return node
-
-
 class UnionSizeT(TypeInfo.Transformer):
     """Enforce max_union_size on resolved unions.
 

--- a/righttyper/type_transformers.py
+++ b/righttyper/type_transformers.py
@@ -6,8 +6,6 @@ from righttyper.typeinfo import TypeInfo, AnyTypeInfo, NoneTypeInfo, UnknownType
 from righttyper.generalize import merged_types
 from functools import cache
 
-import logging
-from righttyper.logger import logger
 
 
 class UnionSizeT(TypeInfo.Transformer):

--- a/righttyper/typeinfo.py
+++ b/righttyper/typeinfo.py
@@ -1,5 +1,5 @@
 import typing
-from typing import Iterator, Final, Callable, Any
+from typing import Iterator, Iterable, Final, Callable, Any
 import types
 from dataclasses import dataclass, replace, field
 from righttyper.righttyper_types import CodeId
@@ -239,4 +239,22 @@ UnknownTypeInfo: Final = TypeInfo.from_type(typing.Any, is_unknown=True)
 AnyTypeInfo: Final = TypeInfo.from_type(typing.Any)
 
 
-type CallTrace = tuple[TypeInfo, ...]
+class CallTrace(tuple[TypeInfo, ...]):
+    """A recorded call trace: tuple of (arg types..., retval) plus per-trace metadata.
+
+    Subclasses tuple so existing iteration/indexing continues to work. Equality
+    and hashing inherit from tuple — two CallTraces with the same contents are
+    equal regardless of metadata (and in practice same contents always implies
+    same metadata, since metadata is a function of the receiver).
+
+    Note: tuple subclasses can't use __slots__, so first_arg_class lives on
+    instance __dict__.  This is fine: dicts pickle and the attribute is always
+    set in __new__.
+    """
+    first_arg_class: "TypeInfo | None"
+
+    def __new__(cls, items: "Iterable[TypeInfo]",
+                first_arg_class: "TypeInfo | None" = None) -> "CallTrace":
+        self = super().__new__(cls, items)
+        self.first_arg_class = first_arg_class
+        return self

--- a/righttyper/typeinfo.py
+++ b/righttyper/typeinfo.py
@@ -33,11 +33,6 @@ class TypeInfo:
     # Multiple can occur in a function call, in different order, so include in comparisons.
     typevar_index: int = field(default=0, compare=True)
 
-    # Indicates equivalence to typing.Self. Note that is_self may be true for one
-    # type (class) in one trace, but false for the exact same type in another,
-    # so that is_self matters for equivalence
-    is_self: bool = field(default=False, compare=True)
-
 
     @staticmethod
     def _arg2str(a: TypeInfoArg, modifier: Callable[["TypeInfo"], str|None]|None) -> str:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4219,6 +4219,7 @@ def test_self_widen_abstract_retval():
 
     # Parent retval widened from children's Self → re-stamp keeps it Self.
     assert get_function(code, 'Base.factory') == textwrap.dedent("""\
+        @abstractmethod
         def factory(self: Self) -> Self: ...
     """)
     assert get_function(code, 'A.factory') == textwrap.dedent("""\
@@ -4252,20 +4253,25 @@ def test_self_widen_lsp_arg():
 
     # Each method, observed once, has only one trace. Non-arg0/non-retval
     # parameter `other` is not stamped Self from a single observation. So
-    # parent's `other` is "Parent" (concrete). After Phase 3, child's `other`
-    # widens from parent's: child sees {Parent (after substitution), Self_child→Child}
-    # → lub Parent. Re-stamp Parent==Child? no → stays Parent.
+    # parent's `other` is Parent (concrete; forward-ref quoted only because
+    # the method is inside the class definition). After Phase 3, child's
+    # `other` widens from parent's: child sees {Parent (after substitution),
+    # Self_child→Child} → lub Parent. Re-stamp Parent==Child? no → stays Parent.
     assert get_function(code, 'Parent.merge') == textwrap.dedent("""\
         def merge(self: Self, other: "Parent") -> Self: ...
     """)
+    # Child references Parent which is defined earlier — no forward-ref quotes.
     assert get_function(code, 'Child.merge') == textwrap.dedent("""\
-        def merge(self: Self, other: "Parent") -> Self: ...
+        def merge(self: Self, other: Parent) -> Self: ...
     """)
 
 
 def test_self_widen_callable_retval():
-    """Method returning a Callable involving Self. Tests that nested Self
-    survives widening across class hierarchy."""
+    """Method returns a Callable that itself returns self. ResolvingT pulls in
+    the lambda's resolved retval (a concrete A after lub-merging A|B from the
+    two trace receivers); we need Self detection to recover Self at the inner
+    Callable position because the lambda's retval matches the outer method's
+    self_class."""
     t = textwrap.dedent("""\
         from typing import Callable
         class A:
@@ -7313,6 +7319,39 @@ def test_parent_type_propagation_only_collect():
     # B's args widened to include A's
     assert get_function(code, 'B.foo') == textwrap.dedent("""\
         def foo(self: Self, x: int|str) -> str: ...
+    """)
+
+
+def test_self_detection_through_collect_and_process():
+    """Self detection survives the .rt collect/process round-trip.
+
+    `--only-collect` writes traces to a .rt file (via dill); `process` reads
+    them back in a fresh interpreter. CallTrace.first_arg_class is recorded
+    as a TypeInfo, so structural Self detection in mk_annotation works on
+    the deserialized data even if type_obj fails to reload.
+    """
+    Path("t.py").write_text(textwrap.dedent("""\
+        class NumberAdd:
+            def operation(self, rhs):
+                return self
+
+        class IntegerAdd(NumberAdd):
+            pass
+
+        a = NumberAdd()
+        b = IntegerAdd()
+        a.operation(b)
+    """))
+
+    rt_run('--only-collect', '--python-version=3.11', 't.py')
+    rt_run('process', '--python-version=3.11')
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+
+    # Same expectation as test_self_unrelated_subclass_arg, but exercises
+    # the .rt serialization path.
+    assert get_function(code, 'NumberAdd.operation') == textwrap.dedent("""\
+        def operation(self: Self, rhs: "NumberAdd") -> Self: ...
     """)
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5404,6 +5404,8 @@ def test_log_includes_non_inline_typevar():
     ("[[[[3]]]]", ("--type-depth-limit", "1"), "list[list]"),
     ("{0:{1:{2:2}}}", ("--type-depth-limit", "1"), "dict[int, dict]"),
     ("[{1}]", ("--type-depth-limit", "1"), "list[set]"),
+    # foo(foo) — self-reference: foo's arg references its own code_id, a cycle
+    # that topo sort cannot resolve, so a fallback resolution pass is required.
     ("foo", ("--type-depth-limit", "0"), "Callable"),
     ("foo", ("--type-depth-limit", "1"), "Callable[[Callable], None]"),
 ])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4062,14 +4062,17 @@ def test_self_subtyping(python_version):
     output = Path("t.py").read_text()
     code = cst.parse_module(output)
 
-    # IntegerAdd IS-A NumberAdd, the enclosed class; so the argument should be 'Self'
+    # Single observation a.operation(b) where rhs (IntegerAdd) is a subclass of
+    # self (NumberAdd). With one trace and no exact-class match for rhs, we don't
+    # stamp Self on a non-arg0 parameter (would over-restrict: Self forbids
+    # b.operation(a), which Python accepts).
     if python_version == '3.10':
         assert get_function(code, 'NumberAdd.operation') == textwrap.dedent("""\
             def operation(self: "NumberAdd", rhs: "NumberAdd") -> "NumberAdd": ...
         """)
     else:
         assert get_function(code, 'NumberAdd.operation') == textwrap.dedent("""\
-            def operation(self: Self, rhs: Self) -> Self: ...
+            def operation(self: Self, rhs: "NumberAdd") -> Self: ...
         """)
 
 
@@ -4149,6 +4152,144 @@ def test_self_subtyping_reversed_too(python_version):
         assert get_function(code, 'NumberAdd.operation') == textwrap.dedent("""\
             def operation(self: Self, rhs: "NumberAdd") -> Self: ...
         """)
+
+
+def test_self_unrelated_subclass_arg():
+    """When rhs receives a subclass of self's class (only once), SelfTransformer
+    over-stamps it as is_self=True. simplify can't undo it because there's only
+    one observation, so the result is `rhs: Self` — but that annotation forbids
+    the inverse call b.operation(a), which the actual code accepts.
+
+    The right detection rule is "rhs's observed type matches self's observed
+    type across all traces." Here rhs is IntegerAdd while self is NumberAdd —
+    different types — so Self is incorrect. SelfTransformer in recorder.py
+    only checks MRO compatibility (rhs's type's MRO contains self_type), which
+    is too permissive.
+    """
+    t = textwrap.dedent("""\
+        class NumberAdd:
+            def operation(self, rhs):
+                # rhs is not accessed inside the method, so accessed_attributes is empty
+                return self
+
+        class IntegerAdd(NumberAdd):
+            pass
+
+        a = NumberAdd()
+        b = IntegerAdd()
+        a.operation(b)  # single call: self=NumberAdd, rhs=IntegerAdd
+        """)
+
+    Path("t.py").write_text(t)
+
+    rt_run('--python-version=3.11', 't.py')
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+
+    # The correct annotation: rhs is observed only as IntegerAdd (a NumberAdd subclass);
+    # it should be NumberAdd (or IntegerAdd), NOT Self. Self would forbid b.operation(a).
+    assert get_function(code, 'NumberAdd.operation') == textwrap.dedent("""\
+        def operation(self: Self, rhs: "NumberAdd") -> Self: ...
+    """)
+
+
+def test_self_widen_abstract_retval():
+    """Phase 2 widening from children's Self retvals into an abstract parent
+    should re-stamp Self in the parent's annotation (not collapse to concrete)."""
+    t = textwrap.dedent("""\
+        from abc import ABC, abstractmethod
+        class Base(ABC):
+            @abstractmethod
+            def factory(self): ...
+        class A(Base):
+            def factory(self):
+                return self
+        class B(Base):
+            def factory(self):
+                return self
+        A().factory()
+        B().factory()
+        """)
+
+    Path("t.py").write_text(t)
+
+    rt_run('--python-version=3.11', 't.py')
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+
+    # Parent retval widened from children's Self → re-stamp keeps it Self.
+    assert get_function(code, 'Base.factory') == textwrap.dedent("""\
+        def factory(self: Self) -> Self: ...
+    """)
+    assert get_function(code, 'A.factory') == textwrap.dedent("""\
+        def factory(self: Self) -> Self: ...
+    """)
+    assert get_function(code, 'B.factory') == textwrap.dedent("""\
+        def factory(self: Self) -> Self: ...
+    """)
+
+
+def test_self_widen_lsp_arg():
+    """Phase 3 widening: child's `other` arg widened from parent's `other: Self`.
+    With substitution (parent's Self → Parent), child's other becomes Parent —
+    Liskov-compatible with parent's signature."""
+    t = textwrap.dedent("""\
+        class Parent:
+            def merge(self, other):
+                return self
+        class Child(Parent):
+            def merge(self, other):
+                return self
+        Parent().merge(Parent())
+        Child().merge(Child())
+        """)
+
+    Path("t.py").write_text(t)
+
+    rt_run('--python-version=3.11', 't.py')
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+
+    # Each method, observed once, has only one trace. Non-arg0/non-retval
+    # parameter `other` is not stamped Self from a single observation. So
+    # parent's `other` is "Parent" (concrete). After Phase 3, child's `other`
+    # widens from parent's: child sees {Parent (after substitution), Self_child→Child}
+    # → lub Parent. Re-stamp Parent==Child? no → stays Parent.
+    assert get_function(code, 'Parent.merge') == textwrap.dedent("""\
+        def merge(self: Self, other: "Parent") -> Self: ...
+    """)
+    assert get_function(code, 'Child.merge') == textwrap.dedent("""\
+        def merge(self: Self, other: "Parent") -> Self: ...
+    """)
+
+
+def test_self_widen_callable_retval():
+    """Method returning a Callable involving Self. Tests that nested Self
+    survives widening across class hierarchy."""
+    t = textwrap.dedent("""\
+        from typing import Callable
+        class A:
+            def factory(self):
+                return lambda: self
+        class B(A):
+            pass
+        A().factory()()
+        B().factory()()
+        """)
+
+    Path("t.py").write_text(t)
+
+    rt_run('--python-version=3.11', 't.py')
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+
+    # B inherits without override: same code_id, single annotation on A.factory.
+    # Retval is observed as a function returning A or B (matching self class
+    # in each trace). Recursive Self detection inside the Callable's retval
+    # position stamps the inner type as Self.
+    fn = get_function(code, 'A.factory')
+    assert 'def factory(self: Self)' in fn
+    assert 'Callable[[], Self]' in fn or 'Callable[..., Self]' in fn
 
 
 def test_returns_or_yields_generator():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1265,8 +1265,12 @@ def test_method_overriding_typeshed():
     output = Path("t.py").read_text()
     code = cst.parse_module(output)
 
+    # `other: object` from typeshed's signature for object.__eq__. With single
+    # observation (self=C, other=C), Self detection on non-arg0/non-retval
+    # requires >= 2 traces, so `other` doesn't become Self. The merge with
+    # typeshed's object widens it correctly.
     assert get_function(code, 'C.__eq__') == textwrap.dedent("""\
-        def __eq__(self: Self, other: object|Self) -> bool: ...
+        def __eq__(self: Self, other: object) -> bool: ...
     """)
 
     assert "\nimport Self" not in output
@@ -1291,7 +1295,7 @@ def test_method_overriding_typeshed_ignore_annotations():
     code = cst.parse_module(output)
 
     assert get_function(code, 'C.__eq__') == textwrap.dedent("""\
-        def __eq__(self: Self, other: object|Self) -> bool: ...
+        def __eq__(self: Self, other: object) -> bool: ...
     """)
 
 
@@ -1312,7 +1316,7 @@ def test_method_overriding_inherited_typeshed():
     code = cst.parse_module(output)
 
     assert get_function(code, 'Comparable.__eq__') == textwrap.dedent("""\
-        def __eq__(self: Self, other: object|Self) -> bool: ...
+        def __eq__(self: Self, other: object) -> bool: ...
     """)
 
 
@@ -4155,16 +4159,13 @@ def test_self_subtyping_reversed_too(python_version):
 
 
 def test_self_unrelated_subclass_arg():
-    """When rhs receives a subclass of self's class (only once), SelfTransformer
-    over-stamps it as is_self=True. simplify can't undo it because there's only
-    one observation, so the result is `rhs: Self` — but that annotation forbids
-    the inverse call b.operation(a), which the actual code accepts.
+    """When rhs receives a subclass of self's class (only once), it must not be
+    typed as `Self`. The annotation `rhs: Self` would forbid the inverse call
+    b.operation(a), which the actual code accepts.
 
-    The right detection rule is "rhs's observed type matches self's observed
-    type across all traces." Here rhs is IntegerAdd while self is NumberAdd —
-    different types — so Self is incorrect. SelfTransformer in recorder.py
-    only checks MRO compatibility (rhs's type's MRO contains self_type), which
-    is too permissive.
+    The detection rule is "rhs's observed type matches self's observed type
+    across all traces." Here rhs is IntegerAdd while self is NumberAdd —
+    different types — so Self is incorrect; rhs should be NumberAdd (concrete).
     """
     t = textwrap.dedent("""\
         class NumberAdd:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -21,7 +21,15 @@ def tmp_cwd(tmp_path, monkeypatch):
     yield tmp_path
 
 
-MYPY_CACHE_DIR = Path.cwd() / '.mypy_tests_cache'
+# Per-worker cache dir under pytest-xdist: mypy's SQLite cache doesn't tolerate
+# concurrent writers from sibling workers ("database is locked"). Falls back to
+# a single shared dir for serial runs.
+import os
+_mypy_worker_id = os.environ.get('PYTEST_XDIST_WORKER')
+MYPY_CACHE_DIR = (
+    Path.cwd() / f'.mypy_tests_cache_{_mypy_worker_id}' if _mypy_worker_id
+    else Path.cwd() / '.mypy_tests_cache'
+)
 
 @pytest.fixture(scope='function', autouse=True)
 def runmypy(tmp_cwd, request):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4202,9 +4202,11 @@ def test_self_unrelated_subclass_arg():
     """)
 
 
-def test_self_widen_abstract_retval():
+@pytest.mark.parametrize("python_version", ["3.10", "3.11"])
+def test_self_widen_abstract_retval(python_version):
     """Phase 2 widening from children's Self retvals into an abstract parent
-    should re-stamp Self in the parent's annotation (not collapse to concrete)."""
+    should re-stamp Self in the parent's annotation (not collapse to concrete).
+    Targeting 3.10 verifies no Self leaks through the re-stamp path."""
     t = textwrap.dedent("""\
         from abc import ABC, abstractmethod
         class Base(ABC):
@@ -4222,24 +4224,30 @@ def test_self_widen_abstract_retval():
 
     Path("t.py").write_text(t)
 
-    rt_run('--python-version=3.11', 't.py')
+    rt_run(f'--python-version={python_version}', 't.py')
     output = Path("t.py").read_text()
     code = cst.parse_module(output)
 
-    # Parent retval widened from children's Self → re-stamp keeps it Self.
-    assert get_function(code, 'Base.factory') == textwrap.dedent("""\
-        @abstractmethod
-        def factory(self: Self) -> Self: ...
-    """)
-    assert get_function(code, 'A.factory') == textwrap.dedent("""\
-        def factory(self: Self) -> Self: ...
-    """)
-    assert get_function(code, 'B.factory') == textwrap.dedent("""\
-        def factory(self: Self) -> Self: ...
-    """)
+    if python_version == "3.11":
+        # Parent retval widened from children's Self → re-stamp keeps it Self.
+        assert get_function(code, 'Base.factory') == textwrap.dedent("""\
+            @abstractmethod
+            def factory(self: Self) -> Self: ...
+        """)
+        assert get_function(code, 'A.factory') == textwrap.dedent("""\
+            def factory(self: Self) -> Self: ...
+        """)
+        assert get_function(code, 'B.factory') == textwrap.dedent("""\
+            def factory(self: Self) -> Self: ...
+        """)
+    else:
+        assert 'Self' not in output, (
+            f"unexpected typing.Self in {python_version}-target output:\n{output}"
+        )
 
 
-def test_self_widen_lsp_arg():
+@pytest.mark.parametrize("python_version", ["3.10", "3.11"])
+def test_self_widen_lsp_arg(python_version):
     """Phase 3 widening: child's `other` arg widened from parent's `other: Self`.
     With substitution (parent's Self → Parent), child's other becomes Parent —
     Liskov-compatible with parent's signature."""
@@ -4256,31 +4264,39 @@ def test_self_widen_lsp_arg():
 
     Path("t.py").write_text(t)
 
-    rt_run('--python-version=3.11', 't.py')
+    rt_run(f'--python-version={python_version}', 't.py')
     output = Path("t.py").read_text()
     code = cst.parse_module(output)
 
-    # Each method, observed once, has only one trace. Non-arg0/non-retval
-    # parameter `other` is not stamped Self from a single observation. So
-    # parent's `other` is Parent (concrete; forward-ref quoted only because
-    # the method is inside the class definition). After Phase 3, child's
-    # `other` widens from parent's: child sees {Parent (after substitution),
-    # Self_child→Child} → lub Parent. Re-stamp Parent==Child? no → stays Parent.
-    assert get_function(code, 'Parent.merge') == textwrap.dedent("""\
-        def merge(self: Self, other: "Parent") -> Self: ...
-    """)
-    # Child references Parent which is defined earlier — no forward-ref quotes.
-    assert get_function(code, 'Child.merge') == textwrap.dedent("""\
-        def merge(self: Self, other: Parent) -> Self: ...
-    """)
+    if python_version == "3.11":
+        # Each method, observed once, has only one trace. Non-arg0/non-retval
+        # parameter `other` is not stamped Self from a single observation. So
+        # parent's `other` is Parent (concrete; forward-ref quoted only because
+        # the method is inside the class definition). After Phase 3, child's
+        # `other` widens from parent's: child sees {Parent (after substitution),
+        # Self_child→Child} → lub Parent. Re-stamp Parent==Child? no → stays Parent.
+        assert get_function(code, 'Parent.merge') == textwrap.dedent("""\
+            def merge(self: Self, other: "Parent") -> Self: ...
+        """)
+        # Child references Parent which is defined earlier — no forward-ref quotes.
+        assert get_function(code, 'Child.merge') == textwrap.dedent("""\
+            def merge(self: Self, other: Parent) -> Self: ...
+        """)
+    else:
+        assert 'Self' not in output, (
+            f"unexpected typing.Self in {python_version}-target output:\n{output}"
+        )
 
 
-def test_self_widen_callable_retval():
+@pytest.mark.parametrize("python_version", ["3.10", "3.11"])
+def test_self_widen_callable_retval(python_version):
     """Method returns a Callable that itself returns self. ResolvingT pulls in
     the lambda's resolved retval (a concrete A after lub-merging A|B from the
     two trace receivers); we need Self detection to recover Self at the inner
     Callable position because the lambda's retval matches the outer method's
-    self_class."""
+    self_class. Targeting 3.10 verifies _clone_for_context's can_restamp
+    branch respects use_typing_self and does not inject Self.
+    """
     t = textwrap.dedent("""\
         from typing import Callable
         class A:
@@ -4294,17 +4310,22 @@ def test_self_widen_callable_retval():
 
     Path("t.py").write_text(t)
 
-    rt_run('--python-version=3.11', 't.py')
+    rt_run(f'--python-version={python_version}', 't.py')
     output = Path("t.py").read_text()
     code = cst.parse_module(output)
 
-    # B inherits without override: same code_id, single annotation on A.factory.
-    # Retval is observed as a function returning A or B (matching self class
-    # in each trace). Recursive Self detection inside the Callable's retval
-    # position stamps the inner type as Self.
-    fn = get_function(code, 'A.factory')
-    assert 'def factory(self: Self)' in fn
-    assert 'Callable[[], Self]' in fn or 'Callable[..., Self]' in fn
+    if python_version == "3.11":
+        # B inherits without override: same code_id, single annotation on A.factory.
+        # Retval is observed as a function returning A or B (matching self class
+        # in each trace). Recursive Self detection inside the Callable's retval
+        # position stamps the inner type as Self.
+        fn = get_function(code, 'A.factory')
+        assert 'def factory(self: Self)' in fn
+        assert 'Callable[[], Self]' in fn or 'Callable[..., Self]' in fn
+    else:
+        assert 'Self' not in output, (
+            f"unexpected typing.Self in {python_version}-target output:\n{output}"
+        )
 
 
 def test_returns_or_yields_generator():

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1305,46 +1305,6 @@ def test_from_set_default_limit_allows_normal_unions():
     assert len(t.args) == 9
 
 
-def test_clear_code_id_deduplicates_union():
-    """ClearCodeIdT should clear code_id and deduplicate resulting unions."""
-    from righttyper.type_transformers import ClearCodeIdT
-    from righttyper.typeinfo import UnionTypeInfo
-    from righttyper.righttyper_types import CodeId
-    import collections.abc
-
-    base = TypeInfo.from_type(collections.abc.Callable)
-    a = base.replace(code_id=CodeId("a.py", "f", 1, 0))
-    b = base.replace(code_id=CodeId("b.py", "g", 1, 0))
-    c = TypeInfo.from_type(int)
-
-    # Union with 3 members: two Callables differing only in code_id, plus int
-    union = UnionTypeInfo.from_type(UnionTypeInfo, args=(a, b, c))
-    assert len(union.args) == 3
-
-    result = ClearCodeIdT().visit(union)
-    # Should deduplicate to Callable | int
-    if isinstance(result, UnionTypeInfo):
-        assert len(result.args) == 2
-    else:
-        assert result.type_obj in (collections.abc.Callable, int)
-
-
-def test_clear_code_id_non_union():
-    """ClearCodeIdT should clear code_id on non-union nodes too."""
-    from righttyper.type_transformers import ClearCodeIdT
-    from righttyper.righttyper_types import CodeId
-    import collections.abc
-
-    node = TypeInfo.from_type(collections.abc.Callable).replace(
-        code_id=CodeId("a.py", "f", 1, 0)
-    )
-    assert node.code_id is not None
-
-    result = ClearCodeIdT().visit(node)
-    assert result.code_id is None
-    assert result.type_obj is collections.abc.Callable
-
-
 def test_merge_observations_unions_overrides_lists():
     """merge_observations must reconcile FuncInfo entries whose overrides
     lists differ in depth.

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -533,6 +533,26 @@ def name(t: type):
     return f"{t.__module__}.{t.__qualname__}"
 
 
+def test_merged_types_superclass_abc():
+    """simplify should merge ABC subclasses to their common base. The check for
+    "is this a class with MRO" must accept ABC classes (whose metaclass is
+    ABCMeta, not type)."""
+    from abc import ABC, abstractmethod
+    class Base(ABC):
+        @abstractmethod
+        def factory(self): ...
+    class A(Base):
+        def factory(self): return self
+    class B(Base):
+        def factory(self): return self
+
+    assert f"{name(Base)}" == str(merged_types({
+            TypeInfo.from_type(A),
+            TypeInfo.from_type(B),
+        }
+    ))
+
+
 def test_merged_types_superclass_checks_attributes():
     class A: pass
     class B(A):


### PR DESCRIPTION
## Summary

Replaces the per-TypeInfo `is_self: bool` flag with structural Self detection driven from per-trace receiver classes. Self detection moves from trace-record time (`SelfTransformer` in `recorder.py`) to annotation-build time (`mk_annotation` in `observations.py`).

The old approach over-stamped `is_self=True` on any value whose class was a subtype of the receiver, producing wrong annotations like `def operation(self: Self, rhs: Self)` when `rhs` was just a subclass of `self`'s class observed once. Captured by the new `test_self_unrelated_subclass_arg` regression test.

## What changed

- `is_self` field removed from `TypeInfo`; equality and merging no longer carry it.
- `CallTrace` is now a `tuple[TypeInfo, ...]` subclass with `first_arg_class` metadata recorded at trace time.
- Self is detected in `mk_annotation` by structural per-position match across traces (arg0 / retval always, other args only with ≥2 traces).
- `FuncAnnotation.self_class` and `FuncInfo.defining_class` plumbed through; cross-annotation cloning (`_clone_for_context`) substitutes/keeps/restamps `Self` based on source/destination contexts.
- `_widen_annotation` now substitutes `Self` -> concrete (Liskov) when widening parent ← children, and preserves Self via the `keep_self` rule when source.self_class is a subclass of destination's.
- Code-id resolution pushed into `mk_annotation` per-trace (driven by topo sort over the code_id graph). Module-vars and per-function vars resolved inline; a fallback `ResolvingT` pass remains for cycles/self-references.
- `PKL_FILE_VERSION` bumped to 7 (CallTrace gained `first_arg_class`; TypeInfo lost `is_self`).
- Test suite now runs in parallel via pytest-xdist (`-n auto`); ~7min -> ~55s.

## Test plan

- [x] `test_self_unrelated_subclass_arg` — new regression test for the original bug.
- [x] `test_self_widen_abstract_retval`, `test_self_widen_lsp_arg`, `test_self_widen_callable_retval` — widening behavior.
- [x] `test_self_detection_through_collect_and_process` — `.rt` collect/process round-trip.
- [x] `test_self_subtyping` updated (old expectation reflected the bug).
- [x] All Self-related integration tests still pass (`tests/test_integration.py -k 'self or Self'`).
- [x] Full suite: 719 passed, 8 skipped, 4 xfailed (no new skips/xfails).

## Notes for reviewer

- The branch fixes a count-loss bug in `FuncInfo.transform_types` that pre-dates this work — separated as `e0651d7`.
- Topo sort now walks arg defaults and override `inline_arg_types` so per-trace resolution sees a complete dependency order.
- `_CloneForContextT` is hoisted to module level to avoid rebuilding the inner class per call (hot path in `_widen_annotation`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)