### PR TITLE
Skip @overload typeshed stubs; FunctionFinder returns full signature

### DIFF
--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -25,7 +25,7 @@ from righttyper.typeinfo import TypeInfo, TypeInfoArg, UnknownTypeInfo, UnionTyp
 from righttyper.righttyper_types import ArgumentName, VariableName, Filename, CodeId
 from righttyper.annotation import FuncAnnotation, ModuleVars, TraceDistribution
 from righttyper.type_id import PostponedArg0, get_type_name
-from righttyper.typeshed import get_typeshed_func_params
+from righttyper.typeshed import get_typeshed_func_signature
 
 
 @dataclass
@@ -985,11 +985,12 @@ def get_typeshed_arg_types(
     """Returns typeshed type annotations for a parent's method's arguments."""
 
     module = parents_func.module if parents_func.module else 'builtins'
-    if not (args := get_typeshed_func_params(module, parents_func.qualname)):
+    if not (args := get_typeshed_func_signature(module, parents_func.qualname)):
         return None
 
     t = LoadAndCheckTypesT()
+    # `signature[-1]` is the return type; this consumer wants only args.
     return tuple(
         t.visit(arg) if arg is not None else None
-        for arg in args
+        for arg in args[:-1]
     )

--- a/righttyper/typeshed.py
+++ b/righttyper/typeshed.py
@@ -33,13 +33,19 @@ def get_full_name(node: cst.Attribute|cst.Name|cst.BaseExpression) -> str:
 
 
 class FunctionFinder(cst.CSTVisitor):
-    METADATA_DEPENDENCIES = (ScopeProvider,)
+    METADATA_DEPENDENCIES = (ScopeProvider, QualifiedNameProvider)
 
     def __init__(self, module_name: str, want: str):
         self._module_name = module_name
         self._name_stack: list[str] = []
         self._want = want.split('.')
         self.result: list[TypeInfo] = []
+        # Set to True if any matching `def` is decorated with `@overload`
+        # (typing or typing_extensions).  We don't match runtime arg shapes
+        # against alternatives, so picking any one overload would silently
+        # produce wrong types.  `get_func_params` discards `result` when
+        # this flag is set — same as a missing stub.
+        self._is_overloaded: bool = False
 
     def _type_from_name(self, scope, node: cst.Name|cst.Attribute) -> TypeInfo:
         full_name = get_full_name(node)
@@ -196,11 +202,29 @@ class FunctionFinder(cst.CSTVisitor):
     def leave_ClassDef(self, node: cst.ClassDef) -> None:
         self._name_stack.pop()
 
+    def _has_overload_decorator(self, node: cst.FunctionDef) -> bool:
+        """Detect `@overload` from typing or typing_extensions on a stub
+        `def`, regardless of import form.  Uses QualifiedNameProvider so
+        all of `from typing import overload`, `import typing`, `import
+        typing as t`, `from typing_extensions import overload` resolve to
+        the same canonical name."""
+        for dec in node.decorators:
+            qnames = self.get_metadata(QualifiedNameProvider, dec.decorator)
+            if any(
+                qn.name in ('typing.overload', 'typing_extensions.overload')
+                for qn in qnames
+            ):
+                return True
+        return False
+
     def visit_FunctionDef(self, node: cst.FunctionDef) -> bool:
         self._name_stack.append(node.name.value)
 
         if self._name_stack == self._want:
-            self._save_results(node)
+            if self._has_overload_decorator(node):
+                self._is_overloaded = True
+            else:
+                self._save_results(node)
 
         self._name_stack.append('<locals>')
         return True
@@ -214,6 +238,8 @@ def get_func_params(code: cst.Module, module_name: str, func_name: str) -> list[
     finder = FunctionFinder(module_name, func_name)
     w = MetadataWrapper(code)
     w.visit(finder)
+    if finder._is_overloaded:
+        return []
     return finder.result
 
 

--- a/righttyper/typeshed.py
+++ b/righttyper/typeshed.py
@@ -39,11 +39,11 @@ class FunctionFinder(cst.CSTVisitor):
         self._module_name = module_name
         self._name_stack: list[str] = []
         self._want = want.split('.')
-        self.result: list[TypeInfo] = []
+        self.result: list[TypeInfo | None] = []
         # Set to True if any matching `def` is decorated with `@overload`
         # (typing or typing_extensions).  We don't match runtime arg shapes
         # against alternatives, so picking any one overload would silently
-        # produce wrong types.  `get_func_params` discards `result` when
+        # produce wrong types.  `get_func_signature` discards `result` when
         # this flag is set — same as a missing stub.
         self._is_overloaded: bool = False
 
@@ -195,6 +195,10 @@ class FunctionFinder(cst.CSTVisitor):
         if isinstance(p := f.params.star_kwarg, cst.Param):
             self.result.append(self._parse_annotation(p.annotation))
 
+        # Return annotation as the last element, matching RightTyper's
+        # signature convention (`signature[-1]` is the retval).
+        self.result.append(self._parse_annotation(f.returns))
+
     def visit_ClassDef(self, node: cst.ClassDef) -> bool:
         self._name_stack.append(node.name.value)
         return True
@@ -234,7 +238,7 @@ class FunctionFinder(cst.CSTVisitor):
         self._name_stack.pop()
 
 
-def get_func_params(code: cst.Module, module_name: str, func_name: str) -> list[TypeInfo]:
+def get_func_signature(code: cst.Module, module_name: str, func_name: str) -> list[TypeInfo | None]:
     finder = FunctionFinder(module_name, func_name)
     w = MetadataWrapper(code)
     w.visit(finder)
@@ -252,8 +256,8 @@ def get_typeshed_module(module_name: str) -> cst.Module|None:
 
 
 @cache
-def get_typeshed_func_params(module_name: str, qualname: str) -> list[TypeInfo] | None:
+def get_typeshed_func_signature(module_name: str, qualname: str) -> list[TypeInfo | None] | None:
     if not (module := get_typeshed_module(module_name)):
         return None
 
-    return get_func_params(module, module_name, qualname)
+    return get_func_signature(module, module_name, qualname)

--- a/tests/test_typeshed.py
+++ b/tests/test_typeshed.py
@@ -177,3 +177,56 @@ def test_from_typeshed():
         None,   # self
         TypeInfo.from_type(object),
     ]
+
+
+def test_overloaded_func_returns_empty():
+    """A function whose stub uses `@overload` cannot be matched by a single
+    signature without runtime arg-shape resolution.  Picking an arbitrary
+    overload would silently produce wrong types, so we discard everything
+    and let the caller treat it as 'no typeshed info'."""
+    code = cst.parse_module(textwrap.dedent("""\
+        from typing import overload
+
+        @overload
+        def f(x: int) -> int: ...
+        @overload
+        def f(x: str) -> str: ...
+    """))
+    assert get_func_params(code, "foo", "f") == []
+
+
+def test_overloaded_func_typing_attr_form():
+    """Same detection for the `@typing.overload` qualified form."""
+    code = cst.parse_module(textwrap.dedent("""\
+        import typing
+
+        @typing.overload
+        def f(x: int) -> int: ...
+        @typing.overload
+        def f(x: str) -> str: ...
+    """))
+    assert get_func_params(code, "foo", "f") == []
+
+
+def test_overloaded_func_typing_extensions():
+    """typing_extensions reexports `overload`; stubs targeting older
+    Pythons commonly use it."""
+    code = cst.parse_module(textwrap.dedent("""\
+        from typing_extensions import overload
+
+        @overload
+        def f(x: int) -> int: ...
+        @overload
+        def f(x: str) -> str: ...
+    """))
+    assert get_func_params(code, "foo", "f") == []
+
+
+def test_non_overloaded_func_unaffected():
+    """Sanity: an undecorated `def` still yields its signature."""
+    code = cst.parse_module(textwrap.dedent("""\
+        def f(x: int) -> str: ...
+    """))
+    assert get_func_params(code, "foo", "f") == [
+        TypeInfo('', 'int'),
+    ]

--- a/tests/test_typeshed.py
+++ b/tests/test_typeshed.py
@@ -1,6 +1,6 @@
 import libcst as cst
 import textwrap
-from righttyper.typeshed import get_func_params, get_typeshed_func_params
+from righttyper.typeshed import get_func_signature, get_typeshed_func_signature
 from righttyper.typeinfo import TypeInfo, UnknownTypeInfo
 import pytest
 
@@ -9,9 +9,9 @@ def test_names_builtin():
     code = cst.parse_module(textwrap.dedent("""\
         def f(x: int): pass
     """))
-    pars = get_func_params(code, "foo", "f")
-    assert pars == [TypeInfo('', 'int')]
-    assert pars[0].type_obj is int
+    pars = get_func_signature(code, "foo", "f")
+    assert pars == [TypeInfo('', 'int'), None]
+    assert pars[0] is not None and pars[0].type_obj is int
 
 
 def test_names_import():
@@ -21,9 +21,10 @@ def test_names_import():
 
         def f(x: a.b.c.d, y: bc.d.e): pass
     """))
-    assert get_func_params(code, "foo", "f") == [
+    assert get_func_signature(code, "foo", "f") == [
         TypeInfo('a.b', 'c.d'),
         TypeInfo('b.c', 'd.e'),
+        None,
     ]
 
 
@@ -33,10 +34,11 @@ def test_names_import_from():
 
         def f(x: c.d, y: duh.f.g, z: uh): pass
     """))
