### PR TITLE
Fix mypy errors and __main__ pickling regression in multiprocessing

### DIFF
--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -451,7 +451,7 @@ def generalize_jaxtyping(samples: Sequence[CallTrace]) -> Sequence[CallTrace]:
             results.append([s[argno] for s in samples])
 
     # Transpose once more to finish up
-    return list(tuple(t) for t in zip(*results))
+    return [CallTrace(t) for t in zip(*results)]
 
 
 def generalize(samples: Sequence[CallTrace]) -> list[TypeInfo]|None:

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -903,6 +903,13 @@ class Observations:
 
                 _visit_dict(annotation.variables, tr, tr_name, prefix)
 
+                if annotation.self_class is not None:
+                    sc_prime = tr.visit(annotation.self_class)
+                    if sc_prime is not annotation.self_class:
+                        if logger.level == logging.DEBUG:
+                            logger.debug(f"{tr_name} {prefix}self_class: {annotation.self_class} -> {sc_prime}")
+                        annotation.self_class = sc_prime
+
             for filename, mv in module_vars.items():
                 module = self.source_to_module_name.get(filename, filename)
                 _visit_dict(mv.variables, tr, tr_name, f"{module} ")

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -390,7 +390,7 @@ class ResolvingT(TypeInfo.Transformer):
         if node.code_id:
             node = node.replace(code_id=None)
         if pre is not node and isinstance(node, UnionTypeInfo):
-            node = TypeInfo.from_set(set(node.args), typevar_index=node.typevar_index)
+            node = TypeInfo.from_set(node.to_set(), typevar_index=node.typevar_index)
 
         return node
 

