### PR TITLE
Fix annotation writer importing typing.Text over local class

### DIFF
--- a/righttyper/unified_transformer.py
+++ b/righttyper/unified_transformer.py
@@ -125,6 +125,16 @@ _DEPRECATED_TYPING_TYPES: typing.Final[tuple[tuple[str, str], ...]] = (
     ("typing.Sized",         "collections.abc.Sized"),
 )
 
+# Reverse map for deprecated typing aliases: fully qualified new name → typing
+# short name.  E.g. "collections.abc.Iterator" → "Iterator".  Used by the
+# Renamer to emit the typing short name (with a 'from typing import ...')
+# instead of the verbose collections.abc form.
+_DEPRECATED_TO_TYPING: dict[str, str] = {
+    new: old.removeprefix("typing.")
+    for old, new in _DEPRECATED_TYPING_TYPES
+    if old.startswith("typing.") and new.startswith("collections.abc.")
+}
+
 def _dotted_name_to_nodes(name: str) -> cst.Attribute | cst.Name:
     """Creates Attribute/Name to build a module name, dotted or not."""
     parts = name.split(".")
@@ -281,17 +291,19 @@ class UnifiedTransformer(cst.CSTTransformer):
                     (a := self.aliases.get(node.fullname()))
                     and (not self._is_defined(a) or self._name_is(a, node.fullname()))
                 ):
-                    if a in _TYPING_TYPES and not self._is_defined(a):
-                        self.needed_typing_imports.add(a)
                     return node.replace(module='', name=a)
 
-                # typing types not in aliases: use short name as-needed,
-                # unless a local name would be shadowed.
-                if node.module == 'typing' and node.name in _TYPING_TYPES:
-                    if not self._is_defined(node.name):
-                        self.aliases[node.fullname()] = node.name
-                        self.needed_typing_imports.add(node.name)
-                        return node.replace(module='')
+                # typing types: use short name as-needed and track the import.
+                # Handles both direct typing.X and deprecated aliases
+                # (e.g. collections.abc.Iterator → Iterator via typing).
+                typing_name = (
+                    node.name if node.module == 'typing' and node.name in _TYPING_TYPES
+                    else _DEPRECATED_TO_TYPING.get(node.fullname())
+                )
+                if typing_name and not self._is_defined(typing_name):
+                    self.aliases[node.fullname()] = typing_name
+                    self.needed_typing_imports.add(typing_name)
+                    return node.replace(module='', name=typing_name)
 
                 assert node.module
                 if node.module:
@@ -415,13 +427,6 @@ class UnifiedTransformer(cst.CSTTransformer):
         # as-needed by the Renamer, which checks for collisions with locally
         # defined names and tracks the result in needed_typing_imports.
         self.aliases: dict[str, str] = {}
-
-        # Reverse map for deprecated typing aliases: when the Renamer sees
-        # e.g. collections.abc.Iterator, it can use the short typing name
-        # (Iterator) and add it to needed_typing_imports.
-        for old, new in _DEPRECATED_TYPING_TYPES:
-            if old.startswith('typing.') and new.startswith('collections.abc'):
-                self.aliases[new] = old[7:]
 
         # Typing names that the Renamer actually used (e.g. typing.Self → Self).
         # Drives import emission instead of guessing via _TYPING_TYPES.

--- a/righttyper/unified_transformer.py
+++ b/righttyper/unified_transformer.py
@@ -281,7 +281,17 @@ class UnifiedTransformer(cst.CSTTransformer):
                     (a := self.aliases.get(node.fullname()))
                     and (not self._is_defined(a) or self._name_is(a, node.fullname()))
                 ):
+                    if a in _TYPING_TYPES and not self._is_defined(a):
+                        self.needed_typing_imports.add(a)
                     return node.replace(module='', name=a)
+
+                # typing types not in aliases: use short name as-needed,
+                # unless a local name would be shadowed.
+                if node.module == 'typing' and node.name in _TYPING_TYPES:
+                    if not self._is_defined(node.name):
+                        self.aliases[node.fullname()] = node.name
+                        self.needed_typing_imports.add(node.name)
+                        return node.replace(module='')
 
                 assert node.module
                 if node.module:
@@ -400,18 +410,22 @@ class UnifiedTransformer(cst.CSTTransformer):
         self.known_names: list[set[str]] = [set(_BUILTIN_TYPES)]
 
         # global aliases from 'from .. import ..' and 'import .. as ..';