-    assert get_func_params(code, "foo", "f") == [
+    assert get_func_signature(code, "foo", "f") == [
         TypeInfo('a.b', 'c.d'),
         TypeInfo('a.b', 'd.f.g'),
         TypeInfo('a.b', 'e'),
+        None,
     ]
 
 
@@ -47,8 +49,9 @@ def test_names_local():
 
         def f(x: A.B): pass
     """))
-    assert get_func_params(code, "foo", "f") == [
-        TypeInfo("foo", "A.B")
+    assert get_func_signature(code, "foo", "f") == [
+        TypeInfo("foo", "A.B"),
+        None,
     ]
 
 
@@ -60,8 +63,9 @@ def test_names_local_override():
 
         def f(x: int): pass
     """))
-    assert get_func_params(code, "foo", "f") == [
-        TypeInfo("foo", "int")
+    assert get_func_signature(code, "foo", "f") == [
+        TypeInfo("foo", "int"),
+        None,
     ]
 
 
@@ -69,8 +73,9 @@ def test_names_undefined():
     code = cst.parse_module(textwrap.dedent("""\
         def f(x: "dunno"): pass
     """))
-    assert get_func_params(code, "foo", "f") == [
-        TypeInfo("foo", "dunno")
+    assert get_func_signature(code, "foo", "f") == [
+        TypeInfo("foo", "dunno"),
+        None,
     ]
 
 
@@ -78,84 +83,91 @@ def test_type_parsing():
     code = cst.parse_module(textwrap.dedent("""\
         def f(x): pass
     """))
-    assert get_func_params(code, "foo", "f") == [None]
+    assert get_func_signature(code, "foo", "f") == [None, None]
 
     code = cst.parse_module(textwrap.dedent("""\
         def f(x: int): pass
     """))
-    assert get_func_params(code, "foo", "f") == [TypeInfo('', 'int')]
+    assert get_func_signature(code, "foo", "f") == [TypeInfo('', 'int'), None]
 
     code = cst.parse_module(textwrap.dedent("""\
         def f(x: list[int]): pass
     """))
-    assert get_func_params(code, "foo", "f") == [
+    assert get_func_signature(code, "foo", "f") == [
         TypeInfo('', 'list', args=(
             TypeInfo('', 'int'),
-        ))
+        )),
+        None,
     ]
 
     code = cst.parse_module(textwrap.dedent("""\
         def f(x: int|str): pass
     """))
-    assert get_func_params(code, "foo", "f") == [
+    assert get_func_signature(code, "foo", "f") == [
         TypeInfo.from_set({
             TypeInfo('', 'int'),
             TypeInfo('', 'str'),
-        })
+        }),
+        None,
     ]
 
     code = cst.parse_module(textwrap.dedent("""\
         def f(x: "int|str"): pass
     """))