--- a/righttyper/recorder.py
+++ b/righttyper/recorder.py
@@ -226,7 +226,7 @@ class ObservationsRecorder:
 
 
     def _register_parent_function(
-        self, child_fi: FuncInfo, parent_func: FunctionType, finder: 'OverrideFinder',
+        self, child_fi: FuncInfo, parent_func: CallableWithCode, finder: 'OverrideFinder',
         parent_defining_class: TypeInfo | None,
     ) -> None:
         """Registers all ancestor functions that the child overrides.
@@ -446,7 +446,6 @@ class ObservationsRecorder:
 
         f_locals = frame.f_locals
         prefix = codevars.var_prefix
-        value: Any
 
         for var_name, const_type in codevars.variables.items():
             qualified = f"{prefix}{var_name}"
@@ -778,7 +777,10 @@ class SelfTypeInfo:
     self_type: TypeInfo | None = None
     self_replacement: TypeInfo | None = None
     overrides: list[OverriddenFunction] = field(default_factory=list)
-    parent_func: FunctionType | None = None
+    # Typed as CallableWithCode (a Protocol) rather than FunctionType to avoid
+    # typeshed's descriptor-protocol behavior on instance access — accessing a
+    # FunctionType-typed dataclass field via an instance reports MethodType.
+    parent_func: CallableWithCode | None = None
     parent_defining_class: TypeInfo | None = None  # defining class of parent_func
     override_finder: OverrideFinder | None = None  # for walking the parent chain
 

--- a/righttyper/type_transformers.py
+++ b/righttyper/type_transformers.py
@@ -84,17 +84,12 @@ class ExcludeTestTypesT(TypeInfo.Transformer):
         # the recursive visit replace them with Unknown/Any, which would
         # poison the whole union (X | Any = Any).
         if isinstance(node, UnionTypeInfo):
-            non_test = tuple(
-                a for a in node.args
-                if not (isinstance(a, TypeInfo) and self._is_test_module(a.module))
-            )
+            non_test = {a for a in node.to_set() if not self._is_test_module(a.module)}
             if len(non_test) < len(node.args):
-                if not non_test or non_test == (NoneTypeInfo,):
+                if not non_test or non_test == {NoneTypeInfo}:
                     # All useful types removed — we don't know the real type.
                     return UnknownTypeInfo
-                node = TypeInfo.from_set(
-                    set(non_test), typevar_index=node.typevar_index
-                )
+                node = TypeInfo.from_set(non_test, typevar_index=node.typevar_index)
 
         return super().visit(node)
 

--- a/righttyper/typeinfo.py
+++ b/righttyper/typeinfo.py
@@ -1,5 +1,5 @@
 import typing
-from typing import Iterator, Iterable, Final, Callable, Any
+from typing import Iterator, Iterable, Final, Callable, Any, cast
 import types
 from dataclasses import dataclass, replace, field
 from righttyper.righttyper_types import CodeId
@@ -203,7 +203,8 @@ class UnionTypeInfo(TypeInfo):
 
 
     def to_set(self) -> set["TypeInfo"]:
-        return set(t for t in self.args if isinstance(t, TypeInfo))
+        # Union args are always TypeInfo by construction.
+        return cast(set["TypeInfo"], set(self.args))
 
 
     def format(self, modifier: Callable[["TypeInfo"], str|None]|None=None) -> str:

--- a/righttyper/unified_transformer.py
+++ b/righttyper/unified_transformer.py
@@ -9,7 +9,7 @@ from righttyper.variable_binding import VariableBindingProvider
 import re
 
 from righttyper.typeinfo import TypeInfo
-from righttyper.righttyper_types import Filename, CodeId, FunctionName
+from righttyper.righttyper_types import Filename, CodeId, FunctionName, VariableName, ArgumentName
 from righttyper.annotation import FuncAnnotation, ModuleVars, TraceDistribution
 
 
@@ -188,7 +188,7 @@ class UnifiedTransformer(cst.CSTTransformer):
     ) -> None:
         self.filename = filename
         self.type_annotations = type_annotations
-        self.module_variables: dict[str, TypeInfo] = module_variables.variables if module_variables else {}
+        self.module_variables: dict[VariableName, TypeInfo] = module_variables.variables if module_variables else {}
         self.module_name = module_name
         self.override_annotations = override_annotations
         self.only_update_annotations = only_update_annotations
@@ -342,7 +342,7 @@ class UnifiedTransformer(cst.CSTTransformer):
 
     def _process_generics(
         self,
-        annmap: dict[str, TypeInfo],
+        annmap: dict[ArgumentName, TypeInfo],
         used_inline_names: set[str],
         reserved_names: list[str] | None = None,
     ) -> dict[TypeInfo, str]:
@@ -356,12 +356,17 @@ class UnifiedTransformer(cst.CSTTransformer):
 
             def visit(vself, node: TypeInfo) -> TypeInfo:
                 if node.typevar_index and node not in vself.generics:
+                    name: str
                     if self.inline_generics:
-                        name = next(reserved_iter, None) if reserved_iter else None
-                        if name is None or name in used_inline_names:
+                        candidate = next(reserved_iter, None) if reserved_iter else None
+                        if candidate is None or candidate in used_inline_names:
                             i = 1
-                            while (name := f"T{i}") in used_inline_names:
+                            while (candidate := f"T{i}") in used_inline_names:
                                 i += 1
+                        # candidate is now a str — either the reserved name or the
+                        # walrus loop's last assignment (the loop runs at least once).
+                        assert candidate is not None
+                        name = candidate
                         used_inline_names.add(name)
                     else:
                         while self._is_defined(name := f"rt_T{self.module_generic_index}"):
@@ -572,7 +577,9 @@ class UnifiedTransformer(cst.CSTTransformer):
         if (func_scope_index := list_rindex(self.name_stack, '<locals>')):
             func_scope_index = len(self.name_stack) + func_scope_index + 1
 
-        qualname = ".".join(self.name_stack[func_scope_index:] + [_nodes_to_dotted_name(target)])
+        qualname = VariableName(
+            ".".join(self.name_stack[func_scope_index:] + [_nodes_to_dotted_name(target)])
+        )
         if func_scope_index:
             if (ann := self.func_ann_stack[-1]):
                 return ann.variables.get(qualname)
@@ -1008,8 +1015,9 @@ class UnifiedTransformer(cst.CSTTransformer):
 
             for par in typing.cast(typing.Iterator[cst.Param],
                                    cstm.findall(updated_node.params, cstm.Param())):
-                if par.name.value in annmap and not _will_update(par.annotation):
-                    del annmap[par.name.value]
+                par_name = ArgumentName(par.name.value)
+                if par_name in annmap and not _will_update(par.annotation):
+                    del annmap[par_name]
 
             pre_function: list[cst.SimpleStatementLine | cst.BaseCompoundStatement] = []
             overloads = self.overload_stack[-1]
@@ -1033,7 +1041,9 @@ class UnifiedTransformer(cst.CSTTransformer):
                                             cstm.findall(updated_node.returns, cstm.Name()))
                 }
             else:
-                annmap['return'] = ann.retval
+                # 'return' is a pseudo-arg name used to thread the return type
+                # through the same processing pipeline as parameter annotations.
+                annmap[ArgumentName('return')] = ann.retval
 
 #            print(f"{annmap.keys()=}")
 #            print(f"{retained_annotation_names=}")
@@ -1098,7 +1108,7 @@ class UnifiedTransformer(cst.CSTTransformer):
                 # Now update the parameters
                 class ParamChanger(cst.CSTTransformer):
                     def leave_Param(vself, node: cst.Param, updated_node: cst.Param) -> cst.Param:
-                        if (annotation := annmap.get(updated_node.name.value)) is None:
+                        if (annotation := annmap.get(ArgumentName(updated_node.name.value))) is None:
                             return updated_node
 
                         if (
@@ -1304,9 +1314,10 @@ class UnifiedTransformer(cst.CSTTransformer):
                 new_body.insert(if_type_checking_position, new_stmt)
 
             # Only need to import TYPE_CHECKING when we created a new block
+            inserted = new_body[if_type_checking_position]
             if (
-                isinstance(new_body[if_type_checking_position], cst.If)
-                and cstm.matches(new_body[if_type_checking_position].test, cstm.Name("TYPE_CHECKING"))
+                isinstance(inserted, cst.If)
+                and cstm.matches(inserted.test, cstm.Name("TYPE_CHECKING"))
                 and 'TYPE_CHECKING' not in self.known_names[-1]
             ):
                 self.unknown_types.add('TYPE_CHECKING')

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1154,6 +1154,30 @@ def test_method_overriding_inherited():
     """)
 
 
