### PR TITLE
Stop __main__ types from leaking into package annotations

### DIFF
--- a/righttyper/recorder.py
+++ b/righttyper/recorder.py
@@ -665,6 +665,23 @@ class ObservationsRecorder:
             if is_test_module(mod_name)
         }
 
+        # If the runner script lives outside --root, treat its module as a
+        # test module: any classes defined in the runner are scaffolding,
+        # not part of any package's contract.
+        main_file = main_globals.get('__file__') if main_globals else None
+        if main_file and run_options.script_dir:
+            script_dir = Path(run_options.script_dir).resolve()
+            main_path = Path(main_file).resolve()
+            if not main_path.is_relative_to(script_dir):
+                if (
+                    (main_spec := main_globals.get('__spec__'))
+                    and main_spec.origin
+                    and (main_name := source_to_module_fqn(Path(main_spec.origin)))
+                ):
+                    obs.test_modules.add(main_name)
+                else:
+                    obs.test_modules.add('__main__')
+
         if run_options.exclude_test_files:
             # should_skip_function doesn't know to skip test files until they are detected,
             # so we can't help but get events for test modules while they are being loaded.

--- a/righttyper/typemap.py
+++ b/righttyper/typemap.py
@@ -75,6 +75,10 @@ class TypeMap:
             # str() because __module__ might be a getset_attribute (hello, cython)
             t_package = str(t.__module__).split('.')[0]
             return (
+                # prefer anything else over __main__: when a type is also reachable
+                # under a real module name (e.g. via 'from pkg._impl import C'), that
+                # name should win over the __main__ entry from main_globals
+                module == '__main__',
                 # prefer non-test to test
                 is_test_module(module),
                 # prefer public to private

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7657,3 +7657,56 @@ def test_local_class_not_imported_from_typing():
     assert get_function(code, 'Text.append') == textwrap.dedent("""\
         def append(self: Self, other: "Text") -> None: ...
     """)
+
+
+def test_main_module_types_not_leaked():
+    """Types imported by the __main__ script from a private submodule should
+    be annotated with their real module path, not __main__.
+    Uses --only-collect then process, like the eval pipeline.
+
+    The bug: runpy.run_path sets __spec__=None, so TypeMap falls through
+    to main_name='__main__'.  Then __main__ has is_private=False while
+    the private submodule (pkg._impl) has is_private=True, so __main__
+    wins the TypeMap sort and becomes the canonical name."""
+
+    # Package with a private submodule defining the type (no re-export)
+    Path("pkg").mkdir()
+    Path("pkg/__init__.py").write_text("")
+    Path("pkg/_impl.py").write_text(textwrap.dedent("""\
+        class Widget:
+            def render(self):
+                return "<widget>"
+    """))
+    Path("pkg/api.py").write_text(textwrap.dedent("""\
+        def process(w):
+            return w.render()
+    """))
+
+    # Exercise script OUTSIDE the --root tree.  Use an absolute path in
+    # /tmp so source_to_module_fqn can't resolve it to a module name
+    # (its parent dir isn't on sys.path) and main_name falls to "__main__".
+    import tempfile
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as f:
+        f.write(textwrap.dedent("""\
+            from pkg._impl import Widget
+            from pkg.api import process
+            process(Widget())
+        """))
+        script = f.name
+
+    try:
+        rt_run('--only-collect', '--root', '.', script)
+        rt_run('process', '--output-files', '--overwrite')
+    finally:
+        os.unlink(script)
+    output = Path("pkg/api.py").read_text()
+
+    # The annotation must NOT use __main__.Widget
+    assert "__main__" not in output, (
+        f"__main__ leaked into annotations:\n{output}"
+    )
+
+    code = cst.parse_module(output)
+    func = get_function(code, 'process')
+    # Accept either 'Widget' or 'pkg._impl.Widget' — the key check is no __main__
+    assert 'Widget' in func, f"Expected Widget in annotation, got: {func}"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7708,5 +7708,50 @@ def test_main_module_types_not_leaked():
 
     code = cst.parse_module(output)
     func = get_function(code, 'process')
-    # Accept either 'Widget' or 'pkg._impl.Widget' — the key check is no __main__
-    assert 'Widget' in func, f"Expected Widget in annotation, got: {func}"
+    assert func is not None
+    # Widget isn't imported in pkg/api.py, so the annotation must qualify it
+    # via its real module — pkg._impl.Widget (not __main__.Widget).
+    assert 'pkg._impl.Widget' in func, (
+        f"Expected pkg._impl.Widget in annotation, got: {func}"
+    )
+
+
+def test_main_module_defined_class_not_leaked():
+    """A class DEFINED in the exercise script (outside --root) is purely
+    test scaffolding from the package's perspective — it must not appear
+    in the package's annotations. RightTyper detects that the runner
+    script is outside --root and adds its main_name to obs.test_modules,
+    so ExcludeTestTypesT filters out types defined in it."""
+
+    Path("pkg").mkdir()
+    Path("pkg/__init__.py").write_text("")
+    Path("pkg/api.py").write_text(textwrap.dedent("""\
+        def process(w):
+            return w.render()
+    """))
+
+    # Exercise script OUTSIDE the --root tree, defining its OWN class.
+    import tempfile
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as f:
+        f.write(textwrap.dedent("""\
+            class MyWidget:
+                def render(self):
+                    return "<widget>"
+
+            from pkg.api import process
+            process(MyWidget())
+        """))
+        script = f.name
+
+    try:
+        rt_run('--only-collect', '--root', '.', script)
+        rt_run('process', '--output-files', '--overwrite')
+    finally:
+        os.unlink(script)
+
+    output = Path("pkg/api.py").read_text()
+    assert "__main__" not in output, output
+    # MyWidget is runner-only scaffolding; it should not appear in pkg.api's annotations.
+    assert "MyWidget" not in output, (
+        f"runner-defined MyWidget leaked into pkg's annotations:\n{output}"
+    )


### PR DESCRIPTION
## Summary

When a runner / exercise script lives outside the \`--root\` tree, types defined or imported in it can leak into the package's annotations as \`__main__.X\` (or the runner script's resolved fqn. Two compounding bugs:

- **TypeMap canonicalization picks `__main__` for imported types**: a type imported from a private submodule (e.g. `pkg._impl`) gets cataloged under both that module (`is_private=True`) and main_globals (`is_private=False`). The sort key preferred public over private and chose the `__main__` entry as canonical.
- **Types defined in the runner reach package annotations**: classes defined in the runner script (e.g. exercise scaffolding) end up in the package's function signatures (`def process(w: __main__.MyWidget)`).

## What changed

- **typemap.py**: demote `__main__` to lowest priority in `typename_key` so any real module wins as canonical.
- **recorder.py finish_recording**: when the runner script is outside `--root`, add its `main_name` to `obs.test_modules` so `ExcludeTestTypesT` filters out runner-defined types from package annotations.