-    assert get_func_params(code, "foo", "f") == [
+    assert get_func_signature(code, "foo", "f") == [
         TypeInfo.from_set({
             TypeInfo('', 'int'),
             TypeInfo('', 'str'),
-        })
+        }),
+        None,
     ]
 
     code = cst.parse_module(textwrap.dedent("""\
         def f(x: list["int|str"]): pass
     """))
-    assert get_func_params(code, "foo", "f") == [
+    assert get_func_signature(code, "foo", "f") == [
         TypeInfo('', 'list', args=(
             TypeInfo.from_set({
                 TypeInfo('', 'int'),
                 TypeInfo('', 'str'),
             }),
-        ))
+        )),
+        None,
     ]
 
     code = cst.parse_module(textwrap.dedent("""\
         from collections.abc import Callable
         def f(x: Callable[[int], None]): pass
     """))
-    assert get_func_params(code, "foo", "f") == [
+    assert get_func_signature(code, "foo", "f") == [
         TypeInfo('collections.abc', 'Callable', args=(
             TypeInfo.list([
                 TypeInfo('', 'int'),
             ]),
             TypeInfo('', 'None'),
-        ))
+        )),
+        None,
     ]
 
     code = cst.parse_module(textwrap.dedent("""\
         def f(x: tuple[int, ...]): pass
     """))
-    assert get_func_params(code, "foo", "f") == [
+    assert get_func_signature(code, "foo", "f") == [
         TypeInfo('', 'tuple', args=(
             TypeInfo('', 'int'),
             ...
-        ))
+        )),
+        None,
     ]
 
     code = cst.parse_module(textwrap.dedent("""\
         def f(x: tuple[()]): pass
     """))