+def test_run_with_multiprocessing_method_in_main():
+    """Regression: with multiprocessing enabled, running rt on a script that
+    defines a class with methods used to fail with 'PicklingError: Can't
+    pickle <class __main__.X>' because FuncAnnotation.self_class carried a
+    live type_obj past the MakePickleableT finalizer."""
+    Path("t.py").write_text(textwrap.dedent("""\
+        class C:
+            def foo(self, x):
+                pass
+
+        C().foo(10)
+    """))
+
+    # rt_run defaults to --no-use-multiprocessing; --use-multiprocessing
+    # appended later wins (click last-wins).
+    rt_run('--use-multiprocessing', 't.py')
+
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+    assert get_function(code, 'C.foo') == textwrap.dedent("""\
+        def foo(self: Self, x: int) -> None: ...
+    """)
+
+
 def test_method_overriding_arg_names_change():
     Path("t.py").write_text(textwrap.dedent("""\
         class C:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4320,6 +4320,7 @@ def test_self_widen_callable_retval(python_version):
         # in each trace). Recursive Self detection inside the Callable's retval
         # position stamps the inner type as Self.
         fn = get_function(code, 'A.factory')
+        assert fn is not None
         assert 'def factory(self: Self)' in fn
         assert 'Callable[[], Self]' in fn or 'Callable[..., Self]' in fn
     else:
@@ -7541,6 +7542,7 @@ def test_no_type_parameters():
     code = cst.parse_module(output)
 
     func = get_function(code, 'f')
+    assert func is not None
     assert 'T1' not in func
     assert get_function(code, 'f') == textwrap.dedent("""\
         def f(x: list[int|str]) -> int|str: ...


### PR DESCRIPTION
## Summary

- **Fix mypy errors** across `righttyper/` and `tests/` (17 errors → 0).
- **Fix multiprocessing pickling regression**: running rt on a script with class methods used to fail with \`PicklingError: Can't pickle <class __main__.X>\` when multiprocessing was enabled. \`FuncAnnotation.self_class\` (added with the Self refactor) was a TypeInfo not visited by the \`collect_annotations\` inner transform helper, so \`MakePickleableT\` didn't clear its \`type_obj\`.

## Test plan

- [x] \`python3.12 -m mypy righttyper/ tests/\` — clean.
- [x] New regression test \`test_run_with_multiprocessing_method_in_main\` runs rt with \`--use-multiprocessing\` against a script defining a class method and asserts the annotation is generated. Fails on main, passes after the fix.
- [x] Full suite green: 721 passed, 8 skipped, 4 xfailed.

## Notes for reviewer

- The mypy fixes are mostly mechanical NewType plumbing (\`ArgumentName\`, \`VariableName\`) and a typeshed-vs-dataclass quirk: a \`FunctionType\` field accessed via instance is reported as \`MethodType\` because typeshed models the descriptor protocol; switched \`SelfTypeInfo.parent_func\` and \`_register_parent_function\`'s parameter to \`CallableWithCode\` (a Protocol), which expresses the actual interface (just needs \`__code__\`) and isn't subject to descriptor invocation.
- \`UnionTypeInfo.to_set()\` now \`cast\`s instead of runtime-isinstance-filtering — union args are TypeInfo by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)