-        # maps from qualified name to local name
-        self.aliases: dict[str, str] = {
-            # we will add any such "typing." names, so add them as aliases
-            f"typing.{t}": t
-            for t in _TYPING_TYPES
-        }
+        # maps from qualified name to local name.
+        # Note: typing names are NOT pre-populated here.  They are resolved
+        # as-needed by the Renamer, which checks for collisions with locally
+        # defined names and tracks the result in needed_typing_imports.
+        self.aliases: dict[str, str] = {}
 
-        # We automatically import 'typing' types, so for now it is convenient
-        # to continue using 'typing', by default (unless imported)
+        # Reverse map for deprecated typing aliases: when the Renamer sees
+        # e.g. collections.abc.Iterator, it can use the short typing name
+        # (Iterator) and add it to needed_typing_imports.
         for old, new in _DEPRECATED_TYPING_TYPES:
             if old.startswith('typing.') and new.startswith('collections.abc'):
                 self.aliases[new] = old[7:]
+
+        # Typing names that the Renamer actually used (e.g. typing.Self → Self).
+        # Drives import emission instead of guessing via _TYPING_TYPES.
+        self.needed_typing_imports: set[str] = set()
 
         # "import ... as ..." within "if TYPE_CHECKING:".
         self.if_checking_aliases: dict[str, str] = dict()
@@ -931,7 +945,7 @@ class UnifiedTransformer(cst.CSTTransformer):
 
         if (
             self.always_quote_annotations
-            or (not self.has_future_annotations and (unknown.types - _TYPING_TYPES))
+            or (not self.has_future_annotations and (unknown.types - self.needed_typing_imports))
         ):
             annotation_expr = cst.SimpleString(_quote(str(annotation)))
 
@@ -1093,7 +1107,7 @@ class UnifiedTransformer(cst.CSTTransformer):
                                        ])
                             )
                         ]))
-                        self.unknown_types.add("TypeVar")
+                        self.needed_typing_imports.add("TypeVar")
 
                 # Now update the parameters
                 class ParamChanger(cst.CSTTransformer):
@@ -1224,7 +1238,7 @@ class UnifiedTransformer(cst.CSTTransformer):
             mod
             for mod in (
                 self._module_for(t)[0]
-                for t in self.unknown_types - _TYPING_TYPES
+                for t in self.unknown_types - self.needed_typing_imports
                 if '.' in t
                 and t.split('.')[0] not in self.known_names[-1]
             )
@@ -1309,10 +1323,10 @@ class UnifiedTransformer(cst.CSTTransformer):
                 and cstm.matches(new_body[if_type_checking_position].test, cstm.Name("TYPE_CHECKING"))
                 and 'TYPE_CHECKING' not in self.known_names[-1]
             ):
-                self.unknown_types.add('TYPE_CHECKING')
+                self.needed_typing_imports.add('TYPE_CHECKING')
 
         # Emit "from typing import ..."
-        if (typing_types := (self.unknown_types & _TYPING_TYPES)):
+        if (typing_types := set(self.needed_typing_imports)):
             existing = stmt_index(new_body, cstm.SimpleStatementLine(
                     body=[cstm.ImportFrom(module=cstm.Name("typing"))]
                 )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7601,3 +7601,33 @@ def test_exclude_test_types_preserves_union_members():
     assert get_function(code, 'f') == textwrap.dedent("""\
         def f(x: int|str) -> str: ...
     """)
+
+
+def test_local_class_not_imported_from_typing():
+    """When a class shares a name with a typing export (e.g. Text),
+    the annotation writer must not add 'from typing import Text' —
+    that would shadow the local class with typing.Text (str alias)."""
+    Path("t.py").write_text(textwrap.dedent("""\
+        class Text:
+            def append(self, other):
+                pass
+
+        t = Text()
+        t.append(Text())
+    """))
+
+    rt_run('t.py')
+    output = Path("t.py").read_text()
+
+    # The import line must not pull Text from typing
+    for line in output.splitlines():
+        if line.startswith("from typing import"):
+            assert "Text" not in line.split("import")[1], \
+                f"imported typing.Text, shadowing local class: {line}"
+
+    # The annotation should use the local Text class, quoted (because the
+    # class name isn't in scope during class body evaluation).
+    code = cst.parse_module(output)
+    assert get_function(code, 'Text.append') == textwrap.dedent("""\
+        def append(self: Self, other: "Text") -> None: ...
+    """)


### PR DESCRIPTION
Annotation writer assumed bare names matching `typing.__all__` should be imported from typing. This shadowed local classes like `Text` with `typing.Text` (a deprecated `str` alias). Now typing aliases are created as-needed with collision checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)