-    assert get_func_params(code, "foo", "f") == [
+    assert get_func_signature(code, "foo", "f") == [
         TypeInfo('', 'tuple', args=(
             (),
-        ))
+        )),
+        None,
     ]
 
     code = cst.parse_module(textwrap.dedent("""\
@@ -164,18 +176,43 @@ def test_type_parsing():
 
         def f(x: jaxtyping.Float16[numpy.ndarray, "1 1 1"]): pass
     """))
-    assert get_func_params(code, "foo", "f") == [
+    assert get_func_signature(code, "foo", "f") == [
         TypeInfo('jaxtyping', 'Float16', args=(
             TypeInfo('numpy', 'ndarray'),
             "1 1 1"
-        ))
+        )),
+        None,
     ]
 
 
 def test_from_typeshed():
-    assert get_typeshed_func_params("builtins", "object.__eq__") == [
+    assert get_typeshed_func_signature("builtins", "object.__eq__") == [
         None,   # self
         TypeInfo.from_type(object),
+        TypeInfo.from_type(bool),  # return type
+    ]
+
+
+def test_retval_included_at_end():
+    """The function's return annotation is appended to `result` as the
+    last element (matching RightTyper's `signature[-1] == retval`
+    convention).  `None` for unannotated returns."""
+    code = cst.parse_module(textwrap.dedent("""\
+        def f(x: int) -> str: ...
+    """))
+    assert get_func_signature(code, "foo", "f") == [
+        TypeInfo('', 'int'),
+        TypeInfo('', 'str'),
+    ]
+
+
+def test_retval_none_when_unannotated():
+    code = cst.parse_module(textwrap.dedent("""\
+        def f(x: int): ...
+    """))
+    assert get_func_signature(code, "foo", "f") == [
+        TypeInfo('', 'int'),
+        None,
     ]
 
 
@@ -192,7 +229,7 @@ def test_overloaded_func_returns_empty():
         @overload
         def f(x: str) -> str: ...
     """))
-    assert get_func_params(code, "foo", "f") == []
+    assert get_func_signature(code, "foo", "f") == []
 
 
 def test_overloaded_func_typing_attr_form():
@@ -205,7 +242,7 @@ def test_overloaded_func_typing_attr_form():
         @typing.overload
         def f(x: str) -> str: ...
     """))
-    assert get_func_params(code, "foo", "f") == []
+    assert get_func_signature(code, "foo", "f") == []
 
 
 def test_overloaded_func_typing_extensions():
@@ -219,7 +256,7 @@ def test_overloaded_func_typing_extensions():
         @overload
         def f(x: str) -> str: ...
     """))
-    assert get_func_params(code, "foo", "f") == []
+    assert get_func_signature(code, "foo", "f") == []
 
 
 def test_non_overloaded_func_unaffected():
@@ -227,6 +264,7 @@ def test_non_overloaded_func_unaffected():
     code = cst.parse_module(textwrap.dedent("""\
         def f(x: int) -> str: ...
     """))
-    assert get_func_params(code, "foo", "f") == [
+    assert get_func_signature(code, "foo", "f") == [
         TypeInfo('', 'int'),
+        TypeInfo('', 'str'),
     ]


### PR DESCRIPTION
## Summary

Two related fixes / cleanups to `FunctionFinder` (the libcst-based typeshed-stub reader):

- **Skip overloaded stubs.** `FunctionFinder` previously concatenated every matching `def`'s annotations into a single result, silently corrupting output for `@overload` stubs (only one variant describes any given call). Detects `@typing.overload` / `@typing_extensions.overload` via `QualifiedNameProvider` (so it works regardless of import form) and returns empty — same shape as a missing stub.
- **Return full signature, not just params.** `FunctionFinder.result` now carries `list[TypeInfo | None]` with the return annotation appended last, matching RightTyper's `signature[-1] == retval` convention. Renamed `get_func_params` → `get_func_signature` (and `get_typeshed_func_params` → `get_typeshed_func_signature`); the one consumer that wants only args slices `[:-1]`. Needed for upcoming constructor-type propagation work and for parent-return-type matching when resolving overrides. Also fixes the `list[TypeInfo]` typing lie — `_parse_annotation` returns `None` for unannotated `self`/`cls`.

## Test plan

- [x] `python3.12 -m pytest tests/test_typeshed.py -q` — new tests cover overloaded `@typing.overload` / `@typing_extensions.overload` / non-overloaded baseline; existing tests updated for the trailing-retval shape
- [x] `python3.12 -m pytest tests/ -q` full suite green
- [x] `python3.12 -m mypy righttyper/ tests/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)