### PR TITLE
lub-based type merging and static-analysis-driven simplification

### DIFF
--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -100,6 +100,11 @@ def _is_private_type(cls: type) -> bool:
     This partially duplicates TypeMap's is_private logic; done here to avoid
     threading the TypeMap through to lub.
     """
+    # A _-prefixed class name signals a private implementation detail,
+    # regardless of which module it lives in.
+    name = getattr(cls, '__name__', '') or ''
+    if name.startswith('_') and not name.startswith('__'):
+        return True
     mod = getattr(cls, '__module__', '') or ''
     if mod == '__main__' or not any(p.startswith('_') for p in mod.split('.')):
         return False

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -147,7 +147,7 @@ def lub(
 
     # Rule 6: Empty container + non-empty container → common ABC with element type.
     # E.g., tuple[()] + list[int] → Sequence[int].
-    _CONTAINER_ABCS = (abc.Sequence, abc.Mapping, abc.Set)
+    _CONTAINER_ABCS = (abc.Sequence, abc.Mapping, abc.Set, abc.Collection)
 
     def _find_common_container_abc(t1: TypeInfo, t2: TypeInfo) -> type | None:
         if not (isinstance(t1.type_obj, type) and isinstance(t2.type_obj, type)):

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -149,6 +149,34 @@ def lub(
                 if base not in (int, float, complex):
                     return get_type_name(base)
 
+    # Rule 8: ABC matching (when accessed_attributes available)
+    if accessed_attributes and isinstance(a.type_obj, type) and isinstance(b.type_obj, type):
+        candidates = [g for g, attrs in _abc_own_attrs.items()
+                      if accessed_attributes <= attrs
+                      and issubclass(a.type_obj, g)
+                      and issubclass(b.type_obj, g)]
+        if candidates:
+            best = max(candidates, key=lambda g: len(g.__mro__))
+            # For generics: try to merge element types
+            if a.args or b.args:
+                a_ti = [x for x in a.args if isinstance(x, TypeInfo)] if a.args else []
+                b_ti = [x for x in b.args if isinstance(x, TypeInfo)] if b.args else []
+                n = min(len(a_ti), len(b_ti))
+                if n > 0:
+                    is_covariant = issubclass(best, _COVARIANT_TYPES)
+                    if for_variable or is_covariant:
+                        merged_args = tuple(
+                            lub(a_ti[i], b_ti[i], for_variable=True)
+                            for i in range(n)
+                        )
+                        return get_type_name(best).replace(args=merged_args)
+                    # Invariant: only merge if args are identical
+                    if a_ti[:n] == b_ti[:n]:
+                        return get_type_name(best).replace(args=tuple(a_ti[:n]))
+                # Can't merge args — fall through to union
+            else:
+                return get_type_name(best)
+
     # Rule 9: Fallback — union
     return TypeInfo.from_set_new({a, b})
 

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -121,11 +121,13 @@ def lub(
                 if a.args == ((),) or all(type_contains(elem, cast(TypeInfo, x)) for x in a.args):
                     return b
 
-        # Rule 5b: Same container, empty subsumed by non-empty
-        if _is_empty_container(a):
-            return b
-        if _is_empty_container(b):
-            return a
+        # Rule 5b: Same container, empty subsumed by non-empty.
+        # For tuples, skip — rule 5d will merge to varlen instead.
+        if a.type_obj is not tuple:
+            if _is_empty_container(a):
+                return b
+            if _is_empty_container(b):
+                return a
 
         # Rule 5c: Same container, same arg count — merge args
         if len(a.args) == len(b.args):
@@ -144,6 +146,19 @@ def lub(
                         for aa, ba in zip(a.args, b.args)
                     )
                     return a.replace(args=merged_args)
+
+        # Rule 5d: Different-length or empty fixed tuples → varlen tuple
+        # tuple[int] | tuple[int, str] → tuple[int|str, ...]
+        # tuple[()] | tuple[int] → tuple[int, ...]
+        if a.type_obj is tuple and (len(a.args) != len(b.args)
+                                    or a.args == ((),) or b.args == ((),)):
+            all_elems: set[TypeInfo] = {x for x in (*a.args, *b.args) if isinstance(x, TypeInfo)}
+            if all_elems:
+                merged_elem = TypeInfo.from_set(all_elems)
+                return a.replace(args=(merged_elem, Ellipsis))
+            # Both empty → stay as empty
+            if a.args == ((),):
+                return a
 
     # Rule 6: Empty container + non-empty container → common ABC with element type.
     # E.g., tuple[()] + list[int] → Sequence[int].

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -2,7 +2,9 @@ from typing import cast, Sequence, Iterator, Any, Never, NoReturn
 from abc import ABCMeta
 import collections.abc as abc
 from collections import Counter
+from functools import cache
 from types import EllipsisType
+import sys
 from righttyper.typeinfo import TypeInfo, ListTypeInfo, CallTrace
 from righttyper.type_id import get_type_name
 from righttyper.options import output_options
@@ -89,6 +91,26 @@ def _find_common_container_abc(t1: TypeInfo, t2: TypeInfo) -> type | None:
         if issubclass(o1, g) and issubclass(o2, g):
             return g
     return None
+
+
+@cache
+def _is_private_type(cls: type) -> bool:
+    """Check if cls is defined in a private module without public re-export.
+
+    This partially duplicates TypeMap's is_private logic; done here to avoid
+    threading the TypeMap through to lub.
+    """
+    mod = getattr(cls, '__module__', '') or ''
+    if mod == '__main__' or not any(p.startswith('_') for p in mod.split('.')):
+        return False
+    # Private module — but check if any public module re-exports this type
+    name = getattr(cls, '__name__', '')
+    for m in sys.modules.values():
+        m_name = getattr(m, '__name__', '')
+        if m_name and not any(p.startswith('_') for p in m_name.split('.')):
+            if getattr(m, name, None) is cls:
+                return False
+    return True
 
 
 # Numeric tower: int <: float <: complex (PEP 3141)
@@ -276,6 +298,8 @@ def lub(
         for base in b.type_obj.__mro__:
             if base in a_mro and base is not object:
                 if base in (int, float, complex):
+                    continue
+                if _is_private_type(base):
                     continue
                 if common_attrs.issubset(dir(base)):
                     return get_type_name(base)

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -128,19 +128,16 @@ def lub(
         if a.args and b.args:
             # Rule 5a: Varlen tuple subsumes fixed tuple (different arg lengths OK)
             if a.type_obj is tuple:
-                a_varlen = len(a.args) == 2 and a.args[1] is Ellipsis and isinstance(a.args[0], TypeInfo)
-                b_varlen = len(b.args) == 2 and b.args[1] is Ellipsis and isinstance(b.args[0], TypeInfo)
-                a_fixed = not a_varlen and all(isinstance(x, TypeInfo) for x in a.args)
-                b_fixed = not b_varlen and all(isinstance(x, TypeInfo) for x in b.args)
+                def _is_varlen(t: TypeInfo) -> bool:
+                    return len(t.args) == 2 and t.args[1] is Ellipsis and isinstance(t.args[0], TypeInfo)
+                def _is_fixed(t: TypeInfo) -> bool:
+                    return not _is_varlen(t) and all(isinstance(x, TypeInfo) for x in t.args)
 
-                if a_varlen and (b_fixed or b.args == ((),)):
-                    elem = cast(TypeInfo, a.args[0])
-                    if b.args == ((),) or all(type_contains(elem, cast(TypeInfo, x)) for x in b.args):
-                        return a
-                if b_varlen and (a_fixed or a.args == ((),)):
-                    elem = cast(TypeInfo, b.args[0])
-                    if a.args == ((),) or all(type_contains(elem, cast(TypeInfo, x)) for x in a.args):
-                        return b
+                for vl, other in ((a, b), (b, a)):
+                    if _is_varlen(vl) and (_is_fixed(other) or other.args == ((),)):
+                        elem = cast(TypeInfo, vl.args[0])
+                        if other.args == ((),) or all(type_contains(elem, cast(TypeInfo, x)) for x in other.args):
+                            return vl
 
             # Rule 5b: Same container, empty subsumed by non-empty.
             # For tuples, skip — rule 5d will merge to varlen instead.

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -364,10 +364,18 @@ def _merge_set(
     # not be overridden in a closer descendant. Otherwise we'd simplify to a
     # base whose attribute (e.g. a method with a narrower signature) doesn't
     # match the actual usage at runtime.
-    if len(typeinfoset) == 1 and accessed_attributes:
+    # De-privatize: if the sole observed type is private, walk up the MRO
+    # to find the nearest public ancestor that still has all accessed
+    # attributes.  Does NOT generalize public types.
+    if len(typeinfoset) == 1:
         t = next(iter(typeinfoset))
-        if isinstance(t.type_obj, type) and not t.args:
+        if isinstance(t.type_obj, type) and not t.args and _is_private_type(t.type_obj):
             sentinel = object()
+            check_attrs = accessed_attributes or frozenset(
+                attr for attr in dir(t.type_obj)
+                if getattr(t.type_obj, attr, None) is not None
+                if not attr.startswith("_") or attr.startswith("__")
+            )
             for base in t.type_obj.__mro__:
                 if base is t.type_obj or base is object:
                     continue
@@ -376,7 +384,7 @@ def _merge_set(
                 if all(
                     (a := getattr(base, attr, sentinel)) is not sentinel
                     and a is getattr(t.type_obj, attr, sentinel)
-                    for attr in accessed_attributes
+                    for attr in check_attrs
                 ):
                     return get_type_name(base)
 

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -14,6 +14,25 @@ from righttyper.options import output_options
 _COVARIANT_TYPES = (tuple, frozenset)
 
 
+# Precomputed ABC data for structural matching in simplify().
+def _build_abc_caches() -> tuple[dict[type, frozenset[str]], dict[type, frozenset[str]]]:
+    from abc import ABCMeta
+    own_attrs: dict[type, frozenset[str]] = {}
+    abstract_methods: dict[type, frozenset[str]] = {}
+    for obj in vars(abc).values():
+        if isinstance(obj, ABCMeta):
+            attrs: set[str] = set()
+            for cls in obj.__mro__:
+                if cls is object:
+                    break
+                attrs |= set(cls.__dict__)
+            own_attrs[obj] = frozenset(attrs)
+            abstract_methods[obj] = frozenset(getattr(obj, '__abstractmethods__', set()))
+    return own_attrs, abstract_methods
+
+_abc_own_attrs, _abc_abstractmethods = _build_abc_caches()
+
+
 def merge_similar_generics(typeinfoset: set[TypeInfo]) -> set[TypeInfo]:
     """Merge generics with same container but different type args.
 
@@ -378,41 +397,29 @@ def simplify(typeinfoset: set[TypeInfo], accessed_attributes: set[str] | None = 
     # mergeable types structurally implement and that covers the accessed
     # attributes. Use it only if it produces a shorter result than MRO.
     if accessed_attributes:
-        from righttyper.type_id import ABCFinder
+        # Pre-filter ABCs whose interface covers the accessed attributes (cheap set check)
+        candidates = [g for g, attrs in _abc_own_attrs.items()
+                       if accessed_attributes <= attrs]
 
-        def structurally_implements(t: type, abc_type: type) -> bool:
-            """Check if t has all abstract methods required by abc_type."""
-            required = getattr(abc_type, '__abstractmethods__', set())
-            return all(hasattr(t, m) for m in required)
-
-        def abc_provides(abc_type: type, attributes: set[str]) -> bool:
-            """Check if the ABC's own interface (not inherited from object) covers the attributes."""
-            own_attrs = set(getattr(abc_type, '__abstractmethods__', set()))
-            for cls in abc_type.__mro__:
-                if cls is object:
+        if candidates:
+            abc_candidates: set[type] | None = None
+            for t in mergeable_types:
+                if type(t.type_obj) is not type:
+                    abc_candidates = set()
                     break
-                own_attrs |= set(cls.__dict__)
-            return attributes <= own_attrs
+                t_attrs = frozenset(dir(t.type_obj))
+                abcs = {g for g in candidates if _abc_abstractmethods[g] <= t_attrs}
+                abc_candidates = abcs if abc_candidates is None else abc_candidates & abcs
 
-        abc_candidates = None
-        for t in mergeable_types:
-            abcs = {
-                g for g in ABCFinder._ABCs
-                if type(t.type_obj) is type
-                and structurally_implements(t.type_obj, g)
-                and abc_provides(g, accessed_attributes)
-            }
-            abc_candidates = abcs if abc_candidates is None else abc_candidates & abcs
-
-        if abc_candidates:
-            best = max(abc_candidates, key=lambda g: len(g.__mro__))
-            abc_result = {get_type_name(best)} | other_types
-            # Use ABC when it's strictly shorter, or when MRO made no
-            # improvement (e.g., single type with no useful supertype).
-            if len(abc_result) < len(mro_result) or (
-                len(abc_result) == len(mro_result) and not mro_replacements
-            ):
-                return abc_result
+            if abc_candidates:
+                best = max(abc_candidates, key=lambda g: len(g.__mro__))
+                abc_result = {get_type_name(best)} | other_types
+                # Use ABC when it's strictly shorter, or when MRO made no
+                # improvement (e.g., single type with no useful supertype).
+                if len(abc_result) < len(mro_result) or (
+                    len(abc_result) == len(mro_result) and not mro_replacements
+                ):
+                    return abc_result
 
     return mro_result
 

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -1,11 +1,9 @@
 from typing import cast, Sequence, Iterator, Any, Never, NoReturn
 import collections.abc as abc
-from collections import defaultdict, Counter
+from collections import Counter
 from types import EllipsisType
-import itertools
 from righttyper.typeinfo import TypeInfo, ListTypeInfo, CallTrace
 from righttyper.type_id import get_type_name
-from righttyper.righttyper_types import cast_not_None
 from righttyper.options import output_options
 
 
@@ -261,6 +259,17 @@ def _merge_set(
     if not typeinfoset:
         return TypeInfo.from_type(Never)
 
+    # Single-type generalization: if accessed_attributes are provided,
+    # walk up the MRO to find a more general base type.
+    if len(typeinfoset) == 1 and accessed_attributes:
+        t = next(iter(typeinfoset))
+        if isinstance(t.type_obj, type) and not t.args:
+            for base in t.type_obj.__mro__:
+                if base is t.type_obj or base is object:
+                    continue
+                if accessed_attributes.issubset(dir(base)):
+                    return get_type_name(base)
+
     # Iteratively reduce: try to merge pairs until stable
     types = list(typeinfoset)
     changed = True
@@ -282,99 +291,6 @@ def _merge_set(
 
     # lub already handled simplification; just form the union
     return TypeInfo.from_set_new(set(types))
-
-
-def merge_similar_generics(typeinfoset: set[TypeInfo]) -> set[TypeInfo]:
-    """Merge generics with same container but different type args.
-
-    E.g., list[int] | list[bool] → list[int] (bool is subtype of int)
-         dict[str, int] | dict[str, str] → dict[str, int | str]
-         tuple[int, ...] | tuple[str, ...] → tuple[int | str, ...]
-
-    For invariant types (list, dict, set, etc.) this is only safe for variable
-    annotations.  For covariant types (tuple, frozenset) this is safe everywhere;
-    see merged_types() for where that distinction is enforced.
-    """
-    if not any(t.args for t in typeinfoset):
-        return typeinfoset
-
-    typeinfoset = set(typeinfoset)  # avoid modifying argument
-
-    # Group by (module, name, per-position TypeInfo pattern, nargs).
-    # This ensures e.g. tuple[int, str] and tuple[int, ...] end up in
-    # different groups (different TypeInfo/Ellipsis patterns).
-    def group_key(t: TypeInfo) -> tuple[str, str, tuple[bool, ...], int]:
-        return (t.module, t.name,
-                tuple(isinstance(arg, TypeInfo) for arg in t.args),
-                len(t.args))
-
-    for (_mod, _name, is_info_per_arg, nargs), group in itertools.groupby(
-        sorted(typeinfoset, key=group_key),
-        group_key
-    ):
-        group_set = set(group)
-        if len(group_set) <= 1:
-            continue
-
-        first = next(iter(group_set))
-
-        # Only merge when every non-TypeInfo arg is Ellipsis
-        if not all(is_info or first.args[i] is Ellipsis
-                   for i, is_info in enumerate(is_info_per_arg)):
-            continue
-
-        typeinfoset -= group_set
-        # Recursively merge and simplify inner type arguments.
-        # This allows bool|int -> int, and handles nested generics.
-        # Ellipsis positions are preserved as-is.
-        typeinfoset.add(first.replace(args=tuple(
-            merged_types({
-                cast(TypeInfo, member.args[i]) for member in group_set
-            }, for_variable=True)
-            if is_info_per_arg[i] else first.args[i]
-            for i in range(nargs)
-        )))
-
-    return typeinfoset
-
-
-def _subsume_fixed_by_varlen_tuples(typeinfoset: set[TypeInfo]) -> set[TypeInfo]:
-    """Remove fixed-length tuples subsumed by a variable-length tuple.
-
-    tuple[int, int] | tuple[int, ...] → tuple[int, ...]
-    because tuple[int, int] is a subtype of tuple[int, ...] (all elements are ints).
-
-    Also removes tuple[()] (empty tuple) since it is a subtype of any tuple[T, ...].
-    """
-    varlen = {
-        t for t in typeinfoset
-        if t.type_obj is tuple
-        and len(t.args) == 2
-        and t.args[1] is Ellipsis
-        and isinstance(t.args[0], TypeInfo)
-    }
-    if not varlen:
-        return typeinfoset
-
-    # Empty tuples (tuple[()]) are subtypes of any tuple[T, ...]
-    empty = {t for t in typeinfoset if t.type_obj is tuple and t.args == ((),)}
-
-    fixed = {
-        t for t in typeinfoset - varlen - empty
-        if t.type_obj is tuple
-        and t.args
-        and all(isinstance(a, TypeInfo) for a in t.args)
-    }
-
-    to_remove = set(empty)
-    for f in fixed:
-        for v in varlen:
-            elem = cast(TypeInfo, v.args[0])
-            if all(type_contains(elem, cast(TypeInfo, a)) for a in f.args):
-                to_remove.add(f)
-                break
-
-    return typeinfoset - to_remove if to_remove else typeinfoset
 
 
 def type_contains(a: TypeInfo, b: TypeInfo) -> bool:
@@ -408,61 +324,6 @@ def type_contains(a: TypeInfo, b: TypeInfo) -> bool:
     return False
 
 
-def merge_container_supersets(typeinfoset: set[TypeInfo]) -> set[TypeInfo]:
-    """Remove containers whose element types are subsets of another container's.
-
-    E.g., list[int] | list[int|str] → list[int|str]
-          list[int] | list[str] → list[int] | list[str]  (no subset relationship)
-
-    This is safe for Container types because a subset observation represents
-    an earlier/partial view of the same container accumulating elements.
-    """
-    # Only consider Container types (list, set, dict, etc.)
-    container_types = {
-        t for t in typeinfoset
-        if t.args and
-        type(t.type_obj) is type and
-        issubclass(t.type_obj, abc.Container)
-    }
-
-    if not container_types:
-        return typeinfoset
-
-    typeinfoset = set(typeinfoset)  # avoid modifying argument
-
-    def group_key(t: TypeInfo) -> tuple[str, str, int]:
-        return t.module, t.name, len(t.args)
-
-    for (_mod, _name, nargs), group in itertools.groupby(
-        sorted(container_types, key=group_key),
-        group_key
-    ):
-        group_list = list(group)
-        if len(group_list) <= 1:
-            continue
-
-        # Check if all args are TypeInfo
-        if not all(all(isinstance(arg, TypeInfo) for arg in t.args) for t in group_list):
-            continue
-
-        # Find containers that are strict subsets of others
-        to_remove = set()
-        for t1 in group_list:
-            if t1 in to_remove:
-                continue
-            for t2 in group_list:
-                if t1 is t2 or t2 in to_remove:
-                    continue
-                # If t1 is contained by t2 (and they're not equal), remove t1
-                if t1 != t2 and type_contains(t2, t1):
-                    to_remove.add(t1)
-                    break
-
-        typeinfoset -= to_remove
-
-    return typeinfoset
-
-
 def _is_empty_container(t: TypeInfo) -> bool:
     """Check if t represents an empty container (e.g., tuple[()], list[Never], dict[Never, Never])."""
     if t.type_obj is tuple and t.args == ((),):
@@ -479,247 +340,9 @@ def merged_types(
     accessed_attributes: set[str] | None = None,
 ) -> TypeInfo:
     """Attempts to merge types in a set before forming their union."""
-    old_result = _merged_types_old(typeinfoset, for_variable, accessed_attributes)
-
     if output_options.simplify_types:
-        new_result = _merge_set(typeinfoset, for_variable, accessed_attributes)
-        if old_result != new_result:
-            import warnings
-            warnings.warn(
-                f"lub mismatch: {typeinfoset} for_variable={for_variable} "
-                f"attrs={accessed_attributes}\n  old={old_result}\n  new={new_result}"
-            )
-
-    return old_result
-
-
-def _merged_types_old(
-    typeinfoset: set[TypeInfo],
-    for_variable: bool = False,
-    accessed_attributes: set[str] | None = None,
-) -> TypeInfo:
-    """Original merged_types implementation (ad-hoc chain)."""
-    if output_options.simplify_types and (len(typeinfoset) > 1 or accessed_attributes):
-        typeinfoset = simplify(typeinfoset, accessed_attributes)
-
-    if len(typeinfoset) > 1:
-        if for_variable:
-            typeinfoset = merge_similar_generics(typeinfoset)
-        else:
-            typeinfoset = merge_container_supersets(typeinfoset)
-            # Covariant (immutable) types can safely have their type args
-            # merged even for params/returns, since there is no write path.
-            if len(typeinfoset) > 1:
-                covariant = {t for t in typeinfoset
-                             if t.args
-                             and isinstance(t.type_obj, type)
-                             and issubclass(t.type_obj, _COVARIANT_TYPES)}
-                if len(covariant) > 1:
-                    others = typeinfoset - covariant
-                    typeinfoset = merge_similar_generics(covariant) | others
-            if len(typeinfoset) > 1:
-                typeinfoset = _subsume_fixed_by_varlen_tuples(typeinfoset)
-
-    # Cross-container ABC merge: find a common ABC for different container
-    # types (e.g., list[int] | tuple[int,...] → Sequence[int]).
-    # Empty containers are dropped first (they're compatible with any element type).
-    if len(typeinfoset) > 1 and accessed_attributes:
-        typeinfoset -= {t for t in typeinfoset if _is_empty_container(t)} or set()
-        # Generics with TypeInfo args — group by number of TypeInfo args
-        generics = {t for t in typeinfoset
-                    if t.args and isinstance(t.args[0], TypeInfo) and isinstance(t.type_obj, type)}
-        n_type_args = {sum(isinstance(a, TypeInfo) for a in t.args) for t in generics}
-        if len(generics) >= (2 if len(typeinfoset) > 1 else 1) and len(n_type_args) == 1:
-            n = next(iter(n_type_args))
-            candidates = [g for g, attrs in _abc_own_attrs.items()
-                          if accessed_attributes <= attrs
-                          and all(issubclass(t.type_obj, g) for t in generics)]
-            if candidates:
-                best = max(candidates, key=lambda g: len(g.__mro__))
-                # Merge corresponding TypeInfo args across all generics
-                merged_args = tuple(
-                    TypeInfo.from_set({cast(TypeInfo, [a for a in t.args if isinstance(a, TypeInfo)][i])
-                                       for t in generics})
-                    for i in range(n)
-                )
-                abc_result = (typeinfoset - generics) | {get_type_name(best).replace(args=merged_args)}
-                if len(abc_result) < len(typeinfoset):
-                    typeinfoset = abc_result
-
+        return _merge_set(typeinfoset, for_variable, accessed_attributes)
     return TypeInfo.from_set(typeinfoset)
-
-
-def simplify(typeinfoset: set[TypeInfo], accessed_attributes: set[str] | None = None) -> set[TypeInfo]:
-    """Simplifies the set by replacing types with supertypes that have
-       all required attributes.
-
-       If accessed_attributes is provided, only those attributes are considered
-       (from static analysis of the function body). Otherwise, falls back to
-       using dir() to find common attributes across the types.
-    """
-    # Types we support simplifying
-    simplifiable_types = set(
-        t
-        for t in typeinfoset
-        if len(t.args) == 0                          # we don't compare arguments yet
-        if not hasattr(t.type_obj, "__orig_class__") # we don't support generics yet
-    )
-
-    if not simplifiable_types:
-        return typeinfoset
-
-    other_types = typeinfoset - simplifiable_types 
-
-    # generics whose incomplete (argumentless) forms default to Any arguments
-    incomplete_types = set(
-        t
-        for t in simplifiable_types
-        if (
-            # TODO many more could be added here -- maybe every ABC?
-            t.type_obj in (abc.Callable, abc.Iterator, abc.AsyncIterator, abc.Iterable,
-                           abc.Generator, abc.AsyncGenerator, abc.Coroutine)
-            or (type(t.type_obj) is type and issubclass(t.type_obj, abc.Container))
-        )
-    )
-
-    if incomplete_types:
-        # the incomplete form subsumes those with arguments: delete them
-        other_types = set(
-            t
-            for t in other_types
-            if not any(bc.type_obj is t.type_obj for bc in incomplete_types)
-        )
-
-    # Types we support merging
-    mergeable_types = set(
-        t
-        for t in simplifiable_types
-        if type(t.type_obj) is type     # we need a type_obj with __mro__ for merging
-    )
-
-    other_types |= (simplifiable_types - mergeable_types)
-
-    if not mergeable_types:
-        return other_types
-
-    # TODO do we want to merge by protocol?  search for protocols in collections.abc types?
-
-    def insert_numerics(mro: tuple[type, ...]) -> tuple[type, ...]:
-        """Inserts numerics where applicable into an mro list
-        
-        This also preserves topological order.
-
-        For example, suppose our type hierarchy looks like
-        ```
-             float int
-                |   |
-                A   B
-        ```
-        And we are given [A, float] for A and [B, int] for B
-
-        According to [PEP 3141](https://peps.python.org/pep-3141/), this type hierarchy is equivalent to
-        ```
-             complex
-                |
-              float
-                | \\
-                |  int
-                |   |
-                A   B
-        ```
-
-        This method returns a new mro that is consistent with this type hierarchy
-        ([A, float, complex] for A and [B, int, float, complex] for B)
-        """
-        numeric_hierarchy = frozenset({int, float, complex, object})
-        numerics = [mro_type for mro_type in mro if mro_type in numeric_hierarchy]
-        if len(numerics) <= 1:
-            return mro
-        new_mro = [mro_type for mro_type in mro if mro_type not in numeric_hierarchy]
-        tower_index = min([int, float, complex, object].index(mro_type) for mro_type in numerics)
-        new_mro.extend([int, float, complex, object][tower_index:])
-        return tuple(new_mro)
-
-    if accessed_attributes is not None:
-        common_attributes = accessed_attributes
-    else:
-        # FIXME besides attribute presence, we should check their types/signatures
-        # FIXME we should check object attributes, not their classes'
-        common_attributes = set.intersection(
-            *(
-                set(
-                    attr
-                    for attr in dir(cast_not_None(t.type_obj))
-                    if getattr(t.type_obj, attr, None) is not None
-                    if not attr.startswith("_") or attr.startswith("__")
-                ) for t in mergeable_types
-            )
-        )
-
-    # Get the superclasses, if any, that have all the common attributes
-    common_supertypes = defaultdict(list)
-    for t in mergeable_types:
-        for base in insert_numerics(cast(type, t.type_obj).__mro__):
-            if common_attributes.issubset(set(dir(base))):
-                common_supertypes[base].append(t)
-
-    # Unless "object" is in the set, it's likely too general to be useful
-    # TODO why aren't the attributes enough to exclude "object" ?
-    if object in common_supertypes and not any(t.type_obj is object for t in mergeable_types):
-        del common_supertypes[object]
-
-#    print("common_supertypes=", {k: [str(t) for t in v] for k, v in common_supertypes.items() if len(v)>1})
-
-    # MRO-based merge: replace types with the most specific common supertype.
-    # Save replacements separately so they don't get replaced in turn.
-    mro_mergeable = set(mergeable_types)
-    mro_replacements: set[TypeInfo] = set()
-
-    # 'defaultdict' retains insertion order, and 'sorted' is stable, so the first supertypes
-    # on the list, after sorting by how many types they replace, are as specific as possible.
-    for st, types in sorted(common_supertypes.items(), key=lambda item: -len(item[1])):
-        if len(types) == 1:
-            if accessed_attributes is None:
-                break   # without accessed_attributes, 1-for-1 exchanges aren't useful
-            # With accessed_attributes, generalize a single type to its base
-            # if the base has all accessed attributes (e.g., PosixPath → Path).
-            # Skip self-replacement and numeric tower widening (float → complex
-            # is technically valid but not useful).
-            if types[0].type_obj is st:
-                continue
-            if st in (int, float, complex):
-                continue
-
-        if any(t in mro_mergeable for t in types):
-            mro_mergeable -= set(types)
-            mro_replacements.add(get_type_name(st))
-
-    mro_result = mro_mergeable | mro_replacements | other_types
-
-    # ABC matching: try to find a collections.abc ABC that all original
-    # mergeable types structurally implement and that covers the accessed
-    # attributes. Use it only if it produces a shorter result than MRO.
-    if accessed_attributes and len(mro_result) > 1:
-        # Pre-filter ABCs whose interface covers the accessed attributes (cheap set check)
-        candidates = [g for g, attrs in _abc_own_attrs.items()
-                       if accessed_attributes <= attrs]
-
-        if candidates:
-            abc_candidates: set[type] | None = None
-            for t in mergeable_types:
-                if type(t.type_obj) is not type:
-                    abc_candidates = set()
-                    break
-                abcs = {g for g in candidates if issubclass(t.type_obj, g)}
-                abc_candidates = abcs if abc_candidates is None else abc_candidates & abcs
-
-            if abc_candidates:
-                best = max(abc_candidates, key=lambda g: len(g.__mro__))
-                abc_result = {get_type_name(best)} | other_types
-                if len(abc_result) < len(mro_result):
-                    return abc_result
-
-    return mro_result
 
 
 def generalize_jaxtyping(samples: Sequence[CallTrace]) -> Sequence[CallTrace]:

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -126,7 +126,40 @@ def lub(
                     return b
 
     # Rule 9: Fallback — union
-    return TypeInfo.from_set({a, b})
+    return TypeInfo.from_set_new({a, b})
+
+
+def _merge_set(
+    typeinfoset: set[TypeInfo],
+    for_variable: bool = False,
+    accessed_attributes: set[str] | None = None,
+) -> TypeInfo:
+    """Reduce a set of types using pairwise lub, then form the final union."""
+    if not typeinfoset:
+        import typing
+        return TypeInfo.from_type(typing.Never)
+
+    # Iteratively reduce: try to merge pairs until stable
+    types = list(typeinfoset)
+    changed = True
+    while changed:
+        changed = False
+        i = 0
+        while i < len(types):
+            j = i + 1
+            while j < len(types):
+                merged = lub(types[i], types[j], for_variable, accessed_attributes)
+                if not merged.is_union():
+                    # lub produced a single type — replace both with it
+                    types[i] = merged
+                    types.pop(j)
+                    changed = True
+                else:
+                    j += 1
+            i += 1
+
+    # lub already handled simplification; just form the union
+    return TypeInfo.from_set_new(set(types))
 
 
 def merge_similar_generics(typeinfoset: set[TypeInfo]) -> set[TypeInfo]:
@@ -324,14 +357,27 @@ def merged_types(
     for_variable: bool = False,
     accessed_attributes: set[str] | None = None,
 ) -> TypeInfo:
-    """Attempts to merge types in a set before forming their union.
+    """Attempts to merge types in a set before forming their union."""
+    old_result = _merged_types_old(typeinfoset, for_variable, accessed_attributes)
 
-    Args:
-        typeinfoset: Set of types to merge
-        for_variable: If True, apply similar generics merging (safe for variables only)
-        accessed_attributes: If provided, attribute names accessed on this variable
-            (from static analysis), used to guide type simplification.
-    """
+    if output_options.simplify_types:
+        new_result = _merge_set(typeinfoset, for_variable, accessed_attributes)
+        if old_result != new_result:
+            import logging
+            logging.getLogger('righttyper').debug(
+                f"lub mismatch: {typeinfoset} for_variable={for_variable} "
+                f"attrs={accessed_attributes}\n  old={old_result}\n  new={new_result}"
+            )
+
+    return old_result
+
+
+def _merged_types_old(
+    typeinfoset: set[TypeInfo],
+    for_variable: bool = False,
+    accessed_attributes: set[str] | None = None,
+) -> TypeInfo:
+    """Original merged_types implementation (ad-hoc chain)."""
     if output_options.simplify_types and (len(typeinfoset) > 1 or accessed_attributes):
         typeinfoset = simplify(typeinfoset, accessed_attributes)
 

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -97,12 +97,16 @@ def _is_subtype(a: type, b: type) -> bool:
         return True
     if issubclass(a, b):
         return True
-    # Numeric tower: int <: float <: complex
-    t = a
-    while t in _NUMERIC_TOWER:
-        t = _NUMERIC_TOWER[t]
-        if t is b:
-            return True
+    # Numeric tower: int <: float <: complex. Walk a's MRO for the nearest
+    # tower entry, then promote up the tower checking against b.
+    for ancestor in a.__mro__:
+        if ancestor in _NUMERIC_TOWER:
+            t = ancestor
+            while t in _NUMERIC_TOWER:
+                t = _NUMERIC_TOWER[t]
+                if issubclass(t, b):
+                    return True
+            break
     return False
 
 

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -47,9 +47,10 @@ _abc_own_attrs = _build_abc_own_attrs()
 
 
 def _find_common_container_abc(t1: TypeInfo, t2: TypeInfo) -> type | None:
-    """Find the most specific generic container ABC both types implement."""
-    if not (isinstance(t1.type_obj, type) and isinstance(t2.type_obj, type)):
-        return None
+    """Find the most specific generic container ABC both types implement.
+
+    Caller must ensure both type_objs are real types (not None or special forms).
+    """
     for g in _CONTAINER_ABCS:
         if issubclass(t1.type_obj, g) and issubclass(t2.type_obj, g):
             return g
@@ -102,83 +103,84 @@ def lub(
     if b.type_obj is Any:
         return b
 
+    # Without a real type (could be None or a typing special form),
+    # no merging rules apply.
+    if not isinstance(a.type_obj, type) or not isinstance(b.type_obj, type):
+        return TypeInfo.from_set_new({a, b})
+
     # Rule 4: Subtype check (MRO + numeric tower)
-    if (isinstance(a.type_obj, type) and isinstance(b.type_obj, type)
-        and not a.args and not b.args):
+    if not a.args and not b.args:
         if _is_subtype(a.type_obj, b.type_obj):
             return b
         if _is_subtype(b.type_obj, a.type_obj):
             return a
 
-    # Rule 4b: Bare generic subsumes parametrized (list subsumes list[int]).
-    if (a.module == b.module and a.name == b.name
-        and isinstance(a.type_obj, type)
-        and (a.type_obj in _BARE_SUBSUMES or issubclass(a.type_obj, abc.Container))):
-        if not a.args and b.args:
-            return a
-        if a.args and not b.args:
-            return b
-
-    # Rule 5: Same container, different args
-    if (a.module == b.module and a.name == b.name
-        and a.args and b.args
-        and isinstance(a.type_obj, type)):
-
-        # Rule 5a: Varlen tuple subsumes fixed tuple (different arg lengths OK)
-        if a.type_obj is tuple:
-            a_varlen = len(a.args) == 2 and a.args[1] is Ellipsis and isinstance(a.args[0], TypeInfo)
-            b_varlen = len(b.args) == 2 and b.args[1] is Ellipsis and isinstance(b.args[0], TypeInfo)
-            a_fixed = all(isinstance(x, TypeInfo) for x in a.args) and not a_varlen
-            b_fixed = all(isinstance(x, TypeInfo) for x in b.args) and not b_varlen
-
-            if a_varlen and (b_fixed or b.args == ((),)):
-                elem = cast(TypeInfo, a.args[0])
-                if b.args == ((),) or all(type_contains(elem, cast(TypeInfo, x)) for x in b.args):
-                    return a
-            if b_varlen and (a_fixed or a.args == ((),)):
-                elem = cast(TypeInfo, b.args[0])
-                if a.args == ((),) or all(type_contains(elem, cast(TypeInfo, x)) for x in a.args):
-                    return b
-
-        # Rule 5b: Same container, empty subsumed by non-empty.
-        # For tuples, skip — rule 5d will merge to varlen instead.
-        if a.type_obj is not tuple:
-            if _is_empty_container(a):
-                return b
-            if _is_empty_container(b):
+    # Rules 4b + 5: Same type — bare subsumption and arg merging.
+    if a.type_obj is b.type_obj:
+        # Rule 4b: Bare generic subsumes parametrized (list subsumes list[int]).
+        if a.type_obj in _BARE_SUBSUMES or issubclass(a.type_obj, abc.Container):
+            if not a.args and b.args:
                 return a
+            if a.args and not b.args:
+                return b
 
-        # Rule 5c: Same container, same arg count — merge args
-        if len(a.args) == len(b.args):
-            # type[X] is covariant (type[B] <: type[A] when B <: A)
-            is_covariant = issubclass(a.type_obj, _COVARIANT_TYPES) or a.type_obj is type
-            if for_variable or is_covariant:
-                can_merge = all(
-                    (isinstance(aa, TypeInfo) and isinstance(ba, TypeInfo))
-                    or aa is ba
-                    for aa, ba in zip(a.args, b.args)
-                )
-                if can_merge:
-                    merged_args = tuple(
-                        lub(cast(TypeInfo, aa), cast(TypeInfo, ba), for_variable=True)
-                        if isinstance(aa, TypeInfo) and isinstance(ba, TypeInfo)
-                        else aa
+        # Rule 5: Same container, different args
+        if a.args and b.args:
+            # Rule 5a: Varlen tuple subsumes fixed tuple (different arg lengths OK)
+            if a.type_obj is tuple:
+                a_varlen = len(a.args) == 2 and a.args[1] is Ellipsis and isinstance(a.args[0], TypeInfo)
+                b_varlen = len(b.args) == 2 and b.args[1] is Ellipsis and isinstance(b.args[0], TypeInfo)
+                a_fixed = all(isinstance(x, TypeInfo) for x in a.args) and not a_varlen
+                b_fixed = all(isinstance(x, TypeInfo) for x in b.args) and not b_varlen
+
+                if a_varlen and (b_fixed or b.args == ((),)):
+                    elem = cast(TypeInfo, a.args[0])
+                    if b.args == ((),) or all(type_contains(elem, cast(TypeInfo, x)) for x in b.args):
+                        return a
+                if b_varlen and (a_fixed or a.args == ((),)):
+                    elem = cast(TypeInfo, b.args[0])
+                    if a.args == ((),) or all(type_contains(elem, cast(TypeInfo, x)) for x in a.args):
+                        return b
+
+            # Rule 5b: Same container, empty subsumed by non-empty.
+            # For tuples, skip — rule 5d will merge to varlen instead.
+            if a.type_obj is not tuple:
+                if _is_empty_container(a):
+                    return b
+                if _is_empty_container(b):
+                    return a
+
+            # Rule 5c: Same container, same arg count — merge args
+            if len(a.args) == len(b.args):
+                # type[X] is covariant (type[B] <: type[A] when B <: A)
+                is_covariant = issubclass(a.type_obj, _COVARIANT_TYPES) or a.type_obj is type
+                if for_variable or is_covariant:
+                    can_merge = all(
+                        (isinstance(aa, TypeInfo) and isinstance(ba, TypeInfo))
+                        or aa is ba
                         for aa, ba in zip(a.args, b.args)
                     )
-                    return a.replace(args=merged_args)
+                    if can_merge:
+                        merged_args = tuple(
+                            lub(cast(TypeInfo, aa), cast(TypeInfo, ba), for_variable=True)
+                            if isinstance(aa, TypeInfo) and isinstance(ba, TypeInfo)
+                            else aa
+                            for aa, ba in zip(a.args, b.args)
+                        )
+                        return a.replace(args=merged_args)
 
-        # Rule 5d: Different-length or empty fixed tuples → varlen tuple
-        # tuple[int] | tuple[int, str] → tuple[int|str, ...]
-        # tuple[()] | tuple[int] → tuple[int, ...]
-        if a.type_obj is tuple and (len(a.args) != len(b.args)
-                                    or a.args == ((),) or b.args == ((),)):
-            all_elems: set[TypeInfo] = {x for x in (*a.args, *b.args) if isinstance(x, TypeInfo)}
-            if all_elems:
-                merged_elem = TypeInfo.from_set(all_elems)
-                return a.replace(args=(merged_elem, Ellipsis))
-            # Both empty → stay as empty
-            if a.args == ((),):
-                return a
+            # Rule 5d: Different-length or empty fixed tuples → varlen tuple
+            # tuple[int] | tuple[int, str] → tuple[int|str, ...]
+            # tuple[()] | tuple[int] → tuple[int, ...]
+            if a.type_obj is tuple and (len(a.args) != len(b.args)
+                                        or a.args == ((),) or b.args == ((),)):
+                all_elems: set[TypeInfo] = {x for x in (*a.args, *b.args) if isinstance(x, TypeInfo)}
+                if all_elems:
+                    merged_elem = TypeInfo.from_set(all_elems)
+                    return a.replace(args=(merged_elem, Ellipsis))
+                # Both empty → stay as empty
+                if a.args == ((),):
+                    return a
 
     # Rule 6: Empty container + non-empty container → common ABC with element type.
     # E.g., tuple[()] + list[int] → Sequence[int].
@@ -190,8 +192,7 @@ def lub(
                 return get_type_name(common).replace(args=(nonempty.args[0],))
 
     # Rule 7: MRO common supertype (non-generic types only).
-    if (not a.args and not b.args
-        and isinstance(a.type_obj, type) and isinstance(b.type_obj, type)):
+    if not a.args and not b.args:
         if accessed_attributes:
             common_attrs = accessed_attributes
         else:
@@ -215,7 +216,7 @@ def lub(
                     return get_type_name(base)
 
     # Rule 8: ABC matching (when accessed_attributes available)
-    if accessed_attributes and isinstance(a.type_obj, type) and isinstance(b.type_obj, type):
+    if accessed_attributes:
         candidates = [g for g, attrs in _abc_own_attrs.items()
                       if accessed_attributes <= attrs
                       and issubclass(a.type_obj, g)

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -205,8 +205,15 @@ def lub(
                 b_ti = [x for x in b.args if isinstance(x, TypeInfo)] if b.args else []
                 n = min(len(a_ti), len(b_ti))
                 if n > 0:
-                    is_covariant = issubclass(best, _COVARIANT_TYPES)
-                    if for_variable or is_covariant:
+                    # If either type is immutable, the function can't mutate
+                    # the container, so the merge is effectively covariant.
+                    # FIXME: this assumes no type narrowing (isinstance checks);
+                    # if the code narrows, the mutable branch could be written to.
+                    either_immutable = (
+                        issubclass(a.type_obj, _COVARIANT_TYPES)
+                        or issubclass(b.type_obj, _COVARIANT_TYPES)
+                    )
+                    if for_variable or either_immutable:
                         merged_args = tuple(
                             lub(a_ti[i], b_ti[i], for_variable=True)
                             for i in range(n)

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -13,11 +13,12 @@ _COVARIANT_TYPES = (tuple, frozenset)
 
 # Generic types where bare form (no args) means "Any args" and subsumes parametrized forms.
 # Containers are handled separately via issubclass(t, abc.Container).
-_BARE_SUBSUMES: set[type] = {
+# abc.Callable etc. are typing special forms, not types — silence mypy.
+_BARE_SUBSUMES: set[type] = cast(set[type], {
     abc.Callable, abc.Iterator, abc.AsyncIterator, abc.Iterable,
     abc.Generator, abc.AsyncGenerator, abc.Coroutine,
     abc.Awaitable, abc.AsyncIterable, abc.Reversible, abc.MappingView, type,
-}
+})
 
 # All generic container ABCs from collections.abc, ordered most-specific-first.
 _CONTAINER_ABCS: list[type] = [
@@ -81,8 +82,10 @@ def _find_common_container_abc(t1: TypeInfo, t2: TypeInfo) -> type | None:
 
     Caller must ensure both type_objs are real types (not None or special forms).
     """
+    # Caller's contract guarantees both type_objs are real types.
+    o1, o2 = cast(type, t1.type_obj), cast(type, t2.type_obj)
     for g in _CONTAINER_ABCS:
-        if issubclass(t1.type_obj, g) and issubclass(t2.type_obj, g):
+        if issubclass(o1, g) and issubclass(o2, g):
             return g
     return None
 

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -296,14 +296,23 @@ def _merge_set(
         return TypeInfo.from_type(Never)
 
     # Single-type generalization: if accessed_attributes are provided,
-    # walk up the MRO to find a more general base type.
+    # walk up the MRO to find a more general base type. Each accessed attribute
+    # must resolve to the same object on the base as on t — i.e. the base must
+    # not be overridden in a closer descendant. Otherwise we'd simplify to a
+    # base whose attribute (e.g. a method with a narrower signature) doesn't
+    # match the actual usage at runtime.
     if len(typeinfoset) == 1 and accessed_attributes:
         t = next(iter(typeinfoset))
         if isinstance(t.type_obj, type) and not t.args:
+            sentinel = object()
             for base in t.type_obj.__mro__:
                 if base is t.type_obj or base is object:
                     continue
-                if accessed_attributes.issubset(dir(base)):
+                if all(
+                    (a := getattr(base, attr, sentinel)) is not sentinel
+                    and a is getattr(t.type_obj, attr, sentinel)
+                    for attr in accessed_attributes
+                ):
                     return get_type_name(base)
 
     # Iteratively reduce: try to merge pairs until stable

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -370,26 +370,27 @@ def _merge_set(
     if len(typeinfoset) == 1:
         t = next(iter(typeinfoset))
         if isinstance(t.type_obj, type) and not t.args and _is_private_type(t.type_obj):
-            sentinel = object()
-            check_attrs = accessed_attributes or frozenset(
-                attr for attr in dir(t.type_obj)
-                if getattr(t.type_obj, attr, None) is not None
-                if not attr.startswith("_") or attr.startswith("__")
+            # Find the nearest public ancestor.
+            public_base = next(
+                (base for base in t.type_obj.__mro__
+                 if base is not t.type_obj and base is not object
+                 and not _is_private_type(base)),
+                None
             )
-            for base in t.type_obj.__mro__:
-                if base is t.type_obj or base is object:
-                    continue
-                if _is_private_type(base):
-                    continue
-                # First public ancestor: de-privatize if it has all
-                # accessed attributes, otherwise keep the private name.
+            if public_base is not None:
+                # De-privatize if the public ancestor has all accessed attributes.
+                sentinel = object()
+                check_attrs = accessed_attributes or frozenset(
+                    attr for attr in dir(t.type_obj)
+                    if getattr(t.type_obj, attr, None) is not None
+                    if not attr.startswith("_") or attr.startswith("__")
+                )
                 if all(
-                    (a := getattr(base, attr, sentinel)) is not sentinel
+                    (a := getattr(public_base, attr, sentinel)) is not sentinel
                     and a is getattr(t.type_obj, attr, sentinel)
                     for attr in check_attrs
                 ):
-                    return get_type_name(base)
-                break
+                    return get_type_name(public_base)
 
     # Flatten any non-typevar unions in the input so each leaf type
     # participates in the pairwise reduction. Otherwise lub treats `int|str`

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -387,8 +387,8 @@ def merged_types(
     if output_options.simplify_types:
         new_result = _merge_set(typeinfoset, for_variable, accessed_attributes)
         if old_result != new_result:
-            import logging
-            logging.getLogger('righttyper').debug(
+            import warnings
+            warnings.warn(
                 f"lub mismatch: {typeinfoset} for_variable={for_variable} "
                 f"attrs={accessed_attributes}\n  old={old_result}\n  new={new_result}"
             )

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -193,15 +193,21 @@ def merge_container_supersets(typeinfoset: set[TypeInfo]) -> set[TypeInfo]:
     return typeinfoset
 
 
-def merged_types(typeinfoset: set[TypeInfo], for_variable: bool = False) -> TypeInfo:
+def merged_types(
+    typeinfoset: set[TypeInfo],
+    for_variable: bool = False,
+    accessed_attributes: set[str] | None = None,
+) -> TypeInfo:
     """Attempts to merge types in a set before forming their union.
 
     Args:
         typeinfoset: Set of types to merge
         for_variable: If True, apply similar generics merging (safe for variables only)
+        accessed_attributes: If provided, attribute names accessed on this variable
+            (from static analysis), used to guide type simplification.
     """
-    if len(typeinfoset) > 1 and output_options.simplify_types:
-        typeinfoset = simplify(typeinfoset)
+    if output_options.simplify_types and (len(typeinfoset) > 1 or accessed_attributes):
+        typeinfoset = simplify(typeinfoset, accessed_attributes)
 
     if len(typeinfoset) > 1:
         if for_variable:
@@ -224,9 +230,13 @@ def merged_types(typeinfoset: set[TypeInfo], for_variable: bool = False) -> Type
     return TypeInfo.from_set(typeinfoset)
 
 
-def simplify(typeinfoset: set[TypeInfo]) -> set[TypeInfo]:
-    """Simplifies the set by replacing types with supertypes that contains
-       all common attributes.
+def simplify(typeinfoset: set[TypeInfo], accessed_attributes: set[str] | None = None) -> set[TypeInfo]:
+    """Simplifies the set by replacing types with supertypes that have
+       all required attributes.
+
+       If accessed_attributes is provided, only those attributes are considered
+       (from static analysis of the function body). Otherwise, falls back to
+       using dir() to find common attributes across the types.
     """
     # Types we support simplifying
     simplifiable_types = set(
@@ -311,18 +321,21 @@ def simplify(typeinfoset: set[TypeInfo]) -> set[TypeInfo]:
         new_mro.extend([int, float, complex, object][tower_index:])
         return tuple(new_mro)
 
-    # FIXME besides attribute presence, we should check their types/signatures
-    # FIXME we should check object attributes, not their classes'
-    common_attributes = set.intersection(
-        *(
-            set(
-                attr
-                for attr in dir(cast_not_None(t.type_obj))
-                if getattr(t.type_obj, attr, None) is not None
-                if not attr.startswith("_") or attr.startswith("__")
-            ) for t in mergeable_types
+    if accessed_attributes is not None:
+        common_attributes = accessed_attributes
+    else:
+        # FIXME besides attribute presence, we should check their types/signatures
+        # FIXME we should check object attributes, not their classes'
+        common_attributes = set.intersection(
+            *(
+                set(
+                    attr
+                    for attr in dir(cast_not_None(t.type_obj))
+                    if getattr(t.type_obj, attr, None) is not None
+                    if not attr.startswith("_") or attr.startswith("__")
+                ) for t in mergeable_types
+            )
         )
-    )
 
     # Get the superclasses, if any, that have all the common attributes
     common_supertypes = defaultdict(list)
@@ -346,7 +359,13 @@ def simplify(typeinfoset: set[TypeInfo]) -> set[TypeInfo]:
     # on the list, after sorting by how many types they replace, are as specific as possible.
     for st, types in sorted(common_supertypes.items(), key=lambda item: -len(item[1])):
         if len(types) == 1:
-            break   # we're not interested in 1-for-1 exchanges
+            if accessed_attributes is None:
+                break   # without accessed_attributes, 1-for-1 exchanges aren't useful
+            # With accessed_attributes, generalize a single type to its base
+            # if the base has all accessed attributes (e.g., PosixPath → Path).
+            # Skip self-replacement (type replacing itself with itself).
+            if types[0].type_obj is st:
+                continue
 
         if any(t in mergeable_types for t in types):
             mergeable_types -= set(types)

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -212,6 +212,17 @@ def merge_container_supersets(typeinfoset: set[TypeInfo]) -> set[TypeInfo]:
     return typeinfoset
 
 
+def _is_empty_container(t: TypeInfo) -> bool:
+    """Check if t represents an empty container (e.g., tuple[()], list[Never], dict[Never, Never])."""
+    import typing
+    if t.type_obj is tuple and t.args == ((),):
+        return True
+    return bool(t.args
+                and isinstance(t.type_obj, type) and issubclass(t.type_obj, abc.Container)
+                and all(isinstance(a, TypeInfo) and a.type_obj is typing.Never
+                        for a in t.args))
+
+
 def merged_types(
     typeinfoset: set[TypeInfo],
     for_variable: bool = False,
@@ -245,6 +256,32 @@ def merged_types(
                     typeinfoset = merge_similar_generics(covariant) | others
             if len(typeinfoset) > 1:
                 typeinfoset = _subsume_fixed_by_varlen_tuples(typeinfoset)
+
+    # Cross-container ABC merge: find a common ABC for different container
+    # types (e.g., list[int] | tuple[int,...] → Sequence[int]).
+    # Empty containers are dropped first (they're compatible with any element type).
+    if len(typeinfoset) > 1 and accessed_attributes:
+        typeinfoset -= {t for t in typeinfoset if _is_empty_container(t)} or set()
+        # Generics with TypeInfo args — group by number of TypeInfo args
+        generics = {t for t in typeinfoset
+                    if t.args and isinstance(t.args[0], TypeInfo) and isinstance(t.type_obj, type)}
+        n_type_args = {sum(isinstance(a, TypeInfo) for a in t.args) for t in generics}
+        if len(generics) >= (2 if len(typeinfoset) > 1 else 1) and len(n_type_args) == 1:
+            n = next(iter(n_type_args))
+            candidates = [g for g, attrs in _abc_own_attrs.items()
+                          if accessed_attributes <= attrs
+                          and all(issubclass(t.type_obj, g) for t in generics)]
+            if candidates:
+                best = max(candidates, key=lambda g: len(g.__mro__))
+                # Merge corresponding TypeInfo args across all generics
+                merged_args = tuple(
+                    TypeInfo.from_set({cast(TypeInfo, [a for a in t.args if isinstance(a, TypeInfo)][i])
+                                       for t in generics})
+                    for i in range(n)
+                )
+                abc_result = (typeinfoset - generics) | {get_type_name(best).replace(args=merged_args)}
+                if len(abc_result) < len(typeinfoset):
+                    typeinfoset = abc_result
 
     return TypeInfo.from_set(typeinfoset)
 

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -381,12 +381,15 @@ def _merge_set(
                     continue
                 if _is_private_type(base):
                     continue
+                # First public ancestor: de-privatize if it has all
+                # accessed attributes, otherwise keep the private name.
                 if all(
                     (a := getattr(base, attr, sentinel)) is not sentinel
                     and a is getattr(t.type_obj, attr, sentinel)
                     for attr in check_attrs
                 ):
                     return get_type_name(base)
+                break
 
     # Flatten any non-typevar unions in the input so each leaf type
     # participates in the pairwise reduction. Otherwise lub treats `int|str`

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -125,6 +125,30 @@ def lub(
                 if a.args == ((),) or all(type_contains(elem, cast(TypeInfo, x)) for x in a.args):
                     return b
 
+    # Rule 6: Empty container subsumed by compatible non-empty container
+    _CONTAINER_ABCS = (abc.Sequence, abc.Mapping, abc.Set)
+
+    def _compatible_containers(t1: TypeInfo, t2: TypeInfo) -> bool:
+        """Check if t1 and t2 share a common container ABC."""
+        if not (isinstance(t1.type_obj, type) and isinstance(t2.type_obj, type)):
+            return False
+        return any(issubclass(t1.type_obj, g) and issubclass(t2.type_obj, g)
+                   for g in _CONTAINER_ABCS)
+
+    if _is_empty_container(a) and b.args and _compatible_containers(a, b):
+        return b
+    if _is_empty_container(b) and a.args and _compatible_containers(a, b):
+        return a
+
+    # Rule 7: MRO common supertype (non-generic types only)
+    if (not a.args and not b.args
+        and isinstance(a.type_obj, type) and isinstance(b.type_obj, type)):
+        a_mro = set(a.type_obj.__mro__)
+        for base in b.type_obj.__mro__:
+            if base in a_mro and base is not object:
+                if base not in (int, float, complex):
+                    return get_type_name(base)
+
     # Rule 9: Fallback — union
     return TypeInfo.from_set_new({a, b})
 

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -1,4 +1,4 @@
-from typing import cast, Sequence, Iterator
+from typing import cast, Sequence, Iterator, Any, Never, NoReturn
 import collections.abc as abc
 from collections import defaultdict, Counter
 from types import EllipsisType
@@ -46,6 +46,16 @@ def _build_abc_own_attrs() -> dict[type, frozenset[str]]:
 _abc_own_attrs = _build_abc_own_attrs()
 
 
+def _find_common_container_abc(t1: TypeInfo, t2: TypeInfo) -> type | None:
+    """Find the most specific generic container ABC both types implement."""
+    if not (isinstance(t1.type_obj, type) and isinstance(t2.type_obj, type)):
+        return None
+    for g in _CONTAINER_ABCS:
+        if issubclass(t1.type_obj, g) and issubclass(t2.type_obj, g):
+            return g
+    return None
+
+
 # Numeric tower: int <: float <: complex (PEP 3141)
 _NUMERIC_TOWER = {int: float, float: complex}
 
@@ -76,22 +86,20 @@ def lub(
     Returns a single TypeInfo that contains both a and b. Falls back to
     a union (a | b) when no better merge is available.
     """
-    import typing
-
     # Rule 1: Identity
     if a == b:
         return a
 
     # Rule 2: Never/NoReturn subsumption
-    if a.type_obj in (typing.Never, typing.NoReturn):
+    if a.type_obj in (Never, NoReturn):
         return b
-    if b.type_obj in (typing.Never, typing.NoReturn):
+    if b.type_obj in (Never, NoReturn):
         return a
 
     # Rule 3: Any subsumption
-    if a.type_obj is typing.Any:
+    if a.type_obj is Any:
         return a
-    if b.type_obj is typing.Any:
+    if b.type_obj is Any:
         return b
 
     # Rule 4: Subtype check (MRO + numeric tower)
@@ -174,22 +182,12 @@ def lub(
 
     # Rule 6: Empty container + non-empty container → common ABC with element type.
     # E.g., tuple[()] + list[int] → Sequence[int].
-    def _find_common_container_abc(t1: TypeInfo, t2: TypeInfo) -> type | None:
-        if not (isinstance(t1.type_obj, type) and isinstance(t2.type_obj, type)):
-            return None
-        for g in _CONTAINER_ABCS:
-            if issubclass(t1.type_obj, g) and issubclass(t2.type_obj, g):
-                return g
-        return None
-
-    if (_is_empty_container(a) and b.args and isinstance(b.args[0], TypeInfo)
-        and a.type_obj is not b.type_obj):  # different containers only
-        if (common := _find_common_container_abc(a, b)):
-            return get_type_name(common).replace(args=(b.args[0],))
-    if (_is_empty_container(b) and a.args and isinstance(a.args[0], TypeInfo)
-        and a.type_obj is not b.type_obj):
-        if (common := _find_common_container_abc(a, b)):
-            return get_type_name(common).replace(args=(a.args[0],))
+    if a.type_obj is not b.type_obj:  # different containers only
+        empty, nonempty = (a, b) if _is_empty_container(a) else (b, a) if _is_empty_container(b) else (None, None)
+        if (empty is not None and nonempty is not None
+            and nonempty.args and isinstance(nonempty.args[0], TypeInfo)):
+            if (common := _find_common_container_abc(empty, nonempty)):
+                return get_type_name(common).replace(args=(nonempty.args[0],))
 
     # Rule 7: MRO common supertype (non-generic types only).
     if (not a.args and not b.args
@@ -237,6 +235,7 @@ def lub(
                     either_immutable = (
                         issubclass(a.type_obj, _COVARIANT_TYPES)
                         or issubclass(b.type_obj, _COVARIANT_TYPES)
+                        or a.type_obj is type or b.type_obj is type
                     )
                     if for_variable or either_immutable:
                         merged_args = tuple(
@@ -262,8 +261,7 @@ def _merge_set(
 ) -> TypeInfo:
     """Reduce a set of types using pairwise lub, then form the final union."""
     if not typeinfoset:
-        import typing
-        return TypeInfo.from_type(typing.Never)
+        return TypeInfo.from_type(Never)
 
     # Iteratively reduce: try to merge pairs until stable
     types = list(typeinfoset)
@@ -469,12 +467,11 @@ def merge_container_supersets(typeinfoset: set[TypeInfo]) -> set[TypeInfo]:
 
 def _is_empty_container(t: TypeInfo) -> bool:
     """Check if t represents an empty container (e.g., tuple[()], list[Never], dict[Never, Never])."""
-    import typing
     if t.type_obj is tuple and t.args == ((),):
         return True
     return bool(t.args
                 and isinstance(t.type_obj, type) and issubclass(t.type_obj, abc.Container)
-                and all(isinstance(a, TypeInfo) and a.type_obj is typing.Never
+                and all(isinstance(a, TypeInfo) and a.type_obj is Never
                         for a in t.args))
 
 

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -389,6 +389,10 @@ def merged_types(
 ) -> TypeInfo:
     """Attempts to merge types in a set before forming their union."""
     if output_options.simplify_types:
+        # Static-analysis simplification (single-type MRO walk + Rule-8 ABC matching)
+        # is gated separately; honor the flag here so callers don't need to.
+        if not output_options.use_attribute_simplification:
+            accessed_attributes = None
         return _merge_set(typeinfoset, for_variable, accessed_attributes)
     return TypeInfo.from_set(typeinfoset)
 

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -366,6 +366,8 @@ def _merge_set(
             for base in t.type_obj.__mro__:
                 if base is t.type_obj or base is object:
                     continue
+                if _is_private_type(base):
+                    continue
                 if all(
                     (a := getattr(base, attr, sentinel)) is not sentinel
                     and a is getattr(t.type_obj, attr, sentinel)

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -26,6 +26,9 @@ _CONTAINER_ABCS: list[type] = [
     if isinstance(obj, type) and hasattr(obj, '__class_getitem__') and issubclass(obj, abc.Container)
 ]
 
+# Container ABCs that take 2 type parameters (KT, VT); all others take 1.
+_TWO_PARAM_ABCS: frozenset[type] = frozenset({abc.Mapping, abc.MutableMapping, abc.ItemsView})
+
 
 def is_homogeneous(types: tuple[TypeInfo, ...] | list[TypeInfo]) -> bool:
     """Whether the tuple only contains instances of a single, consistent generic type
@@ -216,14 +219,24 @@ def lub(
                 if a.args == ((),):
                     return a
 
-    # Rule 6: Empty container + non-empty container → common ABC with element type.
-    # E.g., tuple[()] + list[int] → Sequence[int].
+    # Rule 6: Empty container + non-empty container → MRO common supertype
+    # with the non-empty container's args (the empty side contributes nothing).
+    # E.g., dict[Never,Never] + defaultdict[str, list[X]] → dict[str, list[X]].
     if a.type_obj is not b.type_obj:  # different containers only
         empty, nonempty = (a, b) if _is_empty_container(a) else (b, a) if _is_empty_container(b) else (None, None)
-        if (empty is not None and nonempty is not None
-            and nonempty.args and isinstance(nonempty.args[0], TypeInfo)):
-            if (common := _find_common_container_abc(empty, nonempty)):
-                return get_type_name(common).replace(args=(nonempty.args[0],))
+        if empty is not None and nonempty is not None and nonempty.args:
+            # Find MRO common supertype between the two container types
+            e_obj, ne_obj = cast(type, empty.type_obj), cast(type, nonempty.type_obj)
+            for cls in ne_obj.__mro__:
+                if issubclass(e_obj, cls) and cls is not object:
+                    return get_type_name(cls).replace(args=nonempty.args)
+            # Fallback to ABC if no direct MRO relationship
+            if isinstance(nonempty.args[0], TypeInfo):
+                if (common := _find_common_container_abc(empty, nonempty)):
+                    nparams = 2 if common in _TWO_PARAM_ABCS else 1
+                    return get_type_name(common).replace(
+                        args=tuple(a for a in nonempty.args[:nparams] if isinstance(a, TypeInfo))
+                    )
 
     # Rule 7: MRO common supertype (non-generic types only).
     if not a.args and not b.args:

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -351,9 +351,10 @@ def simplify(typeinfoset: set[TypeInfo], accessed_attributes: set[str] | None = 
 
 #    print("common_supertypes=", {k: [str(t) for t in v] for k, v in common_supertypes.items() if len(v)>1})
 
-    # Since we want types that are as specific as possible, save the replacements in a separate set,
-    # so that they don't get replaced as well.
-    replacements = set()
+    # MRO-based merge: replace types with the most specific common supertype.
+    # Save replacements separately so they don't get replaced in turn.
+    mro_mergeable = set(mergeable_types)
+    mro_replacements: set[TypeInfo] = set()
 
     # 'defaultdict' retains insertion order, and 'sorted' is stable, so the first supertypes
     # on the list, after sorting by how many types they replace, are as specific as possible.
@@ -367,14 +368,16 @@ def simplify(typeinfoset: set[TypeInfo], accessed_attributes: set[str] | None = 
             if types[0].type_obj is st:
                 continue
 
-        if any(t in mergeable_types for t in types):
-            mergeable_types -= set(types)
-            replacements.add(get_type_name(st))
+        if any(t in mro_mergeable for t in types):
+            mro_mergeable -= set(types)
+            mro_replacements.add(get_type_name(st))
 
-    # ABC fallback: when types remain unmerged and we have accessed_attributes,
-    # try to find a collections.abc ABC that all remaining types implement and
-    # that has all the accessed attributes.
-    if accessed_attributes and mergeable_types and len(mergeable_types) > len(replacements):
+    mro_result = mro_mergeable | mro_replacements | other_types
+
+    # ABC matching: try to find a collections.abc ABC that all original
+    # mergeable types structurally implement and that covers the accessed
+    # attributes. Use it only if it produces a shorter result than MRO.
+    if accessed_attributes:
         from righttyper.type_id import ABCFinder
 
         def structurally_implements(t: type, abc_type: type) -> bool:
@@ -384,7 +387,6 @@ def simplify(typeinfoset: set[TypeInfo], accessed_attributes: set[str] | None = 
 
         def abc_provides(abc_type: type, attributes: set[str]) -> bool:
             """Check if the ABC's own interface (not inherited from object) covers the attributes."""
-            # The ABC's own methods: abstract + concrete defined on the ABC itself
             own_attrs = set(getattr(abc_type, '__abstractmethods__', set()))
             for cls in abc_type.__mro__:
                 if cls is object:
@@ -392,8 +394,6 @@ def simplify(typeinfoset: set[TypeInfo], accessed_attributes: set[str] | None = 
                 own_attrs |= set(cls.__dict__)
             return attributes <= own_attrs
 
-        # Find ABCs that every remaining type structurally implements
-        # and whose own interface covers the accessed attributes
         abc_candidates = None
         for t in mergeable_types:
             abcs = {
@@ -405,12 +405,16 @@ def simplify(typeinfoset: set[TypeInfo], accessed_attributes: set[str] | None = 
             abc_candidates = abcs if abc_candidates is None else abc_candidates & abcs
 
         if abc_candidates:
-            # Pick the most specific ABC (deepest MRO)
             best = max(abc_candidates, key=lambda g: len(g.__mro__))
-            mergeable_types.clear()
-            replacements.add(get_type_name(best))
+            abc_result = {get_type_name(best)} | other_types
+            # Use ABC when it's strictly shorter, or when MRO made no
+            # improvement (e.g., single type with no useful supertype).
+            if len(abc_result) < len(mro_result) or (
+                len(abc_result) == len(mro_result) and not mro_replacements
+            ):
+                return abc_result
 
-    return mergeable_types | replacements | other_types
+    return mro_result
 
 
 def generalize_jaxtyping(samples: Sequence[CallTrace]) -> Sequence[CallTrace]:

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -32,6 +32,103 @@ def _build_abc_own_attrs() -> dict[type, frozenset[str]]:
 _abc_own_attrs = _build_abc_own_attrs()
 
 
+# Numeric tower: int <: float <: complex (PEP 3141)
+_NUMERIC_TOWER = {int: float, float: complex}
+
+
+def _is_subtype(a: type, b: type) -> bool:
+    """Check if a is a subtype of b, including the numeric tower."""
+    if a is b:
+        return True
+    if issubclass(a, b):
+        return True
+    # Numeric tower: int <: float <: complex
+    t = a
+    while t in _NUMERIC_TOWER:
+        t = _NUMERIC_TOWER[t]
+        if t is b:
+            return True
+    return False
+
+
+def lub(
+    a: TypeInfo,
+    b: TypeInfo,
+    for_variable: bool = False,
+    accessed_attributes: set[str] | None = None,
+) -> TypeInfo:
+    """Compute the least upper bound (most specific common supertype) of two types.
+
+    Returns a single TypeInfo that contains both a and b. Falls back to
+    a union (a | b) when no better merge is available.
+    """
+    import typing
+
+    # Rule 1: Identity
+    if a == b:
+        return a
+
+    # Rule 2: Never/NoReturn subsumption
+    if a.type_obj in (typing.Never, typing.NoReturn):
+        return b
+    if b.type_obj in (typing.Never, typing.NoReturn):
+        return a
+
+    # Rule 3: Any subsumption
+    if a.type_obj is typing.Any:
+        return a
+    if b.type_obj is typing.Any:
+        return b
+
+    # Rule 4: Subtype check (MRO + numeric tower)
+    if (isinstance(a.type_obj, type) and isinstance(b.type_obj, type)
+        and not a.args and not b.args):
+        if _is_subtype(a.type_obj, b.type_obj):
+            return b
+        if _is_subtype(b.type_obj, a.type_obj):
+            return a
+
+    # Rule 5: Same container, different args
+    if (a.module == b.module and a.name == b.name
+        and a.args and b.args and len(a.args) == len(b.args)
+        and isinstance(a.type_obj, type)):
+        is_covariant = issubclass(a.type_obj, _COVARIANT_TYPES)
+        if for_variable or is_covariant:
+            # Check args are all TypeInfo or matching non-TypeInfo (e.g., Ellipsis)
+            can_merge = all(
+                (isinstance(aa, TypeInfo) and isinstance(ba, TypeInfo))
+                or aa is ba  # both Ellipsis, both (), etc.
+                for aa, ba in zip(a.args, b.args)
+            )
+            if can_merge:
+                merged_args = tuple(
+                    lub(cast(TypeInfo, aa), cast(TypeInfo, ba), for_variable=True)
+                    if isinstance(aa, TypeInfo) and isinstance(ba, TypeInfo)
+                    else aa
+                    for aa, ba in zip(a.args, b.args)
+                )
+                return a.replace(args=merged_args)
+
+        # Varlen tuple subsumes fixed tuple
+        if a.type_obj is tuple:
+            a_varlen = len(a.args) == 2 and a.args[1] is Ellipsis and isinstance(a.args[0], TypeInfo)
+            b_varlen = len(b.args) == 2 and b.args[1] is Ellipsis and isinstance(b.args[0], TypeInfo)
+            a_fixed = all(isinstance(x, TypeInfo) for x in a.args) and not a_varlen
+            b_fixed = all(isinstance(x, TypeInfo) for x in b.args) and not b_varlen
+
+            if a_varlen and (b_fixed or b.args == ((),)):
+                elem = cast(TypeInfo, a.args[0])
+                if b.args == ((),) or all(type_contains(elem, cast(TypeInfo, x)) for x in b.args):
+                    return a
+            if b_varlen and (a_fixed or a.args == ((),)):
+                elem = cast(TypeInfo, b.args[0])
+                if a.args == ((),) or all(type_contains(elem, cast(TypeInfo, x)) for x in a.args):
+                    return b
+
+    # Rule 9: Fallback — union
+    return TypeInfo.from_set({a, b})
+
+
 def merge_similar_generics(typeinfoset: set[TypeInfo]) -> set[TypeInfo]:
     """Merge generics with same container but different type args.
 

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -15,10 +15,10 @@ _COVARIANT_TYPES = (tuple, frozenset)
 
 
 # Precomputed ABC data for structural matching in simplify().
-def _build_abc_caches() -> tuple[dict[type, frozenset[str]], dict[type, frozenset[str]]]:
+def _build_abc_own_attrs() -> dict[type, frozenset[str]]:
+    """Precompute the own attributes (excluding object) for each collections.abc ABC."""
     from abc import ABCMeta
-    own_attrs: dict[type, frozenset[str]] = {}
-    abstract_methods: dict[type, frozenset[str]] = {}
+    result: dict[type, frozenset[str]] = {}
     for obj in vars(abc).values():
         if isinstance(obj, ABCMeta):
             attrs: set[str] = set()
@@ -26,11 +26,10 @@ def _build_abc_caches() -> tuple[dict[type, frozenset[str]], dict[type, frozense
                 if cls is object:
                     break
                 attrs |= set(cls.__dict__)
-            own_attrs[obj] = frozenset(attrs)
-            abstract_methods[obj] = frozenset(getattr(obj, '__abstractmethods__', set()))
-    return own_attrs, abstract_methods
+            result[obj] = frozenset(attrs)
+    return result
 
-_abc_own_attrs, _abc_abstractmethods = _build_abc_caches()
+_abc_own_attrs = _build_abc_own_attrs()
 
 
 def merge_similar_generics(typeinfoset: set[TypeInfo]) -> set[TypeInfo]:
@@ -420,8 +419,11 @@ def simplify(typeinfoset: set[TypeInfo], accessed_attributes: set[str] | None = 
                 break   # without accessed_attributes, 1-for-1 exchanges aren't useful
             # With accessed_attributes, generalize a single type to its base
             # if the base has all accessed attributes (e.g., PosixPath → Path).
-            # Skip self-replacement (type replacing itself with itself).
+            # Skip self-replacement and numeric tower widening (float → complex
+            # is technically valid but not useful).
             if types[0].type_obj is st:
+                continue
+            if st in (int, float, complex):
                 continue
 
         if any(t in mro_mergeable for t in types):
@@ -433,7 +435,7 @@ def simplify(typeinfoset: set[TypeInfo], accessed_attributes: set[str] | None = 
     # ABC matching: try to find a collections.abc ABC that all original
     # mergeable types structurally implement and that covers the accessed
     # attributes. Use it only if it produces a shorter result than MRO.
-    if accessed_attributes:
+    if accessed_attributes and len(mro_result) > 1:
         # Pre-filter ABCs whose interface covers the accessed attributes (cheap set check)
         candidates = [g for g, attrs in _abc_own_attrs.items()
                        if accessed_attributes <= attrs]
@@ -444,18 +446,13 @@ def simplify(typeinfoset: set[TypeInfo], accessed_attributes: set[str] | None = 
                 if type(t.type_obj) is not type:
                     abc_candidates = set()
                     break
-                t_attrs = frozenset(dir(t.type_obj))
-                abcs = {g for g in candidates if _abc_abstractmethods[g] <= t_attrs}
+                abcs = {g for g in candidates if issubclass(t.type_obj, g)}
                 abc_candidates = abcs if abc_candidates is None else abc_candidates & abcs
 
             if abc_candidates:
                 best = max(abc_candidates, key=lambda g: len(g.__mro__))
                 abc_result = {get_type_name(best)} | other_types
-                # Use ABC when it's strictly shorter, or when MRO made no
-                # improvement (e.g., single type with no useful supertype).
-                if len(abc_result) < len(mro_result) or (
-                    len(abc_result) == len(mro_result) and not mro_replacements
-                ):
+                if len(abc_result) < len(mro_result):
                     return abc_result
 
     return mro_result

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -130,8 +130,8 @@ def lub(
             if a.type_obj is tuple:
                 a_varlen = len(a.args) == 2 and a.args[1] is Ellipsis and isinstance(a.args[0], TypeInfo)
                 b_varlen = len(b.args) == 2 and b.args[1] is Ellipsis and isinstance(b.args[0], TypeInfo)
-                a_fixed = all(isinstance(x, TypeInfo) for x in a.args) and not a_varlen
-                b_fixed = all(isinstance(x, TypeInfo) for x in b.args) and not b_varlen
+                a_fixed = not a_varlen and all(isinstance(x, TypeInfo) for x in a.args)
+                b_fixed = not b_varlen and all(isinstance(x, TypeInfo) for x in b.args)
 
                 if a_varlen and (b_fixed or b.args == ((),)):
                     elem = cast(TypeInfo, a.args[0])

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -349,8 +349,18 @@ def _merge_set(
                 ):
                     return get_type_name(base)
 
+    # Flatten any non-typevar unions in the input so each leaf type
+    # participates in the pairwise reduction. Otherwise lub treats `int|str`
+    # as opaque (its type_obj isn't a real `type`) and never gets to compare
+    # `bool` against `int` to discover `bool ⊆ int`. Typevar'd unions stay
+    # opaque — they represent a single named variable, not a leaf set.
+    types = list({
+        leaf
+        for t in typeinfoset
+        for leaf in ({t} if t.is_typevar() else t.to_set())
+    })
+
     # Iteratively reduce: try to merge pairs until stable
-    types = list(typeinfoset)
     changed = True
     while changed:
         changed = False

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -1,4 +1,5 @@
 from typing import cast, Sequence, Iterator, Any, Never, NoReturn
+from abc import ABCMeta
 import collections.abc as abc
 from collections import Counter
 from types import EllipsisType
@@ -26,8 +27,6 @@ _CONTAINER_ABCS: list[type] = [
     if isinstance(obj, type) and hasattr(obj, '__class_getitem__') and issubclass(obj, abc.Container)
 ]
 
-# Container ABCs that take 2 type parameters (KT, VT); all others take 1.
-_TWO_PARAM_ABCS: frozenset[type] = frozenset({abc.Mapping, abc.MutableMapping, abc.ItemsView})
 
 
 def is_homogeneous(types: tuple[TypeInfo, ...] | list[TypeInfo]) -> bool:
@@ -65,7 +64,6 @@ def is_homogeneous(types: tuple[TypeInfo, ...] | list[TypeInfo]) -> bool:
 # Precomputed ABC data for structural matching in lub.
 def _build_abc_own_attrs() -> dict[type, frozenset[str]]:
     """Precompute the own attributes (excluding object) for each collections.abc ABC."""
-    from abc import ABCMeta
     result: dict[type, frozenset[str]] = {}
     for obj in vars(abc).values():
         if isinstance(obj, ABCMeta):
@@ -142,6 +140,19 @@ def lub(
         return a
     if b.type_obj is Any:
         return b
+
+    # Reduce Generator/AsyncGenerator to Iterator/AsyncIterator before merging,
+    # so their extra args (send, return) don't leak into ABC matches.
+    def _reduce_generator(t: TypeInfo) -> TypeInfo:
+        if t.type_obj is abc.Generator and len(t.args) == 3:
+            return TypeInfo.from_type(abc.Iterator, args=(t.args[0],) if isinstance(t.args[0], TypeInfo) else ())
+        if t.type_obj is abc.AsyncGenerator and len(t.args) == 2:
+            return TypeInfo.from_type(abc.AsyncIterator, args=(t.args[0],) if isinstance(t.args[0], TypeInfo) else ())
+        return t
+
+    a, b = _reduce_generator(a), _reduce_generator(b)
+    if a == b:
+        return a
 
     # Without a real type (could be None or a typing special form),
     # no merging rules apply.
@@ -225,18 +236,25 @@ def lub(
     if a.type_obj is not b.type_obj:  # different containers only
         empty, nonempty = (a, b) if _is_empty_container(a) else (b, a) if _is_empty_container(b) else (None, None)
         if empty is not None and nonempty is not None and nonempty.args:
-            # Find MRO common supertype between the two container types
             e_obj, ne_obj = cast(type, empty.type_obj), cast(type, nonempty.type_obj)
+            # MRO walk: find nearest common supertype (includes ABCs
+            # explicitly inherited, e.g. Generator → Iterator → Iterable)
+            common: type | None = None
             for cls in ne_obj.__mro__:
                 if issubclass(e_obj, cls) and cls is not object:
-                    return get_type_name(cls).replace(args=nonempty.args)
-            # Fallback to ABC if no direct MRO relationship
-            if isinstance(nonempty.args[0], TypeInfo):
-                if (common := _find_common_container_abc(empty, nonempty)):
-                    nparams = 2 if common in _TWO_PARAM_ABCS else 1
-                    return get_type_name(common).replace(
-                        args=tuple(a for a in nonempty.args[:nparams] if isinstance(a, TypeInfo))
-                    )
+                    common = cls
+                    break
+            else:
+                # Fallback: virtual ABC registration (e.g. list + dict → Collection)
+                if isinstance(nonempty.args[0], TypeInfo):
+                    common = _find_common_container_abc(empty, nonempty)
+
+            if common is not None:
+                # Mappings (abc or concrete) take 2 type params; all other
+                # containers take 1.
+                nparams = 2 if issubclass(common, abc.Mapping) else 1
+                args = tuple(a for a in nonempty.args[:nparams] if isinstance(a, TypeInfo))
+                return get_type_name(common).replace(args=args)
 
     # Rule 7: MRO common supertype (non-generic types only).
     if not a.args and not b.args:

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -371,6 +371,45 @@ def simplify(typeinfoset: set[TypeInfo], accessed_attributes: set[str] | None = 
             mergeable_types -= set(types)
             replacements.add(get_type_name(st))
 
+    # ABC fallback: when types remain unmerged and we have accessed_attributes,
+    # try to find a collections.abc ABC that all remaining types implement and
+    # that has all the accessed attributes.
+    if accessed_attributes and mergeable_types and len(mergeable_types) > len(replacements):
+        from righttyper.type_id import ABCFinder
+
+        def structurally_implements(t: type, abc_type: type) -> bool:
+            """Check if t has all abstract methods required by abc_type."""
+            required = getattr(abc_type, '__abstractmethods__', set())
+            return all(hasattr(t, m) for m in required)
+
+        def abc_provides(abc_type: type, attributes: set[str]) -> bool:
+            """Check if the ABC's own interface (not inherited from object) covers the attributes."""
+            # The ABC's own methods: abstract + concrete defined on the ABC itself
+            own_attrs = set(getattr(abc_type, '__abstractmethods__', set()))
+            for cls in abc_type.__mro__:
+                if cls is object:
+                    break
+                own_attrs |= set(cls.__dict__)
+            return attributes <= own_attrs
+
+        # Find ABCs that every remaining type structurally implements
+        # and whose own interface covers the accessed attributes
+        abc_candidates = None
+        for t in mergeable_types:
+            abcs = {
+                g for g in ABCFinder._ABCs
+                if type(t.type_obj) is type
+                and structurally_implements(t.type_obj, g)
+                and abc_provides(g, accessed_attributes)
+            }
+            abc_candidates = abcs if abc_candidates is None else abc_candidates & abcs
+
+        if abc_candidates:
+            # Pick the most specific ABC (deepest MRO)
+            best = max(abc_candidates, key=lambda g: len(g.__mro__))
+            mergeable_types.clear()
+            replacements.add(get_type_name(best))
+
     return mergeable_types | replacements | other_types
 
 

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -58,7 +58,7 @@ def is_homogeneous(types: tuple[TypeInfo, ...] | list[TypeInfo]) -> bool:
     )
 
 
-# Precomputed ABC data for structural matching in simplify().
+# Precomputed ABC data for structural matching in lub.
 def _build_abc_own_attrs() -> dict[type, frozenset[str]]:
     """Precompute the own attributes (excluding object) for each collections.abc ABC."""
     from abc import ABCMeta

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -88,28 +88,24 @@ def lub(
         if _is_subtype(b.type_obj, a.type_obj):
             return a
 
+    # Rule 4b: Bare generic subsumes parametrized (list subsumes list[int]).
+    # Only for types where bare means "Any args": containers and ABC generics.
+    _BARE_SUBSUMES = (abc.Callable, abc.Iterator, abc.AsyncIterator, abc.Iterable,
+                      abc.Generator, abc.AsyncGenerator, abc.Coroutine)
+    if (a.module == b.module and a.name == b.name
+        and isinstance(a.type_obj, type)
+        and (a.type_obj in _BARE_SUBSUMES or issubclass(a.type_obj, abc.Container))):
+        if not a.args and b.args:
+            return a
+        if a.args and not b.args:
+            return b
+
     # Rule 5: Same container, different args
     if (a.module == b.module and a.name == b.name
-        and a.args and b.args and len(a.args) == len(b.args)
+        and a.args and b.args
         and isinstance(a.type_obj, type)):
-        is_covariant = issubclass(a.type_obj, _COVARIANT_TYPES)
-        if for_variable or is_covariant:
-            # Check args are all TypeInfo or matching non-TypeInfo (e.g., Ellipsis)
-            can_merge = all(
-                (isinstance(aa, TypeInfo) and isinstance(ba, TypeInfo))
-                or aa is ba  # both Ellipsis, both (), etc.
-                for aa, ba in zip(a.args, b.args)
-            )
-            if can_merge:
-                merged_args = tuple(
-                    lub(cast(TypeInfo, aa), cast(TypeInfo, ba), for_variable=True)
-                    if isinstance(aa, TypeInfo) and isinstance(ba, TypeInfo)
-                    else aa
-                    for aa, ba in zip(a.args, b.args)
-                )
-                return a.replace(args=merged_args)
 
-        # Varlen tuple subsumes fixed tuple
+        # Rule 5a: Varlen tuple subsumes fixed tuple (different arg lengths OK)
         if a.type_obj is tuple:
             a_varlen = len(a.args) == 2 and a.args[1] is Ellipsis and isinstance(a.args[0], TypeInfo)
             b_varlen = len(b.args) == 2 and b.args[1] is Ellipsis and isinstance(b.args[0], TypeInfo)
@@ -125,28 +121,74 @@ def lub(
                 if a.args == ((),) or all(type_contains(elem, cast(TypeInfo, x)) for x in a.args):
                     return b
 
-    # Rule 6: Empty container subsumed by compatible non-empty container
+        # Rule 5b: Same container, empty subsumed by non-empty
+        if _is_empty_container(a):
+            return b
+        if _is_empty_container(b):
+            return a
+
+        # Rule 5c: Same container, same arg count — merge args
+        if len(a.args) == len(b.args):
+            is_covariant = issubclass(a.type_obj, _COVARIANT_TYPES)
+            if for_variable or is_covariant:
+                can_merge = all(
+                    (isinstance(aa, TypeInfo) and isinstance(ba, TypeInfo))
+                    or aa is ba
+                    for aa, ba in zip(a.args, b.args)
+                )
+                if can_merge:
+                    merged_args = tuple(
+                        lub(cast(TypeInfo, aa), cast(TypeInfo, ba), for_variable=True)
+                        if isinstance(aa, TypeInfo) and isinstance(ba, TypeInfo)
+                        else aa
+                        for aa, ba in zip(a.args, b.args)
+                    )
+                    return a.replace(args=merged_args)
+
+    # Rule 6: Empty container + non-empty container → common ABC with element type.
+    # E.g., tuple[()] + list[int] → Sequence[int].
     _CONTAINER_ABCS = (abc.Sequence, abc.Mapping, abc.Set)
 
-    def _compatible_containers(t1: TypeInfo, t2: TypeInfo) -> bool:
-        """Check if t1 and t2 share a common container ABC."""
+    def _find_common_container_abc(t1: TypeInfo, t2: TypeInfo) -> type | None:
         if not (isinstance(t1.type_obj, type) and isinstance(t2.type_obj, type)):
-            return False
-        return any(issubclass(t1.type_obj, g) and issubclass(t2.type_obj, g)
-                   for g in _CONTAINER_ABCS)
+            return None
+        for g in _CONTAINER_ABCS:
+            if issubclass(t1.type_obj, g) and issubclass(t2.type_obj, g):
+                return g
+        return None
 
-    if _is_empty_container(a) and b.args and _compatible_containers(a, b):
-        return b
-    if _is_empty_container(b) and a.args and _compatible_containers(a, b):
-        return a
+    if (_is_empty_container(a) and b.args and isinstance(b.args[0], TypeInfo)
+        and a.type_obj is not b.type_obj):  # different containers only
+        if (common := _find_common_container_abc(a, b)):
+            return get_type_name(common).replace(args=(b.args[0],))
+    if (_is_empty_container(b) and a.args and isinstance(a.args[0], TypeInfo)
+        and a.type_obj is not b.type_obj):
+        if (common := _find_common_container_abc(a, b)):
+            return get_type_name(common).replace(args=(a.args[0],))
 
-    # Rule 7: MRO common supertype (non-generic types only)
+    # Rule 7: MRO common supertype (non-generic types only).
     if (not a.args and not b.args
         and isinstance(a.type_obj, type) and isinstance(b.type_obj, type)):
+        if accessed_attributes:
+            common_attrs = accessed_attributes
+        else:
+            # Without accessed_attributes, use dir() intersection as safety filter:
+            # only merge to a supertype that has all the shared attributes.
+            common_attrs = (
+                {attr for attr in dir(a.type_obj)
+                 if getattr(a.type_obj, attr, None) is not None
+                 if not attr.startswith("_") or attr.startswith("__")}
+                &
+                {attr for attr in dir(b.type_obj)
+                 if getattr(b.type_obj, attr, None) is not None
+                 if not attr.startswith("_") or attr.startswith("__")}
+            )
         a_mro = set(a.type_obj.__mro__)
         for base in b.type_obj.__mro__:
             if base in a_mro and base is not object:
-                if base not in (int, float, complex):
+                if base in (int, float, complex):
+                    continue
+                if common_attrs.issubset(dir(base)):
                     return get_type_name(base)
 
     # Rule 8: ABC matching (when accessed_attributes available)

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -13,6 +13,20 @@ from righttyper.options import output_options
 # is safe even for function parameters and return types.
 _COVARIANT_TYPES = (tuple, frozenset)
 
+# Generic types where bare form (no args) means "Any args" and subsumes parametrized forms.
+# Containers are handled separately via issubclass(t, abc.Container).
+_BARE_SUBSUMES: set[type] = {
+    abc.Callable, abc.Iterator, abc.AsyncIterator, abc.Iterable,
+    abc.Generator, abc.AsyncGenerator, abc.Coroutine,
+    abc.Awaitable, abc.AsyncIterable, abc.Reversible, abc.MappingView, type,
+}
+
+# All generic container ABCs from collections.abc, ordered most-specific-first.
+_CONTAINER_ABCS: list[type] = [
+    obj for obj in reversed(list(vars(abc).values()))
+    if isinstance(obj, type) and hasattr(obj, '__class_getitem__') and issubclass(obj, abc.Container)
+]
+
 
 # Precomputed ABC data for structural matching in simplify().
 def _build_abc_own_attrs() -> dict[type, frozenset[str]]:
@@ -89,9 +103,6 @@ def lub(
             return a
 
     # Rule 4b: Bare generic subsumes parametrized (list subsumes list[int]).
-    # Only for types where bare means "Any args": containers and ABC generics.
-    _BARE_SUBSUMES = (abc.Callable, abc.Iterator, abc.AsyncIterator, abc.Iterable,
-                      abc.Generator, abc.AsyncGenerator, abc.Coroutine)
     if (a.module == b.module and a.name == b.name
         and isinstance(a.type_obj, type)
         and (a.type_obj in _BARE_SUBSUMES or issubclass(a.type_obj, abc.Container))):
@@ -131,7 +142,8 @@ def lub(
 
         # Rule 5c: Same container, same arg count — merge args
         if len(a.args) == len(b.args):
-            is_covariant = issubclass(a.type_obj, _COVARIANT_TYPES)
+            # type[X] is covariant (type[B] <: type[A] when B <: A)
+            is_covariant = issubclass(a.type_obj, _COVARIANT_TYPES) or a.type_obj is type
             if for_variable or is_covariant:
                 can_merge = all(
                     (isinstance(aa, TypeInfo) and isinstance(ba, TypeInfo))
@@ -162,8 +174,6 @@ def lub(
 
     # Rule 6: Empty container + non-empty container → common ABC with element type.
     # E.g., tuple[()] + list[int] → Sequence[int].
-    _CONTAINER_ABCS = (abc.Sequence, abc.Mapping, abc.Set, abc.Collection)
-
     def _find_common_container_abc(t1: TypeInfo, t2: TypeInfo) -> type | None:
         if not (isinstance(t1.type_obj, type) and isinstance(t2.type_obj, type)):
             return None

--- a/righttyper/loader.py
+++ b/righttyper/loader.py
@@ -46,7 +46,9 @@ class RightTyperLoader(ExecutionLoader):
         tree = instrument(tree, replace_dict=self.replace_dict)
         code = compile(tree, str(self.path), "exec")
         code2variables.update(map_variables(
-            tree, code, track_attributes=output_options.use_attribute_simplification
+            tree, code,
+            track_attributes=output_options.use_attribute_simplification,
+            track_constructors=output_options.use_constructor_types,
         ))
         if not skip_this_code(code):
             setup_monitoring_for_code(code)

--- a/righttyper/loader.py
+++ b/righttyper/loader.py
@@ -13,6 +13,7 @@ from righttyper.ast_instrument import instrument
 from righttyper.variable_capture import code2variables, map_variables
 from righttyper.righttyper_utils import skip_this_file, skip_this_code
 from righttyper.righttyper_tool import setup_monitoring_for_code
+from righttyper.options import output_options
 
 
 class RightTyperLoader(ExecutionLoader):
@@ -44,7 +45,9 @@ class RightTyperLoader(ExecutionLoader):
         tree = ast.parse(self.get_source(fullname))
         tree = instrument(tree, replace_dict=self.replace_dict)
         code = compile(tree, str(self.path), "exec")
-        code2variables.update(map_variables(tree, code))
+        code2variables.update(map_variables(
+            tree, code, track_attributes=output_options.use_attribute_simplification
+        ))
         if not skip_this_code(code):
             setup_monitoring_for_code(code)
         return code

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -449,7 +449,7 @@ class Observations:
 
         # Canonical type name map: (original_module, original_name) → (canonical_module, canonical_name).
         # Set by recorder from TypeMap. Used in collect_annotations to fix names
-        # of types introduced by simplify() (e.g., pathlib._local.Path → pathlib.Path).
+        # of types introduced by lub (e.g., pathlib._local.Path → pathlib.Path).
         # All strings, serializable for .rt files.
         self.type_name_map: dict[tuple[str, str], tuple[str, str]] = {}
 
@@ -976,7 +976,7 @@ class Observations:
 
         transform_types(UnionSizeT())
 
-        # Fix type names introduced by simplify() (e.g., MRO supertypes
+        # Fix type names introduced by lub (e.g., MRO supertypes
         # with internal module paths like pathlib._local.Path → pathlib.Path).
         if self.type_name_map:
             class _AdjustNewTypeNames(TypeInfo.Transformer):

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -222,17 +222,22 @@ def _apply_constructor_type(annotation: TypeInfo, candidates: set[TypeInfo]) -> 
     if not isinstance(ct.type_obj, type):
         return annotation
     members = annotation.to_set() if annotation.is_union() else {annotation}
-    if not all(
-        isinstance(m.type_obj, type)
-        and m.type_obj is not ct.type_obj
-        and issubclass(m.type_obj, ct.type_obj)
-        # Don't drop type arguments: if observed is parametrized
-        # (`SubFoo[X]`) and the constructor type is bare (`Foo`),
-        # applying would lose the args. Same-type_obj cases are
-        # already excluded above.
-        and not (m.args and not ct.args)
-        for m in members
-    ):
+
+    ct_type = ct.type_obj  # known to be `type` from the guard above
+
+    def _is_strict_subtype(m: TypeInfo) -> bool:
+        """Check if m is a strict subclass of ct, guarding against types
+        like TypedDict that override __subclasscheck__ to raise."""
+        if not isinstance(m.type_obj, type) or m.type_obj is ct_type:
+            return False
+        if m.args and not ct.args:
+            return False
+        try:
+            return issubclass(m.type_obj, ct_type)
+        except TypeError:
+            return False
+
+    if not all(_is_strict_subtype(m) for m in members):
         return annotation
     return ct
 

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -191,6 +191,12 @@ class Observations:
         # CodeIds of wrapper functions (with __wrapped__) — skip annotation
         self.wrapper_code_ids: set[CodeId] = set()
 
+        # Canonical type name map: (original_module, original_name) → (canonical_module, canonical_name).
+        # Set by recorder from TypeMap. Used in collect_annotations to fix names
+        # of types introduced by simplify() (e.g., pathlib._local.Path → pathlib.Path).
+        # All strings, serializable for .rt files.
+        self.type_name_map: dict[tuple[str, str], tuple[str, str]] = {}
+
 
     def transform_types(self, tr: TypeInfo.Transformer) -> None:
         """Applies the 'tr' transformer to all TypeInfo objects in this class."""
@@ -277,6 +283,7 @@ class Observations:
         self.source_to_module_name |= obs2.source_to_module_name
         self.test_modules |= obs2.test_modules
         self.wrapper_code_ids |= obs2.wrapper_code_ids
+        self.type_name_map |= obs2.type_name_map
 
 
     def _propagate_to_parents(self, raw_annotations: dict[CodeId, FuncAnnotation]) -> None:
@@ -660,6 +667,20 @@ class Observations:
             ))
 
         transform_types(UnionSizeT())
+
+        # Fix type names introduced by simplify() (e.g., MRO supertypes
+        # with internal module paths like pathlib._local.Path → pathlib.Path).
+        if self.type_name_map:
+            class _AdjustNewTypeNames(TypeInfo.Transformer):
+                """Remap type names using the serializable name map."""
+                def visit(vself, node: TypeInfo) -> TypeInfo:
+                    key = (node.module, node.name)
+                    if (canonical := self.type_name_map.get(key)):
+                        if canonical != key:
+                            node = node.replace(module=canonical[0], name=canonical[1])
+                    return super().visit(node)
+            transform_types(_AdjustNewTypeNames())
+
         transform_types(MakePickleableT())
 
         return annotations, module_vars, type_distributions

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -453,6 +453,17 @@ class Observations:
         # All strings, serializable for .rt files.
         self.type_name_map: dict[tuple[str, str], tuple[str, str]] = {}
 
+        # Per-function accessed attributes, gathered by static analysis of the
+        # source in the loader.  Maps CodeId → {variable_name → {attr, ...}}.
+        # Serialized in .rt files so that the process step can use them for
+        # attribute-based type simplification (lub Rule 7/8).
+        self.accessed_attributes: dict[CodeId, dict[str, set[str]]] = {}
+
+        # Per-file accessed attributes for module-level globals only.
+        # Precomputed during the run step (where co_varnames is available to
+        # filter out function-local variables) and serialized for process.
+        self.module_accessed_attributes: dict[Filename, dict[str, set[str]]] = {}
+
 
     def transform_types(self, tr: TypeInfo.Transformer) -> None:
         """Applies the 'tr' transformer to all TypeInfo objects in this class."""
@@ -540,6 +551,8 @@ class Observations:
         self.test_modules |= obs2.test_modules
         self.wrapper_code_ids |= obs2.wrapper_code_ids
         self.type_name_map |= obs2.type_name_map
+        self.accessed_attributes.update(obs2.accessed_attributes)
+        self.module_accessed_attributes.update(obs2.module_accessed_attributes)
 
 
     def _propagate_to_parents(self, raw_annotations: dict[CodeId, FuncAnnotation]) -> None:
@@ -868,27 +881,9 @@ class Observations:
     def collect_annotations(self) -> tuple[dict[CodeId, FuncAnnotation], dict[Filename, ModuleVars], dict[CodeId, list[TraceDistribution]]]:
         """Collects function type annotations from the observed types."""
 
-        # Build CodeId → accessed_attributes from the variable capture data.
-        from righttyper.variable_capture import code2variables
-        accessed_attrs: dict[CodeId, dict[str, set[str]]] = {
-            CodeId.from_code(co): cv.accessed_attributes
-            for co, cv in code2variables.items()
-            if cv.accessed_attributes
-        }
+        accessed_attrs = self.accessed_attributes
 
-        # Aggregate per-file accessed_attributes for module globals only.
-        # A name accessed inside a function is module-global iff it's neither a
-        # local/parameter (co_varnames) nor a closure reference (co_freevars).
-        module_accessed: dict[Filename, dict[str, set[str]]] = defaultdict(
-            lambda: defaultdict(set)
-        )
-        for co, cv in code2variables.items():
-            if cv.accessed_attributes:
-                fn = Filename(co.co_filename)
-                for var_name, attrs in cv.accessed_attributes.items():
-                    if var_name in co.co_varnames or var_name in co.co_freevars:
-                        continue
-                    module_accessed[fn][var_name] |= attrs
+        module_accessed = self.module_accessed_attributes
 
         annotations: dict[CodeId, FuncAnnotation] = {}
         for code_id in self.code_id_topo_sort():
@@ -910,7 +905,7 @@ class Observations:
                 var_name: mv_resolver.visit(merged_types(
                     var_types,
                     for_variable=True,
-                    accessed_attributes=module_accessed[filename].get(var_name) or None,
+                    accessed_attributes=module_accessed.get(filename, {}).get(var_name) or None,
                 ))
                 for var_name, var_types in var_dict.items()
             })

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -59,6 +59,12 @@ class FuncInfo:
 
     traces: Counter[CallTrace] = field(default_factory=Counter)
 
+    # Per-variable observed types.  The recorder also injects a constructor
+    # ceiling: `p = Foo(...)` adds `Foo` (the resolved callee type) to the
+    # set, so `merged_types`'s lub naturally subsumes runtime subtypes
+    # (e.g. PosixPath ⊆ Path → Path).  The synthetic key `'<return>'` carries
+    # the same kind of ceiling for the function's return value (extracted
+    # by mk_annotation and lubbed into the retval).
     # TODO ideally the variables should be included in the trace, so that they can be filtered
     # and also included in any type patterns.
     variables: dict[VariableName, set[TypeInfo]] = field(default_factory=lambda: defaultdict(set))
@@ -792,6 +798,12 @@ class Observations:
 
         n_sig_args = len(signature) - 1  # last element is the return type
 
+        # Pull the return-ceiling set off `func_info.variables` (synthetic
+        # `<return>` key populated by the recorder). It will be lubbed into
+        # the retval below.
+        from righttyper.recorder import RETURN_CEILING_KEY
+        return_ceilings = func_info.variables.get(RETURN_CEILING_KEY, set())
+
         # Resolve code_ids in variable types too (they don't go through traces).
         variables = {
             var_name: merged_types(
@@ -800,7 +812,13 @@ class Observations:
                 accessed_attributes=accessed_attributes.get(var_name) if accessed_attributes else None,
             )
             for var_name, var_types in func_info.variables.items()
+            if var_name != RETURN_CEILING_KEY
         }
+
+        retval = (
+            merged_types({signature[-1], *return_ceilings})
+            if return_ceilings else signature[-1]
+        )
 
         ann = FuncAnnotation(
             args={
@@ -814,7 +832,7 @@ class Observations:
                     )
                 for i, arg in enumerate(func_info.args)
             },
-            retval=signature[-1],
+            retval=retval,
             varargs=func_info.varargs,
             kwargs=func_info.kwargs,
             variables=variables,

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -204,6 +204,9 @@ class FuncInfo:
         for var_name, var_types in list(self.variables.items()):
             self.variables[var_name] = set(tr.visit(t) for t in var_types)
 
+        for var_name, ct_types in list(self.constructor_types.items()):
+            self.constructor_types[var_name] = set(tr.visit(t) for t in ct_types)
+
 
 def _apply_constructor_type(annotation: TypeInfo, candidates: set[TypeInfo]) -> TypeInfo:
     """Propagate the constructor's static type (from `var = Foo(...)`) as
@@ -523,6 +526,10 @@ class Observations:
         for var_dict in list(self.module_variables.values()):
             for var_name, var_types in list(var_dict.items()):
                 var_dict[var_name] = set(tr.visit(t) for t in var_types)
+
+        for ct_dict in list(self.module_constructor_types.values()):
+            for var_name, ct_types in list(ct_dict.items()):
+                ct_dict[var_name] = set(tr.visit(t) for t in ct_types)
 
 
     def merge_observations(self, obs2: "Observations") -> None:

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -59,15 +59,23 @@ class FuncInfo:
 
     traces: Counter[CallTrace] = field(default_factory=Counter)
 
-    # Per-variable observed types.  The recorder also injects a constructor
-    # ceiling: `p = Foo(...)` adds `Foo` (the resolved callee type) to the
-    # set, so `merged_types`'s lub naturally subsumes runtime subtypes
-    # (e.g. PosixPath ⊆ Path → Path).  The synthetic key `'<return>'` carries
-    # the same kind of ceiling for the function's return value (extracted
-    # by mk_annotation and lubbed into the retval).
+    # Per-variable observed runtime types.
     # TODO ideally the variables should be included in the trace, so that they can be filtered
     # and also included in any type patterns.
     variables: dict[VariableName, set[TypeInfo]] = field(default_factory=lambda: defaultdict(set))
+
+    # Per-variable static type from the AST-detected `var = Foo(...)` callee
+    # (resolved via TypeMap canonicalization + typeshed Self lookup at
+    # finish_recording).  mk_annotation propagates this as the variable's
+    # annotation iff the runtime observation is a strict subclass — preserves
+    # the user's source-level type when the dynamic type matches, falls back
+    # to the observation when it diverges (e.g. attrs replacing `attr.Factory(set)`
+    # with the produced `set` on the instance).  The synthetic key
+    # RETURN_CONSTRUCTOR_KEY carries the function's return-expression
+    # constructor type.
+    constructor_types: dict[VariableName, set[TypeInfo]] = field(
+        default_factory=lambda: defaultdict(set)
+    )
 
 
     def most_common_traces(self) -> list[CallTrace]:
@@ -195,6 +203,35 @@ class FuncInfo:
 
         for var_name, var_types in list(self.variables.items()):
             self.variables[var_name] = set(tr.visit(t) for t in var_types)
+
+
+def _apply_constructor_type(annotation: TypeInfo, candidates: set[TypeInfo]) -> TypeInfo:
+    """Propagate the constructor's static type (from `var = Foo(...)`) as
+    the variable's annotation, but only when it's still consistent with
+    the observed dynamic type — i.e., the observation is a strict
+    subclass of the constructor type.  Falls back to the observed
+    annotation when the dynamic type diverges (`attr.Factory(set)` →
+    runtime `set`) or when applying the constructor type would drop
+    information (bare `Foo` over a parametrized `SubFoo[X]`)."""
+    if len(candidates) != 1:
+        return annotation
+    ct = next(iter(candidates))
+    if not isinstance(ct.type_obj, type):
+        return annotation
+    members = annotation.to_set() if annotation.is_union() else {annotation}
+    if not all(
+        isinstance(m.type_obj, type)
+        and m.type_obj is not ct.type_obj
+        and issubclass(m.type_obj, ct.type_obj)
+        # Don't drop type arguments: if observed is parametrized
+        # (`SubFoo[X]`) and the constructor type is bare (`Foo`),
+        # applying would lose the args. Same-type_obj cases are
+        # already excluded above.
+        and not (m.args and not ct.args)
+        for m in members
+    ):
+        return annotation
+    return ct
 
 
 def _stamp_self(
@@ -444,6 +481,12 @@ class Observations:
         # per-module variables
         self.module_variables: dict[Filename, dict[VariableName, set[TypeInfo]]] = defaultdict(lambda: defaultdict(set))
 
+        # per-module constructor types (mirrors module_variables; see
+        # FuncInfo.constructor_types for the per-function counterpart).
+        self.module_constructor_types: dict[Filename, dict[VariableName, set[TypeInfo]]] = defaultdict(
+            lambda: defaultdict(set)
+        )
+
         # Mapping of sources to their module names
         self.source_to_module_name: dict[Filename, str] = {}
 
@@ -543,6 +586,9 @@ class Observations:
 
                 for varname, typeset in func_info2.variables.items():
                     func_info.variables[varname] |= typeset
+
+                for varname, typeset in func_info2.constructor_types.items():
+                    func_info.constructor_types[varname] |= typeset
             else:
                 self.func_info[func_id] = func_info2
 
@@ -552,6 +598,13 @@ class Observations:
                     var_dict[varname] |= typeset
             else:
                 self.module_variables[filename] = var_dict2
+
+        for filename, ct_dict2 in obs2.module_constructor_types.items():
+            if (ct_dict := self.module_constructor_types.get(filename)):
+                for varname, typeset in ct_dict2.items():
+                    ct_dict[varname] |= typeset
+            else:
+                self.module_constructor_types[filename] = ct_dict2
 
         self.source_to_module_name |= obs2.source_to_module_name
         self.test_modules |= obs2.test_modules
@@ -798,26 +851,24 @@ class Observations:
 
         n_sig_args = len(signature) - 1  # last element is the return type
 
-        # Pull the return-ceiling set off `func_info.variables` (synthetic
-        # `<return>` key populated by the recorder). It will be lubbed into
-        # the retval below.
-        from righttyper.recorder import RETURN_CEILING_KEY
-        return_ceilings = func_info.variables.get(RETURN_CEILING_KEY, set())
+        from righttyper.recorder import RETURN_CONSTRUCTOR_KEY
 
         # Resolve code_ids in variable types too (they don't go through traces).
         variables = {
-            var_name: merged_types(
-                {resolver.visit(t) for t in var_types} if annotations else var_types,
-                for_variable=True,
-                accessed_attributes=accessed_attributes.get(var_name) if accessed_attributes else None,
+            var_name: _apply_constructor_type(
+                merged_types(
+                    {resolver.visit(t) for t in var_types} if annotations else var_types,
+                    for_variable=True,
+                    accessed_attributes=accessed_attributes.get(var_name) if accessed_attributes else None,
+                ),
+                func_info.constructor_types.get(var_name, set()),
             )
             for var_name, var_types in func_info.variables.items()
-            if var_name != RETURN_CEILING_KEY
         }
 
-        retval = (
-            merged_types({signature[-1], *return_ceilings})
-            if return_ceilings else signature[-1]
+        retval = _apply_constructor_type(
+            signature[-1],
+            func_info.constructor_types.get(RETURN_CONSTRUCTOR_KEY, set()),
         )
 
         ann = FuncAnnotation(
@@ -920,11 +971,14 @@ class Observations:
         mv_resolver = ResolvingT(annotations, self.func_info)
         module_vars: dict[Filename, ModuleVars] = {
             filename: ModuleVars({
-                var_name: mv_resolver.visit(merged_types(
-                    var_types,
-                    for_variable=True,
-                    accessed_attributes=module_accessed.get(filename, {}).get(var_name) or None,
-                ))
+                var_name: _apply_constructor_type(
+                    mv_resolver.visit(merged_types(
+                        var_types,
+                        for_variable=True,
+                        accessed_attributes=module_accessed.get(filename, {}).get(var_name) or None,
+                    )),
+                    self.module_constructor_types.get(filename, {}).get(var_name, set()),
+                )
                 for var_name, var_types in var_dict.items()
             })
             for filename, var_dict in self.module_variables.items()

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -1055,7 +1055,8 @@ def get_typeshed_arg_types(
         return None
 
     t = LoadAndCheckTypesT()
+    # `signature[-1]` is the return type; this consumer wants only args.
     return tuple(
         t.visit(arg) if arg is not None else None
-        for arg in args
+        for arg in args[:-1]
     )

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -401,7 +401,10 @@ class Observations:
 
 
     @staticmethod
-    def mk_annotation(func_info: FuncInfo) -> FuncAnnotation|None:
+    def mk_annotation(
+        func_info: FuncInfo,
+        accessed_attributes: dict[str, set[str]] | None = None,
+    ) -> FuncAnnotation|None:
         traces = func_info.most_common_traces()
         if not traces:
             return None
@@ -416,10 +419,13 @@ class Observations:
         ann = FuncAnnotation(
             args={
                 arg.arg_name:
-                    merged_types({
-                        signature[i] if i < n_sig_args else UnknownTypeInfo,
-                        *((arg.default,) if arg.default is not None else ()),
-                    })
+                    merged_types(
+                        {
+                            signature[i] if i < n_sig_args else UnknownTypeInfo,
+                            *((arg.default,) if arg.default is not None else ()),
+                        },
+                        accessed_attributes=accessed_attributes.get(arg.arg_name) if accessed_attributes else None,
+                    )
                 for i, arg in enumerate(func_info.args)
             },
             retval=signature[-1],
@@ -486,10 +492,21 @@ class Observations:
 
             return T().visit(node)
 
+        # Build CodeId → accessed_attributes from the variable capture data.
+        from righttyper.variable_capture import code2variables
+        accessed_attrs: dict[CodeId, dict[str, set[str]]] = {
+            CodeId.from_code(co): cv.accessed_attributes
+            for co, cv in code2variables.items()
+            if cv.accessed_attributes
+        }
+
         annotations: dict[CodeId, FuncAnnotation] = {
             code_id: annotation
             for code_id in self.code_id_topo_sort()
-            if (annotation := Observations.mk_annotation(self.func_info[code_id])) is not None
+            if (annotation := Observations.mk_annotation(
+                self.func_info[code_id],
+                accessed_attributes=accessed_attrs.get(code_id),
+            )) is not None
         }
 
         # Merge module variables into ModuleVars (parallel to annotations for functions).

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -215,7 +215,11 @@ def _apply_constructor_type(annotation: TypeInfo, candidates: set[TypeInfo]) -> 
     subclass of the constructor type.  Falls back to the observed
     annotation when the dynamic type diverges (`attr.Factory(set)` →
     runtime `set`) or when applying the constructor type would drop
-    information (bare `Foo` over a parametrized `SubFoo[X]`)."""
+    information (bare `Foo` over a parametrized `SubFoo[X]`).
+
+    `--no-use-constructor-types` is honored at load time by clearing
+    `constructor_types` / `module_constructor_types`, so empty
+    `candidates` is the only signal to skip — no per-call flag check."""
     if len(candidates) != 1:
         return annotation
     ct = next(iter(candidates))

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -784,6 +784,7 @@ class Observations:
             var_name: merged_types(
                 {resolver.visit(t) for t in var_types} if annotations else var_types,
                 for_variable=True,
+                accessed_attributes=accessed_attributes.get(var_name) if accessed_attributes else None,
             )
             for var_name, var_types in func_info.variables.items()
         }
@@ -875,6 +876,20 @@ class Observations:
             if cv.accessed_attributes
         }
 
+        # Aggregate per-file accessed_attributes for module globals only.
+        # A name accessed inside a function is module-global iff it's neither a
+        # local/parameter (co_varnames) nor a closure reference (co_freevars).
+        module_accessed: dict[Filename, dict[str, set[str]]] = defaultdict(
+            lambda: defaultdict(set)
+        )
+        for co, cv in code2variables.items():
+            if cv.accessed_attributes:
+                fn = Filename(co.co_filename)
+                for var_name, attrs in cv.accessed_attributes.items():
+                    if var_name in co.co_varnames or var_name in co.co_freevars:
+                        continue
+                    module_accessed[fn][var_name] |= attrs
+
         annotations: dict[CodeId, FuncAnnotation] = {}
         for code_id in self.code_id_topo_sort():
             annotation = Observations.mk_annotation(
@@ -892,7 +907,11 @@ class Observations:
         mv_resolver = ResolvingT(annotations, self.func_info)
         module_vars: dict[Filename, ModuleVars] = {
             filename: ModuleVars({
-                var_name: mv_resolver.visit(merged_types(var_types, for_variable=True))
+                var_name: mv_resolver.visit(merged_types(
+                    var_types,
+                    for_variable=True,
+                    accessed_attributes=module_accessed[filename].get(var_name) or None,
+                ))
                 for var_name, var_types in var_dict.items()
             })
             for filename, var_dict in self.module_variables.items()

--- a/righttyper/options.py
+++ b/righttyper/options.py
@@ -29,6 +29,7 @@ class OutputOptions:
     always_quote_annotations: bool = False
     type_distribution_comments: bool = False
     use_attribute_simplification: bool = True
+    use_constructor_types: bool = True
 
 
     def process_args(self, kwargs: dict[str, Any]) -> None:

--- a/righttyper/options.py
+++ b/righttyper/options.py
@@ -28,6 +28,7 @@ class OutputOptions:
     detect_test_modules_by_name: bool = False
     always_quote_annotations: bool = False
     type_distribution_comments: bool = False
+    use_attribute_simplification: bool = True
 
 
     def process_args(self, kwargs: dict[str, Any]) -> None:

--- a/righttyper/options.py
+++ b/righttyper/options.py
@@ -28,8 +28,8 @@ class OutputOptions:
     detect_test_modules_by_name: bool = False
     always_quote_annotations: bool = False
     type_distribution_comments: bool = False
-    use_attribute_simplification: bool = True
-    use_constructor_types: bool = True
+    use_attribute_simplification: bool = False
+    use_constructor_types: bool = False
 
 
     def process_args(self, kwargs: dict[str, Any]) -> None:

--- a/righttyper/recorder.py
+++ b/righttyper/recorder.py
@@ -28,30 +28,38 @@ from righttyper.typemap import TypeMap, AdjustTypeNamesT, CheckTypeNamesT
 NO_OBJECT: Final = object()
 
 
-# Synthetic key in `func_info.variables` used to carry the resolved
-# return-constructor ceiling.  mk_annotation pops this and lubs it with the
-# retval annotation so `def f(): p = Path(...); return p` widens consistently
-# (both `p` and the function's return become Path, not PosixPath).
-RETURN_CEILING_KEY: Final = VariableName("<return>")
+# Synthetic key in `func_info.constructor_types` used to carry the resolved
+# return-expression constructor type.  `return` is a Python keyword, so it
+# cannot collide with any user-defined variable name.  mk_annotation
+# extracts this and applies it post-merge to the retval annotation so
+# `def f(): p = Path(...); return p` widens consistently (both `p` and the
+# function's return become Path, not PosixPath).
+RETURN_CONSTRUCTOR_KEY: Final = VariableName("return")
 
 
-def _resolve_constructor_callee(
+def _walk_constructor_callee(
     parts: list[str],
     f_locals: abc.Mapping[str, Any],
     f_globals: abc.Mapping[str, Any],
-) -> type | None:
+) -> tuple[type, str | None] | None:
     """Walk the dotted callee parts (`["Path"]`, `["pathlib", "Path"]`,
     `["Path", "cwd"]`) against the live frame.  Locals are tried first so
     local aliases like `P = Path; p = P(...)` resolve correctly; globals
-    cover imports.
+    cover imports.  Builtins (`set`, `list`, `dict`, ...) are not looked up
+    — for them, ceiling and observation share the same `type_obj` and the
+    post-merge widening is a no-op anyway.
 
-    If the walk lands on a `type`, that's the ceiling — `Foo(...)` returns
-    Self, so Foo is the natural ceiling.  If the walk lands on a callable
-    (e.g. `Path.cwd`, a classmethod), consult typeshed for the declared
-    return type; if it's `Self`, fall back to the most-recent class on the
-    walk.  Returns None for shapes that don't fit either pattern."""
+    Returns `(last_class, method_name)` where `last_class` is the most
+    recent class encountered on the walk and `method_name` is None if the
+    final target *is* `last_class` (direct constructor call) or the last
+    part name if the final target is something else (a method/function on
+    the class — factory pattern).  Returns None for shapes that don't fit
+    either pattern (e.g. free function `os.getcwd`).
+
+    The actual constructor type, including typeshed lookup for factory
+    cases, is determined later in finish_recording (when TypeMap is
+    available)."""
     from righttyper.random_dict import RandomDict
-    from righttyper.typeshed import get_typeshed_func_return
     obj = f_locals.get(parts[0], NO_OBJECT)
     if obj is NO_OBJECT:
         obj = f_globals.get(parts[0], NO_OBJECT)
@@ -65,30 +73,14 @@ def _resolve_constructor_callee(
         obj = nxt
         if isinstance(obj, type):
             last_class = obj
-
-    ceiling: type | None = None
-    if isinstance(obj, type):
-        ceiling = obj
-    elif callable(obj) and last_class is not None:
-        # Factory case: walk landed on a callable defined under a class.
-        # Typeshed for `Class.factory(...) -> Self` resolves Self to the
-        # class.  Other declared returns are skipped for now (would need
-        # full TypeInfo→type resolution and TypeVar handling).
-        module = getattr(obj, '__module__', None)
-        qualname = getattr(obj, '__qualname__', None)
-        if isinstance(module, str) and isinstance(qualname, str):
-            ret = get_typeshed_func_return(module, qualname)
-            if ret is not None and ret.name == 'Self':
-                ceiling = last_class
-
-    # RandomDict is RightTyper's internal stand-in for dict (under
-    # --replace-dict).  type_id._handle_randomdict already masquerades it as
-    # plain `dict` for type-reporting; using it as an annotation ceiling
-    # would introduce RandomDict into user output, which it intentionally
-    # avoids.  Drop it here for symmetry.
-    if ceiling is RandomDict:
+    if last_class is None or last_class is RandomDict:
+        # RandomDict is RightTyper's internal stand-in for dict (under
+        # --replace-dict).  type_id._handle_randomdict masquerades it as
+        # plain `dict` for type-reporting; surfacing it as a ceiling
+        # would introduce RandomDict into user output.  Drop here.
         return None
-    return ceiling
+    method_name = None if isinstance(obj, type) else parts[-1]
+    return (last_class, method_name)
 
 
 def _get_field_names(cls: type) -> tuple[str, ...]|None:
@@ -191,6 +183,19 @@ class ObservationsRecorder:
     def __init__(self) -> None:
         # Finds FuncInfo by their CodeType
         self._code2func_info: dict[CodeType, FuncInfo] = {}
+
+        # Record-time staging for constructor ceilings.  At record time we
+        # walk the live frame to resolve `var = Foo(...)` / `Class.method(...)`
+        # shapes to a (last_class, method_name) tuple — handles local
+        # aliases.  Final canonicalization and typeshed Self-lookup happen
+        # in finish_recording, once TypeMap is built.  Two parallel dicts
+        # mirror the function-level vs module-level split of scope_vars.
+        self._func_var_callees: dict[
+            CodeType, dict[VariableName, set[tuple[type, str | None]]]
+        ] = defaultdict(lambda: defaultdict(set))
+        self._module_var_callees: dict[
+            Filename, dict[VariableName, set[tuple[type, str | None]]]
+        ] = defaultdict(lambda: defaultdict(set))
 
         # Started, but not (yet) completed traces
         self._pending_traces: dict[CodeType, dict[FrameId, PendingCallTrace]] = defaultdict(dict)
@@ -502,10 +507,13 @@ class ObservationsRecorder:
             return
 
         # scope_code is guaranteed non-None in code2variables
+        scope_callees: dict[VariableName, set[tuple[type, str | None]]]
         if (func_info := self._code2func_info.get(cast_not_None(codevars.scope_code))):
             scope_vars = func_info.variables
+            scope_callees = self._func_var_callees[cast_not_None(codevars.scope_code)]
         else:
             scope_vars = self._obs.module_variables[Filename(code.co_filename)]
+            scope_callees = self._module_var_callees[Filename(code.co_filename)]
 
         f_locals = frame.f_locals
         prefix = codevars.var_prefix
@@ -519,23 +527,23 @@ class ObservationsRecorder:
             if isinstance(init, type):
                 scope_vars[VariableName(qualified)].add(TypeInfo.from_type(init))
             elif isinstance(init, Constructor):
-                # Resolve `var = Foo(...)` against the live frame: locals (for
-                # local aliases like `P = Path`), then globals (for imports).
-                # The resolved type acts as a ceiling — added to the observed
-                # set so lub will subsume runtime subtypes (e.g. PosixPath ⊆ Path).
-                if (ceiling := _resolve_constructor_callee(
+                # Resolve the source-level dotted name against the live frame
+                # — locals first (for `P = Path; p = P(...)`), then globals.
+                # The result is staged; canonicalization (private-module
+                # paths like Python 3.13's `pathlib._local.Path`) and the
+                # typeshed Self lookup happen in finish_recording, where
+                # TypeMap is available.
+                if (callee := _walk_constructor_callee(
                         init.parts, f_locals, frame.f_globals)) is not None:
-                    scope_vars[VariableName(qualified)].add(get_type_name(ceiling))
+                    scope_callees[VariableName(qualified)].add(callee)
 
-        # Same idea for the function's return: when every return agrees on a
-        # callee, that callee's type is a ceiling on the return annotation.
-        # Stored under a synthetic key that mk_annotation extracts and lubs
-        # into the retval before serialization.
+        # Same idea for the function's return: stage the callee under the
+        # synthetic <return> key; finalized in finish_recording.
         if codevars.return_constructor is not None:
-            if (ceiling := _resolve_constructor_callee(
+            if (callee := _walk_constructor_callee(
                     codevars.return_constructor.parts,
                     f_locals, frame.f_globals)) is not None:
-                scope_vars[RETURN_CEILING_KEY].add(get_type_name(ceiling))
+                scope_callees[RETURN_CONSTRUCTOR_KEY].add(callee)
 
         if codevars.self and (self_obj := f_locals.get(codevars.self)) is not None:
             obj_attrs = self._object_attributes[codevars.class_key]
@@ -709,6 +717,55 @@ class ObservationsRecorder:
                                 scope_vars[VariableName(qualified_name)].update(class_attrs[VariableName(attr)])
 
 
+    def _finalize_constructor_types(
+        self,
+        var_callees: dict[VariableName, set[tuple[type, str | None]]],
+        out: "abc.MutableMapping[VariableName, set[TypeInfo]]",
+        type_map: TypeMap,
+    ) -> None:
+        """Finalize staged constructor-type candidates: canonicalize the
+        resolved class via TypeMap and consult typeshed for the callee's
+        declared return type (`__new__` for direct constructor calls, the
+        named method for factory calls).  Write the resolved TypeInfo into
+        `out[var_name]` — typically `func_info.constructor_types[var_name]`
+        or `obs.module_constructor_types[filename][var_name]`.
+
+        The runtime-vs-static consistency check (whether the observed
+        runtime type is actually a strict subclass of the constructor
+        type) lives at mk_annotation time, where retval observations from
+        traces are available alongside per-variable observations."""
+        from righttyper.typeshed import get_typeshed_func_return
+        for var_name, callees in var_callees.items():
+            for last_class, method_name in callees:
+                names = type_map.find(last_class)
+                if not names:
+                    continue
+                module, qualname = names[0]
+                lookup = method_name if method_name is not None else '__new__'
+                ret = get_typeshed_func_return(
+                    module if module else 'builtins', f"{qualname}.{lookup}")
+                if ret is None:
+                    # No typeshed entry: for direct calls fall back to
+                    # last_class (most classes inherit object.__new__,
+                    # which is `Self`).  For factory calls we don't know
+                    # what's returned, so skip.
+                    if method_name is not None:
+                        continue
+                elif (
+                    (ret.module in ('typing', 'typing_extensions') and ret.name == 'Self')
+                    or (ret.module == module and ret.name == qualname)
+                ):
+                    # Self (from typing / typing_extensions), or the class
+                    # explicitly named — both resolve to last_class.
+                    pass
+                else:
+                    # TODO resolve specific non-Self return types — needs
+                    # a sys.modules lookup, parametrization-loss handling,
+                    # and TypeVar substitution.
+                    continue
+                out[var_name].add(get_type_name(last_class))
+
+
     def finish_recording(self, main_globals: dict[str, Any]) -> Observations:
         # Any generators left?
         for code, per_frame in self._pending_traces.items():
@@ -759,6 +816,19 @@ class ObservationsRecorder:
 
         if run_options.resolve_mocks:
             obs.transform_types(ResolveMocksT(type_name_adjuster))
+
+        # Finalize constructor ceilings staged at record time:
+        # canonicalize the resolved class via TypeMap, do typeshed Self
+        # lookup for factory cases, and add the ceiling TypeInfo to
+        # scope_vars.  `obs` is the swapped-out Observations; its func_info
+        # is keyed by CodeId.
+        for code, var_callees in self._func_var_callees.items():
+            if (fi := obs.func_info.get(CodeId.from_code(code))):
+                self._finalize_constructor_types(
+                    var_callees, fi.constructor_types, type_map)
+        for filename, var_callees in self._module_var_callees.items():
+            self._finalize_constructor_types(
+                var_callees, obs.module_constructor_types[filename], type_map)
 
         obs.test_modules = set(run_options.test_modules) | set(detected_test_modules) | {
             mod_name

--- a/righttyper/recorder.py
+++ b/righttyper/recorder.py
@@ -13,7 +13,7 @@ from typing import Final, Any, NewType, overload
 import typing
 from righttyper.observations import Observations, FuncInfo, OverriddenFunction, ArgInfo
 from righttyper.variable_capture import code2variables
-from righttyper.options import run_options
+from righttyper.options import run_options, output_options
 from righttyper.righttyper_utils import (
     source_to_module_fqn, get_main_module_fqn, skip_this_file,
     detected_test_files, detected_test_modules, is_test_module,
@@ -642,15 +642,19 @@ class ObservationsRecorder:
         # serialization to .rt files for the --only-collect + process flow.
         # co_varnames/co_freevars are only available while the code object
         # is live, so module_accessed_attributes must be computed now.
-        for co, cv in code2variables.items():
-            if cv.accessed_attributes:
-                self._obs.accessed_attributes[CodeId.from_code(co)] = cv.accessed_attributes
-                module_attrs = self._obs.module_accessed_attributes.setdefault(
-                    Filename(co.co_filename), {}
-                )
-                for var_name, attrs in cv.accessed_attributes.items():
-                    if var_name not in co.co_varnames and var_name not in co.co_freevars:
-                        module_attrs.setdefault(var_name, set()).update(attrs)
+        # Skipped when --no-use-attribute-simplification: the loader will not
+        # have populated cv.accessed_attributes either, but the dict-write
+        # overhead is still worth avoiding.
+        if output_options.use_attribute_simplification:
+            for co, cv in code2variables.items():
+                if cv.accessed_attributes:
+                    self._obs.accessed_attributes[CodeId.from_code(co)] = cv.accessed_attributes
+                    module_attrs = self._obs.module_accessed_attributes.setdefault(
+                        Filename(co.co_filename), {}
+                    )
+                    for var_name, attrs in cv.accessed_attributes.items():
+                        if var_name not in co.co_varnames and var_name not in co.co_freevars:
+                            module_attrs.setdefault(var_name, set()).update(attrs)
 
         obs, self._obs = self._obs, Observations()
         self._code2func_info.clear()

--- a/righttyper/recorder.py
+++ b/righttyper/recorder.py
@@ -806,6 +806,21 @@ class ObservationsRecorder:
         # which operates on deserialized data (vs. data just collected).
         type_map = TypeMap(main_globals)
 
+        # Finalize constructor types staged at record time *before*
+        # AdjustTypeNamesT runs, so the new entries get canonicalized
+        # alongside everything else in obs (avoids leaking private
+        # __module__ paths like `_io` or `pathlib._local`).  type_obj is
+        # set on each new entry for the canonicalization pass; it's
+        # cleared at .rt save by the Pickler dispatch_table.  `obs` is the
+        # swapped-out Observations; its func_info is keyed by CodeId.
+        for code, var_callees in self._func_var_callees.items():
+            if (fi := obs.func_info.get(CodeId.from_code(code))):
+                self._finalize_constructor_types(
+                    var_callees, fi.constructor_types, type_map)
+        for filename, var_callees in self._module_var_callees.items():
+            self._finalize_constructor_types(
+                var_callees, obs.module_constructor_types[filename], type_map)
+
         if run_options.adjust_type_names:
             type_name_adjuster = AdjustTypeNamesT(type_map)
             obs.transform_types(type_name_adjuster)
@@ -816,19 +831,6 @@ class ObservationsRecorder:
 
         if run_options.resolve_mocks:
             obs.transform_types(ResolveMocksT(type_name_adjuster))
-
-        # Finalize constructor ceilings staged at record time:
-        # canonicalize the resolved class via TypeMap, do typeshed Self
-        # lookup for factory cases, and add the ceiling TypeInfo to
-        # scope_vars.  `obs` is the swapped-out Observations; its func_info
-        # is keyed by CodeId.
-        for code, var_callees in self._func_var_callees.items():
-            if (fi := obs.func_info.get(CodeId.from_code(code))):
-                self._finalize_constructor_types(
-                    var_callees, fi.constructor_types, type_map)
-        for filename, var_callees in self._module_var_callees.items():
-            self._finalize_constructor_types(
-                var_callees, obs.module_constructor_types[filename], type_map)
 
         obs.test_modules = set(run_options.test_modules) | set(detected_test_modules) | {
             mod_name

--- a/righttyper/recorder.py
+++ b/righttyper/recorder.py
@@ -666,6 +666,7 @@ class ObservationsRecorder:
         if run_options.adjust_type_names:
             type_name_adjuster = AdjustTypeNamesT(type_map)
             obs.transform_types(type_name_adjuster)
+            obs.type_name_map = type_map.to_name_map()
         else:
             type_name_adjuster = None
             obs.transform_types(CheckTypeNamesT(type_map))

--- a/righttyper/recorder.py
+++ b/righttyper/recorder.py
@@ -40,31 +40,55 @@ def _resolve_constructor_callee(
     f_locals: abc.Mapping[str, Any],
     f_globals: abc.Mapping[str, Any],
 ) -> type | None:
-    """Walk the dotted callee parts (`["Path"]` or `["pathlib", "Path"]`)
-    against the live frame.  Locals are tried first so local aliases like
-    `P = Path; p = P(...)` resolve correctly; globals cover imports.  Returns
-    the resolved type if the leading lookup succeeds and every attribute
-    walk lands on a `type`; else None."""
+    """Walk the dotted callee parts (`["Path"]`, `["pathlib", "Path"]`,
+    `["Path", "cwd"]`) against the live frame.  Locals are tried first so
+    local aliases like `P = Path; p = P(...)` resolve correctly; globals
+    cover imports.
+
+    If the walk lands on a `type`, that's the ceiling — `Foo(...)` returns
+    Self, so Foo is the natural ceiling.  If the walk lands on a callable
+    (e.g. `Path.cwd`, a classmethod), consult typeshed for the declared
+    return type; if it's `Self`, fall back to the most-recent class on the
+    walk.  Returns None for shapes that don't fit either pattern."""
     from righttyper.random_dict import RandomDict
+    from righttyper.typeshed import get_typeshed_func_return
     obj = f_locals.get(parts[0], NO_OBJECT)
     if obj is NO_OBJECT:
         obj = f_globals.get(parts[0], NO_OBJECT)
     if obj is NO_OBJECT or obj is None:
         return None
+    last_class = obj if isinstance(obj, type) else None
     for p in parts[1:]:
-        obj = getattr(obj, p, NO_OBJECT)
-        if obj is NO_OBJECT or obj is None:
+        nxt = getattr(obj, p, NO_OBJECT)
+        if nxt is NO_OBJECT or nxt is None:
             return None
-    if not isinstance(obj, type):
-        return None
+        obj = nxt
+        if isinstance(obj, type):
+            last_class = obj
+
+    ceiling: type | None = None
+    if isinstance(obj, type):
+        ceiling = obj
+    elif callable(obj) and last_class is not None:
+        # Factory case: walk landed on a callable defined under a class.
+        # Typeshed for `Class.factory(...) -> Self` resolves Self to the
+        # class.  Other declared returns are skipped for now (would need
+        # full TypeInfo→type resolution and TypeVar handling).
+        module = getattr(obj, '__module__', None)
+        qualname = getattr(obj, '__qualname__', None)
+        if isinstance(module, str) and isinstance(qualname, str):
+            ret = get_typeshed_func_return(module, qualname)
+            if ret is not None and ret.name == 'Self':
+                ceiling = last_class
+
     # RandomDict is RightTyper's internal stand-in for dict (under
     # --replace-dict).  type_id._handle_randomdict already masquerades it as
     # plain `dict` for type-reporting; using it as an annotation ceiling
     # would introduce RandomDict into user output, which it intentionally
     # avoids.  Drop it here for symmetry.
-    if obj is RandomDict:
+    if ceiling is RandomDict:
         return None
-    return obj
+    return ceiling
 
 
 def _get_field_names(cls: type) -> tuple[str, ...]|None:

--- a/righttyper/recorder.py
+++ b/righttyper/recorder.py
@@ -12,7 +12,7 @@ from righttyper.typeinfo import TypeInfo, NoneTypeInfo, UnknownTypeInfo, CallTra
 from typing import Final, Any, NewType, overload
 import typing
 from righttyper.observations import Observations, FuncInfo, OverriddenFunction, ArgInfo
-from righttyper.variable_capture import code2variables
+from righttyper.variable_capture import code2variables, Constructor
 from righttyper.options import run_options, output_options
 from righttyper.righttyper_utils import (
     source_to_module_fqn, get_main_module_fqn, skip_this_file,
@@ -26,6 +26,45 @@ from righttyper.typemap import TypeMap, AdjustTypeNamesT, CheckTypeNamesT
 
 # Singleton used to differentiate from None
 NO_OBJECT: Final = object()
+
+
+# Synthetic key in `func_info.variables` used to carry the resolved
+# return-constructor ceiling.  mk_annotation pops this and lubs it with the
+# retval annotation so `def f(): p = Path(...); return p` widens consistently
+# (both `p` and the function's return become Path, not PosixPath).
+RETURN_CEILING_KEY: Final = VariableName("<return>")
+
+
+def _resolve_constructor_callee(
+    parts: list[str],
+    f_locals: abc.Mapping[str, Any],
+    f_globals: abc.Mapping[str, Any],
+) -> type | None:
+    """Walk the dotted callee parts (`["Path"]` or `["pathlib", "Path"]`)
+    against the live frame.  Locals are tried first so local aliases like
+    `P = Path; p = P(...)` resolve correctly; globals cover imports.  Returns
+    the resolved type if the leading lookup succeeds and every attribute
+    walk lands on a `type`; else None."""
+    from righttyper.random_dict import RandomDict
+    obj = f_locals.get(parts[0], NO_OBJECT)
+    if obj is NO_OBJECT:
+        obj = f_globals.get(parts[0], NO_OBJECT)
+    if obj is NO_OBJECT or obj is None:
+        return None
+    for p in parts[1:]:
+        obj = getattr(obj, p, NO_OBJECT)
+        if obj is NO_OBJECT or obj is None:
+            return None
+    if not isinstance(obj, type):
+        return None
+    # RandomDict is RightTyper's internal stand-in for dict (under
+    # --replace-dict).  type_id._handle_randomdict already masquerades it as
+    # plain `dict` for type-reporting; using it as an annotation ceiling
+    # would introduce RandomDict into user output, which it intentionally
+    # avoids.  Drop it here for symmetry.
+    if obj is RandomDict:
+        return None
+    return obj
 
 
 def _get_field_names(cls: type) -> tuple[str, ...]|None:
@@ -447,14 +486,32 @@ class ObservationsRecorder:
         f_locals = frame.f_locals
         prefix = codevars.var_prefix
 
-        for var_name, const_type in codevars.variables.items():
+        for var_name, init in codevars.variables.items():
             qualified = f"{prefix}{var_name}"
             # Record runtime value
             if (value := f_locals.get(var_name, NO_OBJECT)) is not NO_OBJECT:
                 scope_vars[VariableName(qualified)].add(get_value_type(value))
             # Include initial constant type if present (e.g., x = None)
-            if const_type is not None:
-                scope_vars[VariableName(qualified)].add(TypeInfo.from_type(const_type))
+            if isinstance(init, type):
+                scope_vars[VariableName(qualified)].add(TypeInfo.from_type(init))
+            elif isinstance(init, Constructor):
+                # Resolve `var = Foo(...)` against the live frame: locals (for
+                # local aliases like `P = Path`), then globals (for imports).
+                # The resolved type acts as a ceiling — added to the observed
+                # set so lub will subsume runtime subtypes (e.g. PosixPath ⊆ Path).
+                if (ceiling := _resolve_constructor_callee(
+                        init.parts, f_locals, frame.f_globals)) is not None:
+                    scope_vars[VariableName(qualified)].add(get_type_name(ceiling))
+
+        # Same idea for the function's return: when every return agrees on a
+        # callee, that callee's type is a ceiling on the return annotation.
+        # Stored under a synthetic key that mk_annotation extracts and lubs
+        # into the retval before serialization.
+        if codevars.return_constructor is not None:
+            if (ceiling := _resolve_constructor_callee(
+                    codevars.return_constructor.parts,
+                    f_locals, frame.f_globals)) is not None:
+                scope_vars[RETURN_CEILING_KEY].add(get_type_name(ceiling))
 
         if codevars.self and (self_obj := f_locals.get(codevars.self)) is not None:
             obj_attrs = self._object_attributes[codevars.class_key]

--- a/righttyper/recorder.py
+++ b/righttyper/recorder.py
@@ -637,6 +637,21 @@ class ObservationsRecorder:
 
         self._assign_attributes_to_scopes()
 
+        # Populate accessed_attributes from the loader's static analysis.
+        # Done here (vs. at collect_annotations time) so the data survives
+        # serialization to .rt files for the --only-collect + process flow.
+        # co_varnames/co_freevars are only available while the code object
+        # is live, so module_accessed_attributes must be computed now.
+        for co, cv in code2variables.items():
+            if cv.accessed_attributes:
+                self._obs.accessed_attributes[CodeId.from_code(co)] = cv.accessed_attributes
+                module_attrs = self._obs.module_accessed_attributes.setdefault(
+                    Filename(co.co_filename), {}
+                )
+                for var_name, attrs in cv.accessed_attributes.items():
+                    if var_name not in co.co_varnames and var_name not in co.co_freevars:
+                        module_attrs.setdefault(var_name, set()).update(attrs)
+
         obs, self._obs = self._obs, Observations()
         self._code2func_info.clear()
         self._pending_traces.clear()

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -697,7 +697,13 @@ def add_output_options(group=None):
                 "--use-attribute-simplification/--no-use-attribute-simplification",
                 is_flag=True,
                 default=output_options.use_attribute_simplification,
-                help="""Whether to simplify types based on the minimum object attributes the code requires, derived through static analysis."""
+                help="""Whether to widen types via static analysis of which attributes the code actually accesses, generalizing to a base class when the code only uses attributes inherited from it.""",
+            ),
+            base.option(
+                "--use-constructor-types/--no-use-constructor-types",
+                is_flag=True,
+                default=output_options.use_constructor_types,
+                help="""Whether to use a variable's source-level constructor or factory call (e.g., `p = Path("/tmp")` or `p = Path.cwd()`) as its annotation, when the observed runtime type is consistent with the call's declared return.""",
             ),
         ]):
             func = opt(func)
@@ -1106,6 +1112,15 @@ def process(**kwargs):
     obs = obs_list[0]
     for obs2 in obs_list[1:]:
         obs.merge_observations(obs2)
+
+    if not output_options.use_constructor_types:
+        # Honors `--no-use-constructor-types` at process time even when
+        # the .rt was recorded with the feature on.  Clearing here is the
+        # single point of action; downstream `_apply_constructor_type`
+        # naturally short-circuits on empty candidates.
+        for fi in obs.func_info.values():
+            fi.constructor_types.clear()
+        obs.module_constructor_types.clear()
 
     from righttyper.type_transformers import LoadTypeObjT
     obs.transform_types(LoadTypeObjT())

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -1000,21 +1000,6 @@ def run(
                 for m in detected_test_modules:
                     logger.debug(f"test module: {m}")
 
-            # Populate accessed_attributes on obs from the loader's static
-            # analysis.  Done before either save or process so both paths
-            # get the data.  co_varnames/co_freevars are only available at
-            # runtime, so module_accessed_attributes must be computed now.
-            from righttyper.variable_capture import code2variables
-            for co, cv in code2variables.items():
-                if cv.accessed_attributes:
-                    obs.accessed_attributes[CodeId.from_code(co)] = cv.accessed_attributes
-                    fn = Filename(co.co_filename)
-                    if fn not in obs.module_accessed_attributes:
-                        obs.module_accessed_attributes[fn] = {}
-                    for var_name, attrs in cv.accessed_attributes.items():
-                        if var_name not in co.co_varnames and var_name not in co.co_freevars:
-                            obs.module_accessed_attributes[fn].setdefault(var_name, set()).update(attrs)
-
             if only_collect:
                 from righttyper.type_transformers import MakePickleableT
                 obs.transform_types(MakePickleableT())

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -693,6 +693,12 @@ def add_output_options(group=None):
                 default=output_options.inline_generics,
                 help="""Whether to use PEP 695 inline type parameter syntax (Python 3.12+). Disable for module-level TypeVar declarations."""
             ),
+            base.option(
+                "--use-attribute-simplification/--no-use-attribute-simplification",
+                is_flag=True,
+                default=output_options.use_attribute_simplification,
+                help="""Whether to simplify types based on the minimum object attributes the code requires, derived through static analysis."""
+            ),
         ]):
             func = opt(func)
         return func

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -1000,6 +1000,21 @@ def run(
                 for m in detected_test_modules:
                     logger.debug(f"test module: {m}")
 
+            # Populate accessed_attributes on obs from the loader's static
+            # analysis.  Done before either save or process so both paths
+            # get the data.  co_varnames/co_freevars are only available at
+            # runtime, so module_accessed_attributes must be computed now.
+            from righttyper.variable_capture import code2variables
+            for co, cv in code2variables.items():
+                if cv.accessed_attributes:
+                    obs.accessed_attributes[CodeId.from_code(co)] = cv.accessed_attributes
+                    fn = Filename(co.co_filename)
+                    if fn not in obs.module_accessed_attributes:
+                        obs.module_accessed_attributes[fn] = {}
+                    for var_name, attrs in cv.accessed_attributes.items():
+                        if var_name not in co.co_varnames and var_name not in co.co_freevars:
+                            obs.module_accessed_attributes[fn].setdefault(var_name, set()).update(attrs)
+
             if only_collect:
                 from righttyper.type_transformers import MakePickleableT
                 obs.transform_types(MakePickleableT())
@@ -1011,7 +1026,7 @@ def run(
                     'timestamp': datetime.datetime.now().isoformat(),
                     'run_options': run_options,
                     'script': Path(script).resolve(),
-                    'observations': obs
+                    'observations': obs,
                 }
 
                 index = 1

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -1001,9 +1001,6 @@ def run(
                     logger.debug(f"test module: {m}")
 
             if only_collect:
-                from righttyper.type_transformers import MakePickleableT
-                obs.transform_types(MakePickleableT())
-
                 collected = {
                     'file_version': PKL_FILE_VERSION,
                     'software': TOOL_NAME,
@@ -1019,7 +1016,19 @@ def run(
                     filename = Path(PKL_FILE_NAME.format(N=index))
                     try:
                         with filename.open("xb") as pklf:
-                            pickle.dump(collected, pklf)
+                            # Strip `type_obj` from TypeInfos as we write —
+                            # see `TypeInfo._strip_type_obj_for_pickle` for why.
+                            # Stdlib pickle (used by multiprocessing) is
+                            # unaffected since this dispatch_table lives on this
+                            # pickler instance only.
+                            import copyreg
+                            from righttyper.typeinfo import TypeInfo
+                            pickler = pickle.Pickler(pklf)
+                            pickler.dispatch_table = {
+                                **copyreg.dispatch_table,
+                                **TypeInfo._pickle_dispatch_entries(),
+                            }
+                            pickler.dump(collected)
                             break
 
                     except FileExistsError:

--- a/righttyper/type_id.py
+++ b/righttyper/type_id.py
@@ -122,7 +122,7 @@ def hint2type(hint: object) -> TypeInfo:
     ):
         # jaxtyping arrays are really dynamic types formed by indexing on their
         # base type.  I am not quite sure whether type_obj should be base_type here:
-        # it may yield incorrect results in generalize.simplify()
+        # it may yield incorrect results in generalize.lub
         return TypeInfo.from_type(base_type, args=(
             get_type_name(array_type), hint.dim_str
         ))

--- a/righttyper/typeinfo.py
+++ b/righttyper/typeinfo.py
@@ -100,6 +100,12 @@ class TypeInfo:
 
     @staticmethod
     def from_set(s: "set[TypeInfo]", empty_is_none=False, **kwargs: Any) -> "TypeInfo":
+        """Form a union from a set, with simplification.
+
+        Expands nested unions, subsumes Any, removes Never/NoReturn,
+        cleans up Never-generics, caps oversized unions, and sorts
+        for deterministic output.
+        """
         if not s:
             return NoneTypeInfo if empty_is_none else TypeInfo.from_type(typing.Never)
 
@@ -149,6 +155,36 @@ class TypeInfo:
             UnionTypeInfo,
             # 'None' at the end is seen as more readable
             args=tuple(sorted(s, key = lambda x: (x == NoneTypeInfo, str(x)))),
+            **kwargs
+        )
+
+
+    @staticmethod
+    def from_set_new(s: "set[TypeInfo]", **kwargs: Any) -> "TypeInfo":
+        """Form a union from a set of already-simplified types.
+
+        Assumes the caller (lub/merge_set) already handled Never removal,
+        Any subsumption, and Never-generic cleanup. Only flattens nested
+        unions, deduplicates, and sorts for deterministic output.
+        """
+        if not s:
+            return TypeInfo.from_type(typing.Never)
+
+        # Flatten nested unions
+        expanded: set[TypeInfo] = set()
+        for t in s:
+            if t.is_union() and not t.typevar_index:
+                expanded |= {a for a in t.args if isinstance(a, TypeInfo)}
+            else:
+                expanded.add(t)
+
+        if len(expanded) == 1:
+            return next(iter(expanded))
+
+        return UnionTypeInfo.from_type(
+            UnionTypeInfo,
+            # Sort for deterministic output (None at end for readability)
+            args=tuple(sorted(expanded, key=lambda x: (x == NoneTypeInfo, str(x)))),
             **kwargs
         )
 

--- a/righttyper/typeinfo.py
+++ b/righttyper/typeinfo.py
@@ -1,7 +1,7 @@
 import typing
 from typing import Iterator, Iterable, Final, Callable, Any, cast
 import types
-from dataclasses import dataclass, replace, field
+from dataclasses import dataclass, fields, replace, field
 from righttyper.righttyper_types import CodeId
 from righttyper.righttyper_utils import normalize_module_name
 
@@ -194,6 +194,35 @@ class TypeInfo:
 
     def replace(self, **kwargs: Any) -> "TypeInfo":
         return replace(self, **kwargs)
+
+
+    @staticmethod
+    def _strip_type_obj_for_pickle(t: "TypeInfo") -> tuple[Any, ...]:
+        """Pickle reducer that drops `type_obj`.  Registered on the
+        `Pickler.dispatch_table` used to write `.rt` files: without it,
+        the live class reference (often a __main__-defined class) leaks
+        through the round-trip and overrides the canonical (module, name)
+        chosen by `AdjustTypeNamesT`, producing names like
+        `__main__.Foo` at process time.  Walks `fields()` so it stays
+        correct as TypeInfo evolves."""
+        return type(t), tuple(
+            None if f.name == 'type_obj' else getattr(t, f.name)
+            for f in fields(type(t))
+        )
+
+
+    @classmethod
+    def _pickle_dispatch_entries(cls) -> dict[type, Callable[[Any], tuple[Any, ...]]]:
+        """Returns dispatch_table entries mapping `cls` and every loaded
+        subclass to `_strip_type_obj_for_pickle`.  Recurses so future
+        subclasses (and sub-subclasses) are picked up automatically as
+        long as they're imported before `.rt` save."""
+        entries: dict[type, Callable[[Any], tuple[Any, ...]]] = {
+            cls: cls._strip_type_obj_for_pickle,
+        }
+        for sub in cls.__subclasses__():
+            entries.update(sub._pickle_dispatch_entries())
+        return entries
 
 
     def is_typevar(self) -> bool:

--- a/righttyper/typemap.py
+++ b/righttyper/typemap.py
@@ -185,10 +185,13 @@ class TypeMap:
         result: dict[tuple[str, str], tuple[str, str]] = {}
         for t, names in self._map.items():
             if names:
-                original = (
-                    normalize_module_name(getattr(t, '__module__', '')),
-                    getattr(t, '__qualname__', getattr(t, '__name__', ''))
-                )
+                mod = getattr(t, '__module__', '')
+                name = getattr(t, '__qualname__', getattr(t, '__name__', ''))
+                # Some C extension types (e.g. Cython metaclasses) have
+                # non-string __module__ descriptors; skip those.
+                if not isinstance(mod, str) or not isinstance(name, str):
+                    continue
+                original = (normalize_module_name(mod), name)
                 canonical = names[0]
                 if original != canonical:
                     result[original] = canonical

--- a/righttyper/typemap.py
+++ b/righttyper/typemap.py
@@ -178,6 +178,23 @@ class TypeMap:
                     )
 
 
+    def to_name_map(self) -> dict[tuple[str, str], tuple[str, str]]:
+        """Build a serializable mapping of (original_module, original_name) → (canonical_module, canonical_name)
+        for types whose canonical name differs from their __module__.__qualname__."""
+        from righttyper.righttyper_utils import normalize_module_name
+        result: dict[tuple[str, str], tuple[str, str]] = {}
+        for t, names in self._map.items():
+            if names:
+                original = (
+                    normalize_module_name(getattr(t, '__module__', '')),
+                    getattr(t, '__qualname__', getattr(t, '__name__', ''))
+                )
+                canonical = names[0]
+                if original != canonical:
+                    result[original] = canonical
+        return result
+
+
 class AdjustTypeNamesT(TypeInfo.Transformer):
     """Adjust types' module and name by looking their type_obj on TypeMap."""
     def __init__(self, type_map: TypeMap) -> None:

--- a/righttyper/typeshed.py
+++ b/righttyper/typeshed.py
@@ -39,7 +39,7 @@ class FunctionFinder(cst.CSTVisitor):
         self._module_name = module_name
         self._name_stack: list[str] = []
         self._want = want.split('.')
-        self.result: list[TypeInfo] = []
+        self.result: list[TypeInfo | None] = []
 
     def _type_from_name(self, scope, node: cst.Name|cst.Attribute) -> TypeInfo:
         full_name = get_full_name(node)
@@ -189,6 +189,10 @@ class FunctionFinder(cst.CSTVisitor):
         if isinstance(p := f.params.star_kwarg, cst.Param):
             self.result.append(self._parse_annotation(p.annotation))
 
+        # Return type as the last element, matching RightTyper's signature
+        # convention (`signature[-1]` is retval).
+        self.result.append(self._parse_annotation(f.returns))
+
     def visit_ClassDef(self, node: cst.ClassDef) -> bool:
         self._name_stack.append(node.name.value)
         return True
@@ -210,7 +214,7 @@ class FunctionFinder(cst.CSTVisitor):
         self._name_stack.pop()
 
 
-def get_func_params(code: cst.Module, module_name: str, func_name: str) -> list[TypeInfo]:
+def get_func_params(code: cst.Module, module_name: str, func_name: str) -> list[TypeInfo | None]:
     finder = FunctionFinder(module_name, func_name)
     w = MetadataWrapper(code)
     w.visit(finder)
@@ -226,8 +230,15 @@ def get_typeshed_module(module_name: str) -> cst.Module|None:
 
 
 @cache
-def get_typeshed_func_params(module_name: str, qualname: str) -> list[TypeInfo] | None:
+def get_typeshed_func_params(module_name: str, qualname: str) -> list[TypeInfo | None] | None:
     if not (module := get_typeshed_module(module_name)):
         return None
 
     return get_func_params(module, module_name, qualname)
+
+
+def get_typeshed_func_return(module_name: str, qualname: str) -> TypeInfo | None:
+    """Returns the typeshed-declared return type of `module_name.qualname`,
+    or None if not found / not annotated."""
+    sig = get_typeshed_func_params(module_name, qualname)
+    return sig[-1] if sig else None

--- a/righttyper/variable_capture.py
+++ b/righttyper/variable_capture.py
@@ -4,6 +4,42 @@ from dataclasses import dataclass, field, replace
 import collections.abc as abc
 
 
+# Operator/builtin → dunder method maps for desugaring
+_BINOP_TO_DUNDER: dict[type, str] = {
+    ast.Add: "__add__", ast.Sub: "__sub__", ast.Mult: "__mul__", ast.Div: "__truediv__",
+    ast.FloorDiv: "__floordiv__", ast.Mod: "__mod__", ast.Pow: "__pow__",
+    ast.LShift: "__lshift__", ast.RShift: "__rshift__",
+    ast.BitOr: "__or__", ast.BitXor: "__xor__", ast.BitAnd: "__and__",
+    ast.MatMult: "__matmul__",
+}
+
+_AUGASSIGN_TO_DUNDER: dict[type, str] = {
+    ast.Add: "__iadd__", ast.Sub: "__isub__", ast.Mult: "__imul__", ast.Div: "__itruediv__",
+    ast.FloorDiv: "__ifloordiv__", ast.Mod: "__imod__", ast.Pow: "__ipow__",
+    ast.LShift: "__ilshift__", ast.RShift: "__irshift__",
+    ast.BitOr: "__ior__", ast.BitXor: "__ixor__", ast.BitAnd: "__iand__",
+    ast.MatMult: "__imatmul__",
+}
+
+_UNARYOP_TO_DUNDER: dict[type, str] = {
+    ast.UAdd: "__pos__", ast.USub: "__neg__", ast.Invert: "__invert__",
+    # ast.Not uses __bool__, but everything has that
+}
+
+_CMPOP_TO_DUNDER: dict[type, str] = {
+    ast.Eq: "__eq__", ast.NotEq: "__ne__",
+    ast.Lt: "__lt__", ast.LtE: "__le__", ast.Gt: "__gt__", ast.GtE: "__ge__",
+}
+
+_BUILTIN_TO_DUNDER: dict[str, str] = {
+    "len": "__len__", "iter": "__iter__", "next": "__next__",
+    "hash": "__hash__", "abs": "__abs__", "repr": "__repr__",
+    "reversed": "__reversed__", "str": "__str__", "bool": "__bool__",
+    "int": "__int__", "float": "__float__", "round": "__round__",
+    "complex": "__complex__", "bytes": "__bytes__",
+}
+
+
 @dataclass
 class CodeVars:
     """Identifies variables and attributes for a code object, facilitating their capture."""
@@ -327,10 +363,83 @@ class VariableFinder(ast.NodeVisitor):
         self._code_stack.pop()
         self._qualname_stack.pop()
 
+    def _is_builtin(self, name: str) -> bool:
+        """Check if name refers to a builtin (not shadowed by a local or parameter)."""
+        return (name not in self._not_locals_stack[-1]  # not a parameter
+                and name not in self.code_vars.get(self._code_stack[-1], CodeVars("")).variables)
+
     def visit_Attribute(self, node: ast.Attribute) -> None:
         # Record attribute accesses on variables: x.foo, x.foo(), x.foo = val
         if isinstance(node.value, ast.Name):
             self._record_attribute_access(node.value.id, node.attr)
+        self.generic_visit(node)
+
+    def visit_Subscript(self, node: ast.Subscript) -> None:
+        if isinstance(node.value, ast.Name):
+            dunder = {ast.Load: "__getitem__", ast.Store: "__setitem__", ast.Del: "__delitem__"}
+            if (d := dunder.get(type(node.ctx))):
+                self._record_attribute_access(node.value.id, d)
+        self.generic_visit(node)
+
+    def visit_BinOp(self, node: ast.BinOp) -> None:
+        if isinstance(node.left, ast.Name) and (d := _BINOP_TO_DUNDER.get(type(node.op))):
+            self._record_attribute_access(node.left.id, d)
+        self.generic_visit(node)
+
+    def visit_UnaryOp(self, node: ast.UnaryOp) -> None:
+        if isinstance(node.operand, ast.Name) and (d := _UNARYOP_TO_DUNDER.get(type(node.op))):
+            self._record_attribute_access(node.operand.id, d)
+        self.generic_visit(node)
+
+    def visit_Compare(self, node: ast.Compare) -> None:
+        # x < y → __lt__ on x; item in x → __contains__ on x (right operand)
+        prev = node.left
+        for op, comparator in zip(node.ops, node.comparators):
+            if isinstance(op, (ast.In, ast.NotIn)):
+                if isinstance(comparator, ast.Name):
+                    self._record_attribute_access(comparator.id, "__contains__")
+            elif isinstance(prev, ast.Name) and (d := _CMPOP_TO_DUNDER.get(type(op))):
+                self._record_attribute_access(prev.id, d)
+            prev = comparator
+        self.generic_visit(node)
+
+    def visit_Await(self, node: ast.Await) -> None:
+        if isinstance(node.value, ast.Name):
+            self._record_attribute_access(node.value.id, "__await__")
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        # Desugar builtin calls: len(x) → __len__ on x, etc.
+        if (isinstance(node.func, ast.Name)
+            and (dunder := _BUILTIN_TO_DUNDER.get(node.func.id))
+            and self._is_builtin(node.func.id)
+            and node.args
+            and isinstance(node.args[0], ast.Name)):
+            self._record_attribute_access(node.args[0].id, dunder)
+        self.generic_visit(node)
+
+    def visit_ListComp(self, node: ast.ListComp) -> None:
+        for gen in node.generators:
+            if isinstance(gen.iter, ast.Name):
+                self._record_attribute_access(gen.iter.id, "__iter__")
+        self.generic_visit(node)
+
+    def visit_SetComp(self, node: ast.SetComp) -> None:
+        for gen in node.generators:
+            if isinstance(gen.iter, ast.Name):
+                self._record_attribute_access(gen.iter.id, "__iter__")
+        self.generic_visit(node)
+
+    def visit_DictComp(self, node: ast.DictComp) -> None:
+        for gen in node.generators:
+            if isinstance(gen.iter, ast.Name):
+                self._record_attribute_access(gen.iter.id, "__iter__")
+        self.generic_visit(node)
+
+    def visit_GeneratorExp(self, node: ast.GeneratorExp) -> None:
+        for gen in node.generators:
+            if isinstance(gen.iter, ast.Name):
+                self._record_attribute_access(gen.iter.id, "__iter__")
         self.generic_visit(node)
 
     def visit_Lambda(self, node: ast.Lambda) -> None:
@@ -377,6 +486,8 @@ class VariableFinder(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit_AugAssign(self, node: ast.AugAssign) -> None:
+        if isinstance(node.target, ast.Name) and (d := _AUGASSIGN_TO_DUNDER.get(type(node.op))):
+            self._record_attribute_access(node.target.id, d)
         for t in _iter_target_atoms(node.target):
             self._record_target(t)
         self.generic_visit(node)
@@ -387,17 +498,24 @@ class VariableFinder(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit_For(self, node: ast.For) -> None:
+        if isinstance(node.iter, ast.Name):
+            self._record_attribute_access(node.iter.id, "__iter__")
         for t in _iter_target_atoms(node.target):
             self._record_target(t)
         self.generic_visit(node)
 
     def visit_AsyncFor(self, node: ast.AsyncFor) -> None:
+        if isinstance(node.iter, ast.Name):
+            self._record_attribute_access(node.iter.id, "__iter__")
         for t in _iter_target_atoms(node.target):
             self._record_target(t)
         self.generic_visit(node)
 
     def visit_With(self, node: ast.With) -> None:
         for item in node.items:
+            if isinstance(item.context_expr, ast.Name):
+                self._record_attribute_access(item.context_expr.id, "__enter__")
+                self._record_attribute_access(item.context_expr.id, "__exit__")
             if item.optional_vars is not None:
                 for t in _iter_target_atoms(item.optional_vars):
                     self._record_target(t)
@@ -405,6 +523,9 @@ class VariableFinder(ast.NodeVisitor):
 
     def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
         for item in node.items:
+            if isinstance(item.context_expr, ast.Name):
+                self._record_attribute_access(item.context_expr.id, "__aenter__")
+                self._record_attribute_access(item.context_expr.id, "__aexit__")
             if item.optional_vars is not None:
                 for t in _iter_target_atoms(item.optional_vars):
                     self._record_target(t)

--- a/righttyper/variable_capture.py
+++ b/righttyper/variable_capture.py
@@ -219,13 +219,6 @@ class VariableFinder(ast.NodeVisitor):
         """Resolve a variable name to all names it could refer to (including itself)."""
         return self._aliases_stack[-1].get(name, set()) | {name}
 
-    def _record_attribute_access(self, var_name: str, attr_name: str) -> None:
-        """Record that attr_name is accessed on var_name (and its aliases)."""
-        code_name = self._code_stack[-1]
-        attrs = self._accessed_attributes.setdefault(code_name, {})
-        for name in self._resolve_aliases(var_name):
-            attrs.setdefault(name, set()).add(attr_name)
-
     def _record_target(self, t: ast.AST, value: ast.expr | None = None) -> None:
         if isinstance(t, ast.Name):
             self._record_variable(t.id, value)
@@ -375,6 +368,129 @@ class VariableFinder(ast.NodeVisitor):
         return (name not in self._not_locals_stack[-1]  # not a parameter
                 and name not in self.code_vars.get(self._code_stack[-1], CodeVars("")).variables)
 
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        # any NamedExpr within stay within the lambda's scope
+        pass
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        # Only pass value for simple single-target assignments like "x = None"
+        # or "self.x = None". We skip multi-target (x = y = 1) and tuple
+        # unpacking (a, b = 0, 1) to keep the implementation simple.
+        value = node.value if (len(node.targets) == 1
+                               and isinstance(node.targets[0], (ast.Name, ast.Attribute))) else None
+
+        # Check if we're in a class body (not in a function)
+        in_class_body = (
+            self._class_stack
+            and self._code_stack[-1] == self._class_stack[-1].name
+        )
+
+        for tgt in node.targets:
+            for t in _iter_target_atoms(tgt):
+                # Capture class-body assignments like `monitor = None`
+                if in_class_body and isinstance(t, ast.Name):
+                    class_info = self._class_stack[-1]
+                    # Only record first assignment; capture initial constant type if applicable
+                    if t.id not in class_info.class_attributes:
+                        const_type = type(value.value) if (value is not None and isinstance(value, ast.Constant)) else None
+                        class_info.class_attributes[t.id] = const_type
+                self._record_target(t, value)
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        # require value to filter out pure type declarations
+        if node.value is not None and node.target is not None:
+            for t in _iter_target_atoms(node.target):
+                self._record_target(t, node.value)
+        self.generic_visit(node)
+
+    def visit_TypeAlias(self, node: ast.TypeAlias) -> None:
+        # Is 'type X = ...' a declaration or variable definition?
+        # For now, we err on the side of capturing it.
+        for t in _iter_target_atoms(node.name):
+            self._record_target(t)
+        self.generic_visit(node)
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> None:
+        for t in _iter_target_atoms(node.target):
+            self._record_target(t)
+        self.generic_visit(node)
+
+    def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
+        for t in _iter_target_atoms(node.target):
+            self._record_target(t)
+        self.generic_visit(node)
+
+    def visit_For(self, node: ast.For) -> None:
+        for t in _iter_target_atoms(node.target):
+            self._record_target(t)
+        self.generic_visit(node)
+
+    def visit_AsyncFor(self, node: ast.AsyncFor) -> None:
+        for t in _iter_target_atoms(node.target):
+            self._record_target(t)
+        self.generic_visit(node)
+
+    def visit_With(self, node: ast.With) -> None:
+        for item in node.items:
+            if item.optional_vars is not None:
+                for t in _iter_target_atoms(item.optional_vars):
+                    self._record_target(t)
+        self.generic_visit(node)
+
+    def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
+        for item in node.items:
+            if item.optional_vars is not None:
+                for t in _iter_target_atoms(item.optional_vars):
+                    self._record_target(t)
+        self.generic_visit(node)
+
+    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+        if isinstance(node.name, str):
+            self._record_variable(node.name)
+        self.generic_visit(node)
+
+    def visit_Match(self, node: ast.Match) -> None:
+        # Bind names from patterns
+        for case in node.cases:
+            for nm in _from_pattern(case.pattern):
+                self._record_variable(nm)
+        self.generic_visit(node)
+
+    def visit_Import(self, node: ast.Import) -> None:
+        pass # don't need these
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        pass # don't need these
+
+
+def _walk_code_objects(co: types.CodeType) -> abc.Iterator[types.CodeType]:
+    """Iterates through all code objects within a code object."""
+    yield co
+
+    for c in co.co_consts:
+        if isinstance(c, types.CodeType):
+            yield from _walk_code_objects(c)
+
+
+class AttributeTrackingVariableFinder(VariableFinder):
+    """Adds static analysis of attribute accesses on top of variable tracking.
+
+    The pure-attribute visit methods (visit_Attribute, visit_Subscript, ...) live
+    only on this subclass so that, when `--no-use-attribute-simplification` is in
+    effect, ast.NodeVisitor.visit() finds no override and falls straight to
+    generic_visit — eliminating per-node dispatch overhead. Mixed methods
+    (visit_For, visit_AugAssign, ...) override the base's variable-only
+    implementation and call super() to add the attribute-recording side.
+    """
+
+    def _record_attribute_access(self, var_name: str, attr_name: str) -> None:
+        """Record that attr_name is accessed on var_name (and its aliases)."""
+        code_name = self._code_stack[-1]
+        attrs = self._accessed_attributes.setdefault(code_name, {})
+        for name in self._resolve_aliases(var_name):
+            attrs.setdefault(name, set()).add(attr_name)
+
     def visit_Attribute(self, node: ast.Attribute) -> None:
         # Record attribute accesses on variables: x.foo, x.foo(), x.foo = val
         if isinstance(node.value, ast.Name):
@@ -449,128 +565,45 @@ class VariableFinder(ast.NodeVisitor):
                 self._record_attribute_access(gen.iter.id, "__iter__")
         self.generic_visit(node)
 
-    def visit_Lambda(self, node: ast.Lambda) -> None:
-        # any NamedExpr within stay within the lambda's scope
-        pass
-
-    def visit_Assign(self, node: ast.Assign) -> None:
-        # Only pass value for simple single-target assignments like "x = None"
-        # or "self.x = None". We skip multi-target (x = y = 1) and tuple
-        # unpacking (a, b = 0, 1) to keep the implementation simple.
-        value = node.value if (len(node.targets) == 1
-                               and isinstance(node.targets[0], (ast.Name, ast.Attribute))) else None
-
-        # Check if we're in a class body (not in a function)
-        in_class_body = (
-            self._class_stack
-            and self._code_stack[-1] == self._class_stack[-1].name
-        )
-
-        for tgt in node.targets:
-            for t in _iter_target_atoms(tgt):
-                # Capture class-body assignments like `monitor = None`
-                if in_class_body and isinstance(t, ast.Name):
-                    class_info = self._class_stack[-1]
-                    # Only record first assignment; capture initial constant type if applicable
-                    if t.id not in class_info.class_attributes:
-                        const_type = type(value.value) if (value is not None and isinstance(value, ast.Constant)) else None
-                        class_info.class_attributes[t.id] = const_type
-                self._record_target(t, value)
-        self.generic_visit(node)
-
-    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
-        # require value to filter out pure type declarations
-        if node.value is not None and node.target is not None:
-            for t in _iter_target_atoms(node.target):
-                self._record_target(t, node.value)
-        self.generic_visit(node)
-
-    def visit_TypeAlias(self, node: ast.TypeAlias) -> None:
-        # Is 'type X = ...' a declaration or variable definition?
-        # For now, we err on the side of capturing it.
-        for t in _iter_target_atoms(node.name):
-            self._record_target(t)
-        self.generic_visit(node)
-
     def visit_AugAssign(self, node: ast.AugAssign) -> None:
         if isinstance(node.target, ast.Name) and (d := _AUGASSIGN_TO_DUNDER.get(type(node.op))):
             self._record_attribute_access(node.target.id, d)
-        for t in _iter_target_atoms(node.target):
-            self._record_target(t)
-        self.generic_visit(node)
-
-    def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
-        for t in _iter_target_atoms(node.target):
-            self._record_target(t)
-        self.generic_visit(node)
+        super().visit_AugAssign(node)
 
     def visit_For(self, node: ast.For) -> None:
         if isinstance(node.iter, ast.Name):
             self._record_attribute_access(node.iter.id, "__iter__")
-        for t in _iter_target_atoms(node.target):
-            self._record_target(t)
-        self.generic_visit(node)
+        super().visit_For(node)
 
     def visit_AsyncFor(self, node: ast.AsyncFor) -> None:
         if isinstance(node.iter, ast.Name):
             self._record_attribute_access(node.iter.id, "__iter__")
-        for t in _iter_target_atoms(node.target):
-            self._record_target(t)
-        self.generic_visit(node)
+        super().visit_AsyncFor(node)
 
     def visit_With(self, node: ast.With) -> None:
         for item in node.items:
             if isinstance(item.context_expr, ast.Name):
                 self._record_attribute_access(item.context_expr.id, "__enter__")
                 self._record_attribute_access(item.context_expr.id, "__exit__")
-            if item.optional_vars is not None:
-                for t in _iter_target_atoms(item.optional_vars):
-                    self._record_target(t)
-        self.generic_visit(node)
+        super().visit_With(node)
 
     def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
         for item in node.items:
             if isinstance(item.context_expr, ast.Name):
                 self._record_attribute_access(item.context_expr.id, "__aenter__")
                 self._record_attribute_access(item.context_expr.id, "__aexit__")
-            if item.optional_vars is not None:
-                for t in _iter_target_atoms(item.optional_vars):
-                    self._record_target(t)
-        self.generic_visit(node)
-
-    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
-        if isinstance(node.name, str):
-            self._record_variable(node.name)
-        self.generic_visit(node)
-
-    def visit_Match(self, node: ast.Match) -> None:
-        # Bind names from patterns
-        for case in node.cases:
-            for nm in _from_pattern(case.pattern):
-                self._record_variable(nm)
-        self.generic_visit(node)
-
-    def visit_Import(self, node: ast.Import) -> None:
-        pass # don't need these
-
-    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
-        pass # don't need these
+        super().visit_AsyncWith(node)
 
 
-def _walk_code_objects(co: types.CodeType) -> abc.Iterator[types.CodeType]:
-    """Iterates through all code objects within a code object."""
-    yield co
-
-    for c in co.co_consts:
-        if isinstance(c, types.CodeType):
-            yield from _walk_code_objects(c)
-
-
-def map_variables(tree: ast.Module, module_code: types.CodeType) -> dict[types.CodeType, CodeVars]:
+def map_variables(
+    tree: ast.Module,
+    module_code: types.CodeType,
+    track_attributes: bool = True,
+) -> dict[types.CodeType, CodeVars]:
     """Creates a map of code objects to the variables assigned to in that code,
        to facilitate variable sampling."""
 
-    f = VariableFinder()
+    f: VariableFinder = AttributeTrackingVariableFinder() if track_attributes else VariableFinder()
     f.visit(tree)
 
     qualname2code: dict[str|None, types.CodeType] = {

--- a/righttyper/variable_capture.py
+++ b/righttyper/variable_capture.py
@@ -184,7 +184,11 @@ class VariableFinder(ast.NodeVisitor):
     assigned or bound within each scope.
     Imports, comprehensions, generator expressions are ignored.
     """
-    def __init__(self) -> None:
+    def __init__(self, track_constructors: bool = True) -> None:
+        # When False, skip recording `var = Foo(...)` callee info — the
+        # `--no-use-constructor-types` path doesn't need it.
+        self._track_constructors = track_constructors
+
         # Used to build an item's qualified name
         self._qualname_stack: list[str] = []
 
@@ -253,7 +257,7 @@ class VariableFinder(ast.NodeVisitor):
         new_init: type | Constructor | None = None
         if isinstance(value, ast.Constant):
             new_init = type(value.value)
-        elif isinstance(value, ast.Call):
+        elif self._track_constructors and isinstance(value, ast.Call):
             new_init = _extract_call_target(value)
             if new_init is not None and self._is_receiver_call(new_init):
                 # `cls(...)` / `self(...)` patterns: existing Self detection
@@ -539,8 +543,11 @@ class VariableFinder(ast.NodeVisitor):
     def visit_Return(self, node: ast.Return) -> None:
         # Record a candidate Constructor for this return statement.
         # Returns outside any function (parser-syntax error normally) have no
-        # active stack — ignore to be safe.
-        if self._returns_stack:
+        # active stack — ignore to be safe.  When constructor tracking is
+        # off, `_record_variable` never set Constructor entries, so the
+        # `return Name` lookup below would always fall through; skip the
+        # whole pass.
+        if self._returns_stack and self._track_constructors:
             candidate: Constructor | None = None
             value = node.value
             if isinstance(value, ast.Call):
@@ -712,11 +719,16 @@ def map_variables(
     tree: ast.Module,
     module_code: types.CodeType,
     track_attributes: bool = True,
+    track_constructors: bool = True,
 ) -> dict[types.CodeType, CodeVars]:
     """Creates a map of code objects to the variables assigned to in that code,
        to facilitate variable sampling."""
 
-    f: VariableFinder = AttributeTrackingVariableFinder() if track_attributes else VariableFinder()
+    f: VariableFinder = (
+        AttributeTrackingVariableFinder(track_constructors=track_constructors)
+        if track_attributes
+        else VariableFinder(track_constructors=track_constructors)
+    )
     f.visit(tree)
 
     qualname2code: dict[str|None, types.CodeType] = {

--- a/righttyper/variable_capture.py
+++ b/righttyper/variable_capture.py
@@ -41,6 +41,16 @@ _BUILTIN_TO_DUNDER: dict[str, str] = {
 
 
 @dataclass
+class Constructor:
+    """Identifies that a variable was initialized as `var = Name(...)` (or
+    `var = pkg.Name(...)`), with the dotted source-level callee parts
+    (e.g. ["Path"], ["pathlib", "Path"]). Used to look up the callee's
+    typeshed-declared return type and apply it as a ceiling on the
+    variable's annotation."""
+    parts: list[str]
+
+
+@dataclass
 class CodeVars:
     """Identifies variables and attributes for a code object, facilitating their capture."""
 
@@ -53,8 +63,13 @@ class CodeVars:
     # prefix for qualified variable names (e.g., "C." for class C, "" for functions)
     var_prefix: str = ""
 
-    # local variable names: var_name -> initial constant type (or None if not a constant)
-    variables: dict[str, type | None] = field(default_factory=dict)
+    # Local variable names mapped to what we know about their initialization:
+    #   - `type` (e.g., int) for `x = <constant of that type>`
+    #   - `Constructor(parts=...)` for `var = Foo(...)` where every assignment
+    #     in the function is a Call with that callee (kill-on-mismatch)
+    #   - None when the var is bound but neither pattern fits, or for vars
+    #     whose constructor entry was killed by an inconsistent reassignment
+    variables: dict[str, type | Constructor | None] = field(default_factory=dict)
 
     # qualified name of this code object's class, if it's a method
     class_name: str | None = None
@@ -77,6 +92,13 @@ class CodeVars:
     # attributes accessed on each variable (from static analysis of the function body)
     accessed_attributes: dict[str, set[str]] = field(default_factory=dict)
 
+    # For functions whose every `return` is `return Name(...)` or `return var`
+    # (where var has a Constructor entry in `variables`), the constructor.
+    # Used to widen the function's return annotation consistently with its
+    # variable annotations, so `def f(): p = Path(...); return p` has both
+    # `p: Path` and `f() -> Path` (avoiding mypy return-covariance errors).
+    return_constructor: Constructor | None = None
+
 
 """Maps code objects to the variables assigned/bound within each object."""
 code2variables: dict[types.CodeType, CodeVars] = dict()
@@ -96,6 +118,22 @@ def _extract_name(node: ast.AST) -> str:
         parts.append(node.id)
 
     return ".".join(reversed(parts))
+
+
+def _extract_call_target(call: ast.Call) -> Constructor | None:
+    """If `call.func` is a Name or an Attribute chain ending in a Name,
+    return a Constructor with the dotted source-level parts; else None.
+    Skips dynamic call targets (e.g. `factories[i](...)` or `make()(...)`)."""
+    func = call.func
+    parts: list[str] = []
+    while isinstance(func, ast.Attribute):
+        parts.append(func.attr)
+        func = func.value
+    if isinstance(func, ast.Name):
+        parts.append(func.id)
+        parts.reverse()
+        return Constructor(parts=parts)
+    return None
 
 
 def _iter_target_atoms(target: ast.AST) -> abc.Iterator[ast.AST]:
@@ -182,6 +220,20 @@ class VariableFinder(ast.NodeVisitor):
         # Stored as code_qualname -> {var_name -> {attr_names}}
         self._accessed_attributes: dict[str, dict[str, set[str]]] = {}
 
+        # One entry per active function scope; each entry collects the candidate
+        # for every `return` encountered: a Constructor (resolved from the return
+        # expression at the time it is visited) or None (kill marker — bare
+        # return, complex expression, name without a Constructor entry, etc.).
+        # After the function body is visited, codevars.return_constructor is set
+        # iff every entry is a Constructor and they all agree.
+        self._returns_stack: list[list[Constructor | None]] = []
+
+    def _is_receiver_call(self, ctor: "Constructor") -> bool:
+        """True if the constructor's leading name is the current scope's
+        `self` or `cls` parameter — these are Self-typed constructions and
+        should not get a concrete-class ceiling layered on top."""
+        return ctor.parts[0] in (self._self_stack[-1], self._cls_stack[-1])
+
     def _record_variable(self, name: str, value: ast.expr | None = None) -> None:
         if name in self._not_locals_stack[-1]:
             return
@@ -197,10 +249,29 @@ class VariableFinder(ast.NodeVisitor):
             if prefix_parts:
                 codevars.var_prefix = '.'.join(prefix_parts) + "."
 
-        # Only record if this is the first assignment (variable definition)
+        # What we know about THIS particular assignment.
+        new_init: type | Constructor | None = None
+        if isinstance(value, ast.Constant):
+            new_init = type(value.value)
+        elif isinstance(value, ast.Call):
+            new_init = _extract_call_target(value)
+            if new_init is not None and self._is_receiver_call(new_init):
+                # `cls(...)` / `self(...)` patterns: existing Self detection
+                # already infers Self for these, more precisely than a
+                # concrete-class ceiling. Drop the Constructor entry.
+                new_init = None
+
         if name not in codevars.variables:
-            const_type = type(value.value) if (value is not None and isinstance(value, ast.Constant)) else None
-            codevars.variables[name] = const_type
+            # First assignment — record whatever we have.
+            codevars.variables[name] = new_init
+        elif isinstance(codevars.variables[name], Constructor):
+            # Subsequent assignment to a Constructor entry: every assignment
+            # must agree, otherwise the entry is killed (ceiling can't apply).
+            existing = codevars.variables[name]
+            if not (isinstance(new_init, Constructor)
+                    and isinstance(existing, Constructor)
+                    and new_init.parts == existing.parts):
+                codevars.variables[name] = None
 
     def _record_alias(self, name: str, value: ast.expr | None) -> None:
         """Track name-to-name aliases for attribute access propagation.
@@ -310,6 +381,8 @@ class VariableFinder(ast.NodeVisitor):
         # Inherit a copy of the parent's aliases so closure refs still propagate,
         # but isolate this scope's new aliases from siblings.
         self._aliases_stack.append(dict(self._aliases_stack[-1]))
+        # Per-function return-candidate accumulator (consumed after generic_visit).
+        self._returns_stack.append([])
 
         if self._class_stack:
             class_info = self._class_stack[-1]
@@ -323,6 +396,24 @@ class VariableFinder(ast.NodeVisitor):
             )
 
         self.generic_visit(node)
+
+        # Resolve the function's return-constructor: every collected candidate
+        # must be a Constructor and they must all agree. Bare returns, complex
+        # return expressions, and `return name` where name has no Constructor
+        # entry come through as None and kill the result.
+        candidates = self._returns_stack.pop()
+        first = candidates[0] if candidates else None
+        if (
+            isinstance(first, Constructor)
+            and all(isinstance(c, Constructor) and c.parts == first.parts
+                    for c in candidates)
+        ):
+            codevars = self.code_vars.setdefault(
+                self._code_stack[-1],
+                CodeVars('.'.join(self._scope_stack[-1][:-1])
+                         if self._scope_stack[-1] else '<module>'),
+            )
+            codevars.return_constructor = first
 
         self._aliases_stack.pop()
         self._not_locals_stack.pop()
@@ -443,6 +534,28 @@ class VariableFinder(ast.NodeVisitor):
             if item.optional_vars is not None:
                 for t in _iter_target_atoms(item.optional_vars):
                     self._record_target(t)
+        self.generic_visit(node)
+
+    def visit_Return(self, node: ast.Return) -> None:
+        # Record a candidate Constructor for this return statement.
+        # Returns outside any function (parser-syntax error normally) have no
+        # active stack — ignore to be safe.
+        if self._returns_stack:
+            candidate: Constructor | None = None
+            value = node.value
+            if isinstance(value, ast.Call):
+                candidate = _extract_call_target(value)
+                if candidate is not None and self._is_receiver_call(candidate):
+                    candidate = None
+            elif isinstance(value, ast.Name):
+                # Look up the variable's current entry; only Constructor counts.
+                codevars = self.code_vars.get(self._code_stack[-1])
+                if codevars is not None:
+                    existing = codevars.variables.get(value.id)
+                    if isinstance(existing, Constructor):
+                        candidate = existing
+            # value is None (bare return) or a more complex expression → kill.
+            self._returns_stack[-1].append(candidate)
         self.generic_visit(node)
 
     def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:

--- a/righttyper/variable_capture.py
+++ b/righttyper/variable_capture.py
@@ -38,6 +38,9 @@ class CodeVars:
     # class-level attributes (cls.x or class body assignments): attr_name -> initial constant type
     class_attributes: dict[str, type | None] | None = None
 
+    # attributes accessed on each variable (from static analysis of the function body)
+    accessed_attributes: dict[str, set[str]] = field(default_factory=dict)
+
 
 """Maps code objects to the variables assigned/bound within each object."""
 code2variables: dict[types.CodeType, CodeVars] = dict()
@@ -134,6 +137,13 @@ class VariableFinder(ast.NodeVisitor):
         # Resulting map of executing code object to their CodeVars
         self.code_vars: dict[str, CodeVars] = dict()
 
+        # Alias tracking: variable -> set of variables it could be (for attribute propagation)
+        self._aliases: dict[str, set[str]] = {}
+
+        # Attribute accesses collected for the current scope
+        # Stored as code_qualname -> {var_name -> {attr_names}}
+        self._accessed_attributes: dict[str, dict[str, set[str]]] = {}
+
     def _record_variable(self, name: str, value: ast.expr | None = None) -> None:
         if name in self._not_locals_stack[-1]:
             return
@@ -154,9 +164,33 @@ class VariableFinder(ast.NodeVisitor):
             const_type = type(value.value) if (value is not None and isinstance(value, ast.Constant)) else None
             codevars.variables[name] = const_type
 
+    def _record_alias(self, name: str, value: ast.expr | None) -> None:
+        """Track name-to-name aliases for attribute access propagation.
+        Unions aliases across branches (conservative: over-approximates)."""
+        if value is not None and isinstance(value, ast.Name):
+            # y = x → y aliases whatever x aliases (plus x itself), unioned with any prior aliases
+            new_aliases = self._aliases.get(value.id, set()) | {value.id}
+            self._aliases[name] = self._aliases.get(name, set()) | new_aliases
+        elif name in self._aliases:
+            # y = <non-name> → y is no longer a pure alias, but keep prior aliases
+            # (could be from a different branch)
+            pass
+
+    def _resolve_aliases(self, name: str) -> set[str]:
+        """Resolve a variable name to all names it could refer to (including itself)."""
+        return self._aliases.get(name, set()) | {name}
+
+    def _record_attribute_access(self, var_name: str, attr_name: str) -> None:
+        """Record that attr_name is accessed on var_name (and its aliases)."""
+        code_name = self._code_stack[-1]
+        attrs = self._accessed_attributes.setdefault(code_name, {})
+        for name in self._resolve_aliases(var_name):
+            attrs.setdefault(name, set()).add(attr_name)
+
     def _record_target(self, t: ast.AST, value: ast.expr | None = None) -> None:
         if isinstance(t, ast.Name):
             self._record_variable(t.id, value)
+            self._record_alias(t.id, value)
             if t.id == self._self_stack[-1]:
                 self._self_stack[-1] = None # a new assignment masked 'self'
             if t.id == self._cls_stack[-1]:
@@ -293,6 +327,12 @@ class VariableFinder(ast.NodeVisitor):
         self._code_stack.pop()
         self._qualname_stack.pop()
 
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        # Record attribute accesses on variables: x.foo, x.foo(), x.foo = val
+        if isinstance(node.value, ast.Name):
+            self._record_attribute_access(node.value.id, node.attr)
+        self.generic_visit(node)
+
     def visit_Lambda(self, node: ast.Lambda) -> None:
         # any NamedExpr within stay within the lambda's scope
         pass
@@ -410,13 +450,22 @@ def map_variables(tree: ast.Module, module_code: types.CodeType) -> dict[types.C
         for co in _walk_code_objects(module_code)
     }
 
-    return {
-        co: replace(
-            codevars,
-            scope_code=scope_code,
-            class_key=qualname2code.get(codevars.class_name)
-        )
-        for co in qualname2code.values()
-        if (codevars := f.code_vars.get(co.co_qualname))
-        if (scope_code := qualname2code.get(codevars.scope))
-    }
+    result: dict[types.CodeType, CodeVars] = {}
+    for co in qualname2code.values():
+        accessed = f._accessed_attributes.get(co.co_qualname, {})
+        if (codevars := f.code_vars.get(co.co_qualname)):
+            if (scope_code := qualname2code.get(codevars.scope)):
+                result[co] = replace(
+                    codevars,
+                    scope_code=scope_code,
+                    class_key=qualname2code.get(codevars.class_name),
+                    accessed_attributes=accessed,
+                )
+        elif accessed:
+            # Function has attribute accesses but no local variables
+            result[co] = CodeVars(
+                scope=co.co_qualname,
+                scope_code=co,
+                accessed_attributes=accessed,
+            )
+    return result

--- a/righttyper/variable_capture.py
+++ b/righttyper/variable_capture.py
@@ -173,8 +173,10 @@ class VariableFinder(ast.NodeVisitor):
         # Resulting map of executing code object to their CodeVars
         self.code_vars: dict[str, CodeVars] = dict()
 
-        # Alias tracking: variable -> set of variables it could be (for attribute propagation)
-        self._aliases: dict[str, set[str]] = {}
+        # Alias tracking: variable -> set of variables it could be (for attribute propagation).
+        # Stacked per function scope so siblings don't see each other's aliases; nested
+        # functions inherit a copy of their parent scope's aliases (closure refs preserved).
+        self._aliases_stack: list[dict[str, set[str]]] = [{}]
 
         # Attribute accesses collected for the current scope
         # Stored as code_qualname -> {var_name -> {attr_names}}
@@ -203,18 +205,19 @@ class VariableFinder(ast.NodeVisitor):
     def _record_alias(self, name: str, value: ast.expr | None) -> None:
         """Track name-to-name aliases for attribute access propagation.
         Unions aliases across branches (conservative: over-approximates)."""
+        aliases = self._aliases_stack[-1]
         if value is not None and isinstance(value, ast.Name):
             # y = x → y aliases whatever x aliases (plus x itself), unioned with any prior aliases
-            new_aliases = self._aliases.get(value.id, set()) | {value.id}
-            self._aliases[name] = self._aliases.get(name, set()) | new_aliases
-        elif name in self._aliases:
+            new_aliases = aliases.get(value.id, set()) | {value.id}
+            aliases[name] = aliases.get(name, set()) | new_aliases
+        elif name in aliases:
             # y = <non-name> → y is no longer a pure alias, but keep prior aliases
             # (could be from a different branch)
             pass
 
     def _resolve_aliases(self, name: str) -> set[str]:
         """Resolve a variable name to all names it could refer to (including itself)."""
-        return self._aliases.get(name, set()) | {name}
+        return self._aliases_stack[-1].get(name, set()) | {name}
 
     def _record_attribute_access(self, var_name: str, attr_name: str) -> None:
         """Record that attr_name is accessed on var_name (and its aliases)."""
@@ -311,6 +314,9 @@ class VariableFinder(ast.NodeVisitor):
             self._cls_stack.append(None)
 
         self._not_locals_stack.append(set(arguments))
+        # Inherit a copy of the parent's aliases so closure refs still propagate,
+        # but isolate this scope's new aliases from siblings.
+        self._aliases_stack.append(dict(self._aliases_stack[-1]))
 
         if self._class_stack:
             class_info = self._class_stack[-1]
@@ -325,6 +331,7 @@ class VariableFinder(ast.NodeVisitor):
 
         self.generic_visit(node)
 
+        self._aliases_stack.pop()
         self._not_locals_stack.pop()
         self._self_stack.pop()
         self._cls_stack.pop()

--- a/tests/test_generalize.py
+++ b/tests/test_generalize.py
@@ -996,18 +996,24 @@ def test_lub_idempotent():
         assert lub(a, a) == a
 
 
-def test_lub_empty_container_subsumed():
-    """lub(tuple[()], list[int]) → list[int] (empty subsumed by non-empty)."""
+def test_lub_empty_tuple_and_list_to_sequence():
+    """lub(tuple[()], list[int]) → Sequence[int] (cross-container, common ABC)."""
+    import collections.abc
     from righttyper.generalize import lub
     int_t = TypeInfo.from_type(int)
     empty = TypeInfo.from_type(tuple).replace(args=((),))
     non_empty = TypeInfo.from_type(list).replace(args=(int_t,))
-    assert lub(empty, non_empty) == non_empty
-    assert lub(non_empty, empty) == non_empty
+    result = lub(empty, non_empty)
+    assert not result.is_union()
+    assert isinstance(result.type_obj, type)
+    assert issubclass(result.type_obj, collections.abc.Sequence)
+    assert result.args and result.args[0].type_obj is int
+    # Commutative
+    assert lub(non_empty, empty) == result
 
 
-def test_lub_empty_never_container_subsumed():
-    """lub(list[Never], list[int]) → list[int]."""
+def test_lub_empty_same_container():
+    """lub(list[Never], list[int]) → list[int] (same container, empty subsumed)."""
     from righttyper.generalize import lub
     int_t = TypeInfo.from_type(int)
     empty = TypeInfo.from_type(list).replace(args=(TypeInfo.from_type(Never),))
@@ -1037,8 +1043,18 @@ def test_lub_empty_tuple_subsumed_by_varlen():
     assert lub(varlen, empty) == varlen
 
 
-def test_lub_mro_common_base():
-    """lub(ChildA, ChildB) → Base (common MRO supertype)."""
+def test_lub_mro_common_base_with_attrs():
+    """lub(ChildA, ChildB) → Base with accessed_attributes."""
+    from righttyper.generalize import lub
+    a = TypeInfo.from_type(_ChildA)
+    b = TypeInfo.from_type(_ChildB)
+    result = lub(a, b, accessed_attributes={"name"})
+    assert not result.is_union()
+    assert result.type_obj is _Base
+
+
+def test_lub_mro_common_base_without_attrs():
+    """lub(ChildA, ChildB) → Base even without accessed_attributes (dir() check passes)."""
     from righttyper.generalize import lub
     a = TypeInfo.from_type(_ChildA)
     b = TypeInfo.from_type(_ChildB)

--- a/tests/test_generalize.py
+++ b/tests/test_generalize.py
@@ -1022,15 +1022,17 @@ def test_lub_empty_same_container():
     assert lub(non_empty, empty) == non_empty
 
 
-def test_lub_empty_container_incompatible():
-    """lub(dict[Never,Never], list[int]) stays as union (incompatible containers)."""
+def test_lub_empty_dict_and_list_to_collection():
+    """lub(dict[Never,Never], list[int]) → Collection[int] (both are Collections)."""
+    import collections.abc
     from righttyper.generalize import lub
     int_t = TypeInfo.from_type(int)
     empty_dict = TypeInfo.from_type(dict).replace(args=(TypeInfo.from_type(Never), TypeInfo.from_type(Never)))
     list_int = TypeInfo.from_type(list).replace(args=(int_t,))
     result = lub(empty_dict, list_int)
-    assert result.is_union()
-    assert result.to_set() == {empty_dict, list_int}
+    assert not result.is_union()
+    assert isinstance(result.type_obj, type)
+    assert issubclass(result.type_obj, collections.abc.Collection)
 
 
 def test_lub_empty_tuple_subsumed_by_varlen():
@@ -1077,6 +1079,59 @@ def test_lub_mro_skips_numeric_widening():
     from righttyper.generalize import lub
     result = lub(TypeInfo.from_type(int), TypeInfo.from_type(float))
     assert result.type_obj is float  # numeric tower, not complex
+
+
+def test_lub_empty_tuple_and_fixed_tuple():
+    """tuple[()]|tuple[str] should merge.
+    An empty tuple + a fixed tuple of strings → variable-length tuple of strings."""
+    from righttyper.generalize import lub
+    empty = TypeInfo.from_type(tuple).replace(args=((),))
+    fixed = TypeInfo.from_type(tuple).replace(args=(TypeInfo.from_type(str),))
+    result = lub(empty, fixed)
+    # varlen tuple subsumes both
+    assert result.type_obj is tuple
+    assert not result.is_union()
+
+
+def test_lub_list_and_empty_tuple_to_sequence():
+    """list[tuple[int,int]]|tuple[()] → Sequence[tuple[int,int]]."""
+    import collections.abc
+    from righttyper.generalize import lub
+    int_t = TypeInfo.from_type(int)
+    inner = TypeInfo.from_type(tuple).replace(args=(int_t, int_t))
+    list_t = TypeInfo.from_type(list).replace(args=(inner,))
+    empty = TypeInfo.from_type(tuple).replace(args=((),))
+    result = lub(list_t, empty)
+    assert not result.is_union()
+    assert isinstance(result.type_obj, type)
+    assert issubclass(result.type_obj, collections.abc.Sequence)
+
+
+def test_lub_set_and_empty_tuple_to_collection():
+    """set[int]|tuple[()] → Collection[int] (both are Collections)."""
+    import collections.abc
+    from righttyper.generalize import lub
+    int_t = TypeInfo.from_type(int)
+    set_t = TypeInfo.from_type(set).replace(args=(int_t,))
+    empty = TypeInfo.from_type(tuple).replace(args=((),))
+    result = lub(set_t, empty)
+    assert not result.is_union()
+    assert isinstance(result.type_obj, type)
+    assert issubclass(result.type_obj, collections.abc.Collection)
+    assert result.args and result.args[0].type_obj is int
+
+
+def test_lub_list_str_and_empty_tuple_to_sequence():
+    """list[str]|tuple[()] → Sequence[str]."""
+    import collections.abc
+    from righttyper.generalize import lub
+    list_t = TypeInfo.from_type(list).replace(args=(TypeInfo.from_type(str),))
+    empty = TypeInfo.from_type(tuple).replace(args=((),))
+    result = lub(list_t, empty)
+    assert not result.is_union()
+    assert isinstance(result.type_obj, type)
+    assert issubclass(result.type_obj, collections.abc.Sequence)
+    assert result.args and result.args[0].type_obj is str
 
 
 def test_lub_abc_fallback():

--- a/tests/test_generalize.py
+++ b/tests/test_generalize.py
@@ -1044,6 +1044,19 @@ def test_lub_empty_dict_and_list_to_collection():
     assert issubclass(result.type_obj, collections.abc.Collection)
 
 
+def test_lub_empty_dict_and_defaultdict():
+    """lub(dict[Never,Never], defaultdict[str, list[int]]) → dict[str, list[int]]
+    (MRO common supertype with the non-empty container's args)."""
+    import collections
+    from righttyper.generalize import lub
+    empty_dict = TypeInfo.from_type(dict, args=(TypeInfo.from_type(Never), TypeInfo.from_type(Never)))
+    dd = TypeInfo.from_type(collections.defaultdict, args=(TypeInfo.from_type(str),
+                            TypeInfo.from_type(list, args=(TypeInfo.from_type(int),))))
+    result = lub(empty_dict, dd)
+    assert result == TypeInfo.from_type(dict, args=(TypeInfo.from_type(str),
+                      TypeInfo.from_type(list, args=(TypeInfo.from_type(int),))))
+
+
 def test_lub_empty_tuple_subsumed_by_varlen():
     """lub(tuple[()], tuple[int, ...]) → tuple[int, ...] (empty subsumed by varlen)."""
     from righttyper.generalize import lub

--- a/tests/test_generalize.py
+++ b/tests/test_generalize.py
@@ -751,14 +751,14 @@ def test_list_and_empty_tuple_without_accessed_attrs():
 # With accessed_attributes={'name'}, the merge should still work (Base has .name).
 # With accessed_attributes={'extra_a'}, merge should NOT happen (Base lacks .extra_a).
 
-class _Base:
+class Base:
     name: str = ""
     value: int = 0
 
-class _ChildA(_Base):
+class ChildA(Base):
     extra_a: str = ""
 
-class _ChildB(_Base):
+class ChildB(Base):
     extra_b: str = ""
 
 
@@ -766,38 +766,38 @@ def test_lub_with_accessed_attributes():
     """When accessed_attributes are provided and the common base has them, merge happens."""
     from righttyper.generalize import merged_types
 
-    a = TypeInfo.from_type(_ChildA)
-    b = TypeInfo.from_type(_ChildB)
+    a = TypeInfo.from_type(ChildA)
+    b = TypeInfo.from_type(ChildB)
 
     result = merged_types({a, b}, accessed_attributes={"name"})
     assert not result.is_union()
-    assert result.type_obj is _Base
+    assert result.type_obj is Base
 
 
 def test_lub_without_accessed_attributes():
     """Without accessed_attributes, dir()-based MRO merge to common base."""
     from righttyper.generalize import merged_types
 
-    a = TypeInfo.from_type(_ChildA)
-    b = TypeInfo.from_type(_ChildB)
+    a = TypeInfo.from_type(ChildA)
+    b = TypeInfo.from_type(ChildB)
 
     result = merged_types({a, b})
     assert not result.is_union()
-    assert result.type_obj is _Base
+    assert result.type_obj is Base
 
 
 def test_lub_accessed_attrs_prevents_over_merge():
     """When accessed_attributes include an attr not on the common base, merge is prevented."""
     from righttyper.generalize import merged_types
 
-    a = TypeInfo.from_type(_ChildA)
-    b = TypeInfo.from_type(_ChildB)
+    a = TypeInfo.from_type(ChildA)
+    b = TypeInfo.from_type(ChildB)
 
     # extra_a is only on ChildA, not on Base → can't merge to Base
     result = merged_types({a, b}, accessed_attributes={"extra_a"})
     assert result.is_union()
     types = {t.type_obj for t in result.to_set()}
-    assert types == {_ChildA, _ChildB}
+    assert types == {ChildA, ChildB}
 
 
 def test_lub_single_type_with_accessed_attributes():
@@ -805,21 +805,21 @@ def test_lub_single_type_with_accessed_attributes():
     are all present on that base."""
     from righttyper.generalize import merged_types
 
-    a = TypeInfo.from_type(_ChildA)
+    a = TypeInfo.from_type(ChildA)
 
-    # 'name' is on _Base → ChildA can be generalized to Base
+    # 'name' is on Base → ChildA can be generalized to Base
     result = merged_types({a}, accessed_attributes={"name"})
-    assert result.type_obj is _Base
+    assert result.type_obj is Base
 
 
 def test_lub_single_type_no_generalization_without_attrs():
     """Without accessed_attributes, a single type stays as-is."""
     from righttyper.generalize import merged_types
 
-    a = TypeInfo.from_type(_ChildA)
+    a = TypeInfo.from_type(ChildA)
 
     result = merged_types({a})
-    assert result.type_obj is _ChildA
+    assert result.type_obj is ChildA
 
 
 # =============================================================================
@@ -857,13 +857,13 @@ def test_lub_abc_not_used_when_concrete_base_exists():
     prefer it over ABC matching."""
     from righttyper.generalize import merged_types
 
-    a = TypeInfo.from_type(_ChildA)
-    b = TypeInfo.from_type(_ChildB)
+    a = TypeInfo.from_type(ChildA)
+    b = TypeInfo.from_type(ChildB)
 
-    # 'name' is on _Base → concrete merge to _Base, not to some ABC
+    # 'name' is on Base → concrete merge to Base, not to some ABC
     result = merged_types({a, b}, accessed_attributes={"name"})
     assert not result.is_union()
-    assert result.type_obj is _Base
+    assert result.type_obj is Base
 
 
 def test_lub_abc_single_type():
@@ -1103,21 +1103,21 @@ def test_lub_empty_tuple_subsumed_by_varlen():
 def test_lub_mro_common_base_with_attrs():
     """lub(ChildA, ChildB) → Base with accessed_attributes."""
     from righttyper.generalize import lub
-    a = TypeInfo.from_type(_ChildA)
-    b = TypeInfo.from_type(_ChildB)
+    a = TypeInfo.from_type(ChildA)
+    b = TypeInfo.from_type(ChildB)
     result = lub(a, b, accessed_attributes={"name"})
     assert not result.is_union()
-    assert result.type_obj is _Base
+    assert result.type_obj is Base
 
 
 def test_lub_mro_common_base_without_attrs():
     """lub(ChildA, ChildB) → Base even without accessed_attributes (dir() check passes)."""
     from righttyper.generalize import lub
-    a = TypeInfo.from_type(_ChildA)
-    b = TypeInfo.from_type(_ChildB)
+    a = TypeInfo.from_type(ChildA)
+    b = TypeInfo.from_type(ChildB)
     result = lub(a, b)
     assert not result.is_union()
-    assert result.type_obj is _Base
+    assert result.type_obj is Base
 
 
 def test_lub_mro_no_useful_base():
@@ -1233,8 +1233,8 @@ def test_lub_dict_and_list_of_tuples():
 def test_lub_subtype_narrowing():
     """lub(ChildA, Base) → Base (ChildA <: Base)."""
     from righttyper.generalize import lub
-    a = TypeInfo.from_type(_ChildA)
-    base = TypeInfo.from_type(_Base)
+    a = TypeInfo.from_type(ChildA)
+    base = TypeInfo.from_type(Base)
     assert lub(a, base) == base
     assert lub(base, a) == base
 
@@ -1379,24 +1379,24 @@ def test_lub_abc_cross_container_different_args_for_variable():
 #  / \     |
 # B   C    E
 
-class _A_mypy: pass
-class _B_mypy(_A_mypy): pass
-class _C_mypy(_A_mypy): pass
-class _D_mypy: pass
+class A_mypy: pass
+class B_mypy(A_mypy): pass
+class C_mypy(A_mypy): pass
+class D_mypy: pass
 
 from abc import ABC
-class _F_mypy(ABC): pass
-class _E_mypy(_F_mypy): pass
+class F_mypy(ABC): pass
+class E_mypy(F_mypy): pass
 
 
 def test_lub_mypy_class_subtyping():
     """From mypy JoinSuite.test_class_subtyping."""
     from righttyper.generalize import lub
-    a, b, c, d, o = (TypeInfo.from_type(t) for t in (_A_mypy, _B_mypy, _C_mypy, _D_mypy, object))
+    a, b, c, d, o = (TypeInfo.from_type(t) for t in (A_mypy, B_mypy, C_mypy, D_mypy, object))
     # join(a, o) = o
     assert lub(a, o) == o
     # join(b, c) = a
-    assert lub(b, c).type_obj is _A_mypy
+    assert lub(b, c).type_obj is A_mypy
     # join(b, d) = union (only object in common, excluded)
     assert lub(b, d).is_union()
     assert lub(b, d).to_set() == {b, d}
@@ -1409,8 +1409,8 @@ def test_lub_mypy_interface_types():
     """From mypy JoinSuite.test_join_interface_and_class_types.
     E implements F (abstract). join(e, f) = f."""
     from righttyper.generalize import lub
-    e = TypeInfo.from_type(_E_mypy)
-    f = TypeInfo.from_type(_F_mypy)
+    e = TypeInfo.from_type(E_mypy)
+    f = TypeInfo.from_type(F_mypy)
     assert lub(e, f) == f
     assert lub(f, e) == f
 
@@ -1418,8 +1418,8 @@ def test_lub_mypy_interface_types():
 def test_lub_mypy_unrelated_with_object():
     """Unrelated types join to union (no useful base besides object)."""
     from righttyper.generalize import lub
-    a = TypeInfo.from_type(_A_mypy)
-    d = TypeInfo.from_type(_D_mypy)
+    a = TypeInfo.from_type(A_mypy)
+    d = TypeInfo.from_type(D_mypy)
     result = lub(a, d)
     assert result.is_union()
     assert result.to_set() == {a, d}
@@ -1429,7 +1429,7 @@ def test_lub_mypy_varlen_tuples():
     """From mypy JoinSuite.test_var_tuples.
     join(tuple[a], tuple[a, ...]) = tuple[a, ...]."""
     from righttyper.generalize import lub
-    a_t = TypeInfo.from_type(_A_mypy)
+    a_t = TypeInfo.from_type(A_mypy)
     fixed = TypeInfo.from_type(tuple).replace(args=(a_t,))
     varlen = TypeInfo.from_type(tuple).replace(args=(a_t, Ellipsis))
     assert lub(fixed, varlen) == varlen
@@ -1508,27 +1508,27 @@ def test_lub_callable_ellipsis_params():
 def test_lub_type_of_subtype():
     """lub(type[B], type[C]) = type[A] when B, C both extend A."""
     from righttyper.generalize import lub
-    b_t = TypeInfo.from_type(type).replace(args=(TypeInfo.from_type(_B_mypy),))
-    c_t = TypeInfo.from_type(type).replace(args=(TypeInfo.from_type(_C_mypy),))
+    b_t = TypeInfo.from_type(type).replace(args=(TypeInfo.from_type(B_mypy),))
+    c_t = TypeInfo.from_type(type).replace(args=(TypeInfo.from_type(C_mypy),))
     result = lub(b_t, c_t)
     assert result.type_obj is type
     assert not result.is_union()
     # type arg should be A (common base of B and C)
-    assert _ti(result.args[0]).type_obj is _A_mypy
+    assert _ti(result.args[0]).type_obj is A_mypy
 
 
 def test_lub_type_of_same():
     """lub(type[B], type[B]) = type[B]."""
     from righttyper.generalize import lub
-    b_t = TypeInfo.from_type(type).replace(args=(TypeInfo.from_type(_B_mypy),))
+    b_t = TypeInfo.from_type(type).replace(args=(TypeInfo.from_type(B_mypy),))
     assert lub(b_t, b_t) == b_t
 
 
 def test_lub_type_of_unrelated():
     """lub(type[A], type[D]) = type[A|D] (covariant merge of unrelated args)."""
     from righttyper.generalize import lub
-    a_ti = TypeInfo.from_type(_A_mypy)
-    d_ti = TypeInfo.from_type(_D_mypy)
+    a_ti = TypeInfo.from_type(A_mypy)
+    d_ti = TypeInfo.from_type(D_mypy)
     a_t = TypeInfo.from_type(type).replace(args=(a_ti,))
     d_t = TypeInfo.from_type(type).replace(args=(d_ti,))
     result = lub(a_t, d_t)
@@ -1597,20 +1597,24 @@ def test_is_private_type():
     private_type = type('HiddenType', (object,), {'__module__': '_secret_impl'})
     assert _is_private_type(private_type)
 
+    # A _-prefixed class name in a public module
+    private_name = type('_InternalHelper', (object,), {'__module__': 'mypkg.utils'})
+    assert _is_private_type(private_name)
+
 
 def test_lub_skips_private_mro_ancestors():
     """lub should not merge to a common ancestor defined in a private module."""
     from righttyper.generalize import lub
 
     # Build a class hierarchy where the common ancestor is in a private module
-    _Base = type('_Base', (object,), {'__module__': '_internal.base', 'x': 1})
-    A = type('A', (_Base,), {'__module__': 'mypkg', 'x': 1})
-    B = type('B', (_Base,), {'__module__': 'mypkg', 'x': 1})
+    Base = type('Base', (object,), {'__module__': '_internal.base', 'x': 1})
+    A = type('A', (Base,), {'__module__': 'mypkg', 'x': 1})
+    B = type('B', (Base,), {'__module__': 'mypkg', 'x': 1})
 
     a = TypeInfo.from_type(A)
     b = TypeInfo.from_type(B)
     result = lub(a, b)
-    # Should NOT merge to _Base (private) — should be a union
+    # Should NOT merge to Base (private) — should be a union
     assert result.is_union(), f"expected union, got {result}"
 
 
@@ -1619,9 +1623,9 @@ def test_merged_types_single_type_skips_private_ancestor():
     generalize to an ancestor in a private module."""
     from righttyper.generalize import merged_types
 
-    _Base = type('_Base', (object,), {'__module__': '_internal.base', 'do_thing': lambda self: None})
-    Concrete = type('Concrete', (_Base,), {'__module__': 'mypkg'})
+    Base = type('Base', (object,), {'__module__': '_internal.base', 'do_thing': lambda self: None})
+    Concrete = type('Concrete', (Base,), {'__module__': 'mypkg'})
 
     result = merged_types({TypeInfo.from_type(Concrete)}, accessed_attributes={'do_thing'})
-    # Should stay as Concrete, not generalize to _Base
+    # Should stay as Concrete, not generalize to Base
     assert result == TypeInfo.from_type(Concrete)

--- a/tests/test_generalize.py
+++ b/tests/test_generalize.py
@@ -34,6 +34,11 @@ def generalize(samples):
     return result
 
 
+@pytest.fixture(autouse=True)
+def _enable_attribute_simplification(monkeypatch):
+    monkeypatch.setattr(output_options, 'use_attribute_simplification', True)
+
+
 def test_no_simplify_types(monkeypatch):
     monkeypatch.setattr(output_options, 'simplify_types', False)
 

--- a/tests/test_generalize.py
+++ b/tests/test_generalize.py
@@ -1134,6 +1134,47 @@ def test_lub_list_str_and_empty_tuple_to_sequence():
     assert result.args and result.args[0].type_obj is str
 
 
+def test_lub_list_and_tuple_same_elem_to_sequence():
+    """list[str]|tuple[str] → Sequence[str] (cross-container, same element type)."""
+    import collections.abc
+    from righttyper.generalize import lub
+    str_t = TypeInfo.from_type(str)
+    a = TypeInfo.from_type(list).replace(args=(str_t,))
+    b = TypeInfo.from_type(tuple).replace(args=(str_t,))
+    result = lub(a, b, accessed_attributes={"__iter__"})
+    assert not result.is_union()
+    assert isinstance(result.type_obj, type)
+    assert issubclass(result.type_obj, collections.abc.Sequence)
+    assert result.args and result.args[0].type_obj is str
+
+
+def test_lub_list_and_tuple_different_elem():
+    """list[int]|tuple[str] → Sequence[int|str] (immutable tuple makes it covariant)."""
+    import collections.abc
+    from righttyper.generalize import lub
+    a = TypeInfo.from_type(list).replace(args=(TypeInfo.from_type(int),))
+    b = TypeInfo.from_type(tuple).replace(args=(TypeInfo.from_type(str),))
+    result = lub(a, b, accessed_attributes={"__iter__"})
+    assert not result.is_union()
+    assert isinstance(result.type_obj, type)
+    assert issubclass(result.type_obj, collections.abc.Sequence)
+    assert result.args and result.args[0].is_union()
+    assert result.args[0].to_set() == {TypeInfo.from_type(int), TypeInfo.from_type(str)}
+
+
+def test_lub_dict_and_list_of_tuples():
+    """dict[str,str]|list[tuple[str,str]] stays as union (incompatible arg arities)."""
+    from righttyper.generalize import lub
+    str_t = TypeInfo.from_type(str)
+    d = TypeInfo.from_type(dict).replace(args=(str_t, str_t))
+    lt = TypeInfo.from_type(list).replace(args=(
+        TypeInfo.from_type(tuple).replace(args=(str_t, str_t)),
+    ))
+    result = lub(d, lt)
+    assert result.is_union()
+    assert result.to_set() == {d, lt}
+
+
 def test_lub_abc_fallback():
     """lub(IterableA, IterableB) → Iterable when no MRO base but both implement ABC."""
     import collections.abc

--- a/tests/test_generalize.py
+++ b/tests/test_generalize.py
@@ -807,9 +807,10 @@ def test_lub_single_type_with_accessed_attributes():
 
     a = TypeInfo.from_type(ChildA)
 
-    # 'name' is on Base → ChildA can be generalized to Base
+    # ChildA is public — single-type generalization only de-privatizes,
+    # so ChildA stays as-is even with accessed_attributes.
     result = merged_types({a}, accessed_attributes={"name"})
-    assert result.type_obj is Base
+    assert result.type_obj is ChildA
 
 
 def test_lub_single_type_no_generalization_without_attrs():
@@ -1623,9 +1624,20 @@ def test_merged_types_single_type_skips_private_ancestor():
     generalize to an ancestor in a private module."""
     from righttyper.generalize import merged_types
 
-    Base = type('Base', (object,), {'__module__': '_internal.base', 'do_thing': lambda self: None})
-    Concrete = type('Concrete', (Base,), {'__module__': 'mypkg'})
+    _Base = type('_Base', (object,), {'__module__': '_internal.base', 'do_thing': lambda self: None})
+    Concrete = type('Concrete', (_Base,), {'__module__': 'mypkg'})
 
     result = merged_types({TypeInfo.from_type(Concrete)}, accessed_attributes={'do_thing'})
-    # Should stay as Concrete, not generalize to Base
+    # Concrete is public — should stay as Concrete, not generalize to private _Base
     assert result == TypeInfo.from_type(Concrete)
+
+
+def test_merged_types_single_type_deprivatizes_to_public_ancestor():
+    """A private type should de-privatize to its nearest public ancestor."""
+    from righttyper.generalize import merged_types
+
+    PublicBase = type('PublicBase', (object,), {'__module__': 'mypkg', 'do_thing': lambda self: None})
+    _Private = type('_Private', (PublicBase,), {'__module__': 'mypkg'})
+
+    result = merged_types({TypeInfo.from_type(_Private)}, accessed_attributes={'do_thing'})
+    assert result == TypeInfo.from_type(PublicBase)

--- a/tests/test_generalize.py
+++ b/tests/test_generalize.py
@@ -1057,6 +1057,39 @@ def test_lub_empty_dict_and_defaultdict():
                       TypeInfo.from_type(list, args=(TypeInfo.from_type(int),))))
 
 
+def test_lub_empty_tuple_and_generator():
+    """lub(tuple[()], Generator[str, None, None]) should reduce Generator to
+    Iterator[str] first, then merge with the empty tuple → Iterable[str]."""
+    import collections.abc
+    from righttyper.generalize import lub
+    empty_tuple = TypeInfo.from_type(tuple, args=((),))
+    gen = TypeInfo.from_type(collections.abc.Generator, args=(
+        TypeInfo.from_type(str),
+        TypeInfo.from_type(type(None)),
+        TypeInfo.from_type(type(None)),
+    ))
+    result = lub(empty_tuple, gen)
+    assert result == TypeInfo.from_type(collections.abc.Iterable, args=(TypeInfo.from_type(str),))
+
+
+def test_lub_generator_reduced_to_iterator_before_merge():
+    """lub should reduce Generator[X, None, None] to Iterator[X] before
+    merging, so 3 Generator args don't leak into the result."""
+    import collections.abc
+    from righttyper.generalize import lub
+    gen = TypeInfo.from_type(collections.abc.Generator, args=(
+        TypeInfo.from_type(int),
+        TypeInfo.from_type(type(None)),
+        TypeInfo.from_type(type(None)),
+    ))
+    lst = TypeInfo.from_type(list, args=(TypeInfo.from_type(int),))
+    result = lub(gen, lst)
+    assert result == TypeInfo.from_set({
+        TypeInfo.from_type(collections.abc.Iterator, args=(TypeInfo.from_type(int),)),
+        TypeInfo.from_type(list, args=(TypeInfo.from_type(int),)),
+    })
+
+
 def test_lub_empty_tuple_subsumed_by_varlen():
     """lub(tuple[()], tuple[int, ...]) → tuple[int, ...] (empty subsumed by varlen)."""
     from righttyper.generalize import lub

--- a/tests/test_generalize.py
+++ b/tests/test_generalize.py
@@ -1061,3 +1061,78 @@ def test_lub_mro_skips_numeric_widening():
     from righttyper.generalize import lub
     result = lub(TypeInfo.from_type(int), TypeInfo.from_type(float))
     assert result.type_obj is float  # numeric tower, not complex
+
+
+def test_lub_abc_fallback():
+    """lub(IterableA, IterableB) → Iterable when no MRO base but both implement ABC."""
+    import collections.abc
+    from righttyper.generalize import lub
+
+    a = TypeInfo.from_type(_IterableA)
+    b = TypeInfo.from_type(_IterableB)
+
+    # No common MRO base (only object), but both implement Iterable.
+    # ABC matching only kicks in when it reduces a union (len > 1),
+    # so we need accessed_attributes for the ABC pre-filter.
+    result = lub(a, b, accessed_attributes={"__iter__"})
+    assert not result.is_union()
+    assert isinstance(result.type_obj, type)
+    assert issubclass(result.type_obj, collections.abc.Iterable)
+
+
+def test_lub_abc_not_used_without_accessed_attrs():
+    """Without accessed_attributes, ABC matching doesn't fire."""
+    from righttyper.generalize import lub
+
+    a = TypeInfo.from_type(_IterableA)
+    b = TypeInfo.from_type(_IterableB)
+
+    # No accessed_attributes → falls through to union
+    result = lub(a, b)
+    assert result.is_union()
+    assert result.to_set() == {a, b}
+
+
+def test_lub_abc_cross_container_same_args():
+    """lub(list[int], set[int]) → Collection[int] via ABC when args match."""
+    import collections.abc
+    from righttyper.generalize import lub
+
+    int_t = TypeInfo.from_type(int)
+    a = TypeInfo.from_type(list).replace(args=(int_t,))
+    b = TypeInfo.from_type(set).replace(args=(int_t,))
+
+    result = lub(a, b, accessed_attributes={"__iter__"})
+    assert not result.is_union()
+    assert isinstance(result.type_obj, type)
+    assert issubclass(result.type_obj, collections.abc.Iterable)
+    assert result.args and result.args[0].type_obj is int
+
+
+def test_lub_abc_cross_container_different_args_invariant():
+    """lub(list[int], set[str]) stays as union when for_variable=False (invariant)."""
+    from righttyper.generalize import lub
+
+    a = TypeInfo.from_type(list).replace(args=(TypeInfo.from_type(int),))
+    b = TypeInfo.from_type(set).replace(args=(TypeInfo.from_type(str),))
+
+    result = lub(a, b, for_variable=False, accessed_attributes={"__iter__"})
+    assert result.is_union()
+    assert result.to_set() == {a, b}
+
+
+def test_lub_abc_cross_container_different_args_for_variable():
+    """lub(list[int], set[str]) merges args when for_variable=True."""
+    import collections.abc
+    from righttyper.generalize import lub
+
+    a = TypeInfo.from_type(list).replace(args=(TypeInfo.from_type(int),))
+    b = TypeInfo.from_type(set).replace(args=(TypeInfo.from_type(str),))
+
+    result = lub(a, b, for_variable=True, accessed_attributes={"__iter__"})
+    assert not result.is_union()
+    assert isinstance(result.type_obj, type)
+    assert issubclass(result.type_obj, collections.abc.Iterable)
+    # Args should be merged: int|str
+    assert result.args and result.args[0].is_union()
+    assert result.args[0].to_set() == {TypeInfo.from_type(int), TypeInfo.from_type(str)}

--- a/tests/test_generalize.py
+++ b/tests/test_generalize.py
@@ -1,13 +1,19 @@
-from righttyper.typeinfo import TypeInfo
+from righttyper.typeinfo import TypeInfo, TypeInfoArg
 from righttyper.type_id import normalize_module_name
 import righttyper.generalize
-from typing import Any, Never, Self
+from typing import Any, Never, Self, cast
 import pytest
 from righttyper.options import output_options
 
 
 def ti(name: str, **kwargs) -> TypeInfo:
     return TypeInfo(module='', name=name, **kwargs)
+
+
+def _ti(a: TypeInfoArg) -> TypeInfo:
+    """Narrow a TypeInfoArg to TypeInfo for tests where it's known to be one."""
+    assert isinstance(a, TypeInfo)
+    return a
 
 
 def generalize(samples):
@@ -680,7 +686,7 @@ def test_list_and_varlen_tuple_to_sequence():
     assert issubclass(result.type_obj, collections.abc.Sequence)
     # Element type preserved
     assert result.args and isinstance(result.args[0], TypeInfo)
-    assert result.args[0].type_obj is int
+    assert _ti(result.args[0]).type_obj is int
 
 
 def test_set_and_frozenset_to_abc_set():
@@ -843,7 +849,7 @@ def test_lub_abc_fallback():
 
     result = merged_types({a, b}, accessed_attributes={"__iter__"})
     assert not result.is_union()
-    assert issubclass(result.type_obj, abc.Iterable)
+    assert issubclass(cast(type, result.type_obj), abc.Iterable)
 
 
 def test_lub_abc_not_used_when_concrete_base_exists():
@@ -932,7 +938,7 @@ def test_lub_same_container_merge_for_variable():
     result = lub(a, b, for_variable=True)
     assert result.type_obj is list
     assert result.args and isinstance(result.args[0], TypeInfo)
-    assert result.args[0].is_union()
+    assert _ti(result.args[0]).is_union()
 
 
 def test_lub_same_container_no_merge_invariant():
@@ -954,7 +960,7 @@ def test_lub_same_container_subtype_args():
     b = TypeInfo.from_type(list).replace(args=(TypeInfo.from_type(int),))
     result = lub(a, b, for_variable=True)
     assert result.type_obj is list
-    assert result.args[0].type_obj is int
+    assert _ti(result.args[0]).type_obj is int
 
 
 def test_lub_covariant_tuple_always_merges():
@@ -966,7 +972,7 @@ def test_lub_covariant_tuple_always_merges():
     b = TypeInfo.from_type(tuple).replace(args=(str_t, Ellipsis))
     result = lub(a, b, for_variable=False)
     assert result.type_obj is tuple
-    assert result.args[0].is_union()
+    assert _ti(result.args[0]).is_union()
 
 
 def test_lub_varlen_subsumes_fixed():
@@ -1010,7 +1016,7 @@ def test_lub_empty_tuple_and_list_to_sequence():
     assert not result.is_union()
     assert isinstance(result.type_obj, type)
     assert issubclass(result.type_obj, collections.abc.Sequence)
-    assert result.args and result.args[0].type_obj is int
+    assert result.args and _ti(result.args[0]).type_obj is int
     # Commutative
     assert lub(non_empty, empty) == result
 
@@ -1121,7 +1127,7 @@ def test_lub_set_and_empty_tuple_to_collection():
     assert not result.is_union()
     assert isinstance(result.type_obj, type)
     assert issubclass(result.type_obj, collections.abc.Collection)
-    assert result.args and result.args[0].type_obj is int
+    assert result.args and _ti(result.args[0]).type_obj is int
 
 
 def test_lub_list_str_and_empty_tuple_to_sequence():
@@ -1134,7 +1140,7 @@ def test_lub_list_str_and_empty_tuple_to_sequence():
     assert not result.is_union()
     assert isinstance(result.type_obj, type)
     assert issubclass(result.type_obj, collections.abc.Sequence)
-    assert result.args and result.args[0].type_obj is str
+    assert result.args and _ti(result.args[0]).type_obj is str
 
 
 def test_lub_list_and_tuple_same_elem_to_sequence():
@@ -1148,7 +1154,7 @@ def test_lub_list_and_tuple_same_elem_to_sequence():
     assert not result.is_union()
     assert isinstance(result.type_obj, type)
     assert issubclass(result.type_obj, collections.abc.Sequence)
-    assert result.args and result.args[0].type_obj is str
+    assert result.args and _ti(result.args[0]).type_obj is str
 
 
 def test_lub_list_and_tuple_different_elem():
@@ -1161,8 +1167,8 @@ def test_lub_list_and_tuple_different_elem():
     assert not result.is_union()
     assert isinstance(result.type_obj, type)
     assert issubclass(result.type_obj, collections.abc.Sequence)
-    assert result.args and result.args[0].is_union()
-    assert result.args[0].to_set() == {TypeInfo.from_type(int), TypeInfo.from_type(str)}
+    assert result.args and _ti(result.args[0]).is_union()
+    assert _ti(result.args[0]).to_set() == {TypeInfo.from_type(int), TypeInfo.from_type(str)}
 
 
 def test_lub_dict_and_list_of_tuples():
@@ -1214,7 +1220,7 @@ def test_lub_empty_and_fixed_tuple_to_varlen():
     assert not result.is_union()
     assert len(result.args) == 2
     assert result.args[1] is Ellipsis
-    assert result.args[0].type_obj is int
+    assert _ti(result.args[0]).type_obj is int
 
 
 def test_lub_fixed_tuple_same_length_merge():
@@ -1226,8 +1232,8 @@ def test_lub_fixed_tuple_same_length_merge():
     assert result.type_obj is tuple
     assert not result.is_union()
     # First arg merged (int|float → float via numeric tower)
-    assert result.args[0].type_obj is float
-    assert result.args[1].type_obj is str
+    assert _ti(result.args[0]).type_obj is float
+    assert _ti(result.args[1]).type_obj is str
 
 
 def test_lub_multiple_lists_merge_args():
@@ -1237,11 +1243,11 @@ def test_lub_multiple_lists_merge_args():
     b = TypeInfo.from_type(list).replace(args=(TypeInfo.from_type(str),))
     result = lub(a, b, for_variable=True)
     assert result.type_obj is list
-    assert result.args[0].is_union()
-    assert result.args[0].to_set() == {TypeInfo.from_type(int), TypeInfo.from_type(str)}
+    assert _ti(result.args[0]).is_union()
+    assert _ti(result.args[0]).to_set() == {TypeInfo.from_type(int), TypeInfo.from_type(str)}
 
 
-def test_lub_abc_fallback():
+def test_lub_abc_fallback_via_lub():
     """lub(IterableA, IterableB) → Iterable when no MRO base but both implement ABC."""
     import collections.abc
     from righttyper.generalize import lub
@@ -1284,7 +1290,7 @@ def test_lub_abc_cross_container_same_args():
     assert not result.is_union()
     assert isinstance(result.type_obj, type)
     assert issubclass(result.type_obj, collections.abc.Iterable)
-    assert result.args and result.args[0].type_obj is int
+    assert result.args and _ti(result.args[0]).type_obj is int
 
 
 def test_lub_abc_cross_container_different_args_invariant():
@@ -1312,8 +1318,8 @@ def test_lub_abc_cross_container_different_args_for_variable():
     assert isinstance(result.type_obj, type)
     assert issubclass(result.type_obj, collections.abc.Iterable)
     # Args should be merged: int|str
-    assert result.args and result.args[0].is_union()
-    assert result.args[0].to_set() == {TypeInfo.from_type(int), TypeInfo.from_type(str)}
+    assert result.args and _ti(result.args[0]).is_union()
+    assert _ti(result.args[0]).to_set() == {TypeInfo.from_type(int), TypeInfo.from_type(str)}
 
 
 # =============================================================================
@@ -1413,11 +1419,11 @@ def test_lub_callable_different_return():
     assert result.type_obj is collections.abc.Callable
     assert not result.is_union()
     # Return type (last arg) should be a union
-    assert result.args[-1].is_union()
-    assert result.args[-1].to_set() == {int_t, str_t}
+    assert _ti(result.args[-1]).is_union()
+    assert _ti(result.args[-1]).to_set() == {int_t, str_t}
     # Params (first arg) should be unchanged
-    assert result.args[0].is_list()
-    assert result.args[0].args == (int_t,)
+    assert _ti(result.args[0]).is_list()
+    assert _ti(result.args[0]).args == (int_t,)
 
 
 def test_lub_callable_different_params():
@@ -1449,8 +1455,8 @@ def test_lub_callable_ellipsis_params():
     assert result.type_obj is collections.abc.Callable
     assert not result.is_union()
     assert result.args[0] is ...
-    assert result.args[-1].is_union()
-    assert result.args[-1].to_set() == {int_t, str_t}
+    assert _ti(result.args[-1]).is_union()
+    assert _ti(result.args[-1]).to_set() == {int_t, str_t}
 
 
 def test_lub_type_of_subtype():
@@ -1462,7 +1468,7 @@ def test_lub_type_of_subtype():
     assert result.type_obj is type
     assert not result.is_union()
     # type arg should be A (common base of B and C)
-    assert result.args[0].type_obj is _A_mypy
+    assert _ti(result.args[0]).type_obj is _A_mypy
 
 
 def test_lub_type_of_same():
@@ -1483,8 +1489,8 @@ def test_lub_type_of_unrelated():
     assert result.type_obj is type
     assert not result.is_union()
     # Inner arg is the union A|D
-    assert result.args[0].is_union()
-    assert result.args[0].to_set() == {a_ti, d_ti}
+    assert _ti(result.args[0]).is_union()
+    assert _ti(result.args[0]).to_set() == {a_ti, d_ti}
 
 
 # --- Rule 4b: bare generic subsumes parametrized ---

--- a/tests/test_generalize.py
+++ b/tests/test_generalize.py
@@ -711,3 +711,65 @@ def test_simplify_single_type_no_generalization_without_attrs():
     result = simplify({a})
     assert len(result) == 1
     assert next(iter(result)).type_obj is _ChildA
+
+
+# =============================================================================
+# Tests for ABC/protocol matching in simplification
+# =============================================================================
+
+class _IterableA:
+    """Implements Iterable (recognized by __subclasshook__)."""
+    def __iter__(self): return iter(())
+    def __len__(self): return 0
+
+class _IterableB:
+    """Different class, also implements Iterable."""
+    def __iter__(self): return iter(())
+    def __len__(self): return 0
+
+
+def test_simplify_abc_fallback():
+    """When types share no concrete base (only object), simplify falls back to
+    ABC matching. _IterableA and _IterableB both implement Iterable via
+    __subclasshook__, so accessing __iter__ should merge to Iterable."""
+    import collections.abc as abc
+    from righttyper.generalize import simplify
+
+    a = TypeInfo.from_type(_IterableA)
+    b = TypeInfo.from_type(_IterableB)
+
+    result = simplify({a, b}, accessed_attributes={"__iter__"})
+    assert len(result) == 1
+    result_type = next(iter(result)).type_obj
+    assert issubclass(result_type, abc.Iterable)
+
+
+def test_simplify_abc_not_used_when_concrete_base_exists():
+    """When a concrete base exists and has the accessed attributes,
+    prefer it over ABC matching."""
+    from righttyper.generalize import simplify
+
+    a = TypeInfo.from_type(_ChildA)
+    b = TypeInfo.from_type(_ChildB)
+
+    # 'name' is on _Base → concrete merge to _Base, not to some ABC
+    result = simplify({a, b}, accessed_attributes={"name"})
+    assert len(result) == 1
+    assert next(iter(result)).type_obj is _Base
+
+
+def test_simplify_abc_single_type():
+    """A single type can be generalized to an ABC if the accessed attributes
+    match and there's no better concrete base."""
+    import collections.abc as abc
+    from righttyper.generalize import simplify
+
+    a = TypeInfo.from_type(_IterableA)
+
+    # _IterableA has no useful concrete base, but implements Sized + Iterable.
+    # Should generalize to the ABC, not stay as _IterableA.
+    result = simplify({a}, accessed_attributes={"__len__"})
+    assert len(result) == 1
+    result_type = next(iter(result)).type_obj
+    assert result_type is not _IterableA
+    assert issubclass(result_type, abc.Sized)

--- a/tests/test_generalize.py
+++ b/tests/test_generalize.py
@@ -1578,3 +1578,37 @@ def test_lub_bare_reversible_subsumes_parametrized():
     parametrized = TypeInfo.from_type(abc.Reversible).replace(args=(TypeInfo.from_type(float),))
     assert lub(bare, parametrized) == bare
     assert lub(parametrized, bare) == bare
+
+
+def test_is_private_type():
+    """Types in private modules without public re-export should be detected."""
+    from righttyper.generalize import _is_private_type
+    import io
+
+    # _io.BytesIO: __module__='_io' but re-exported via io → not private
+    assert not _is_private_type(io.BytesIO)
+    assert not _is_private_type(io.StringIO)
+
+    # builtins are not private
+    assert not _is_private_type(int)
+    assert not _is_private_type(dict)
+
+    # A type genuinely stuck in a private module (no public re-export)
+    private_type = type('HiddenType', (object,), {'__module__': '_secret_impl'})
+    assert _is_private_type(private_type)
+
+
+def test_lub_skips_private_mro_ancestors():
+    """lub should not merge to a common ancestor defined in a private module."""
+    from righttyper.generalize import lub
+
+    # Build a class hierarchy where the common ancestor is in a private module
+    _Base = type('_Base', (object,), {'__module__': '_internal.base', 'x': 1})
+    A = type('A', (_Base,), {'__module__': 'mypkg', 'x': 1})
+    B = type('B', (_Base,), {'__module__': 'mypkg', 'x': 1})
+
+    a = TypeInfo.from_type(A)
+    b = TypeInfo.from_type(B)
+    result = lub(a, b)
+    # Should NOT merge to _Base (private) — should be a union
+    assert result.is_union(), f"expected union, got {result}"

--- a/tests/test_generalize.py
+++ b/tests/test_generalize.py
@@ -866,3 +866,130 @@ def test_simplify_abc_single_type():
     result = simplify({a}, accessed_attributes={"__len__"})
     assert len(result) == 1
     assert next(iter(result)).type_obj is _IterableA
+
+
+# =============================================================================
+# Tests for lub(a, b) — least upper bound
+# =============================================================================
+
+def test_lub_identity():
+    """lub(a, a) = a."""
+    from righttyper.generalize import lub
+    a = TypeInfo.from_type(int)
+    assert lub(a, a) == a
+
+
+def test_lub_never():
+    """lub(a, Never) = a."""
+    from righttyper.generalize import lub
+    a = TypeInfo.from_type(int)
+    never = TypeInfo.from_type(Never)
+    assert lub(a, never) == a
+    assert lub(never, a) == a
+
+
+def test_lub_any():
+    """lub(a, Any) = Any."""
+    from righttyper.generalize import lub
+    a = TypeInfo.from_type(int)
+    any_t = TypeInfo.from_type(Any)
+    assert lub(a, any_t) == any_t
+    assert lub(any_t, a) == any_t
+
+
+def test_lub_subtype_bool_int():
+    """lub(bool, int) = int (bool <: int)."""
+    from righttyper.generalize import lub
+    assert lub(TypeInfo.from_type(bool), TypeInfo.from_type(int)) == TypeInfo.from_type(int)
+    assert lub(TypeInfo.from_type(int), TypeInfo.from_type(bool)) == TypeInfo.from_type(int)
+
+
+def test_lub_numeric_tower():
+    """lub(int, float) = float (numeric tower)."""
+    from righttyper.generalize import lub
+    assert lub(TypeInfo.from_type(int), TypeInfo.from_type(float)).type_obj is float
+
+
+def test_lub_no_common_base():
+    """lub(int, str) = int|str (no useful common supertype)."""
+    from righttyper.generalize import lub
+    result = lub(TypeInfo.from_type(int), TypeInfo.from_type(str))
+    assert result.is_union()
+    types = {t.type_obj for t in result.args if isinstance(t, TypeInfo)}
+    assert types == {int, str}
+
+
+def test_lub_same_container_merge_for_variable():
+    """lub(list[int], list[str]) = list[int|str] when for_variable=True."""
+    from righttyper.generalize import lub
+    int_t = TypeInfo.from_type(int)
+    str_t = TypeInfo.from_type(str)
+    a = TypeInfo.from_type(list).replace(args=(int_t,))
+    b = TypeInfo.from_type(list).replace(args=(str_t,))
+    result = lub(a, b, for_variable=True)
+    assert result.type_obj is list
+    assert result.args and isinstance(result.args[0], TypeInfo)
+    assert result.args[0].is_union()
+
+
+def test_lub_same_container_no_merge_invariant():
+    """lub(list[int], list[str]) = list[int]|list[str] when for_variable=False (invariant)."""
+    from righttyper.generalize import lub
+    int_t = TypeInfo.from_type(int)
+    str_t = TypeInfo.from_type(str)
+    a = TypeInfo.from_type(list).replace(args=(int_t,))
+    b = TypeInfo.from_type(list).replace(args=(str_t,))
+    result = lub(a, b, for_variable=False)
+    assert result.is_union()
+
+
+def test_lub_same_container_subtype_args():
+    """lub(list[bool], list[int]) = list[int] when for_variable=True (bool <: int)."""
+    from righttyper.generalize import lub
+    a = TypeInfo.from_type(list).replace(args=(TypeInfo.from_type(bool),))
+    b = TypeInfo.from_type(list).replace(args=(TypeInfo.from_type(int),))
+    result = lub(a, b, for_variable=True)
+    assert result.type_obj is list
+    assert result.args[0].type_obj is int
+
+
+def test_lub_covariant_tuple_always_merges():
+    """lub(tuple[int,...], tuple[str,...]) = tuple[int|str,...] even for_variable=False."""
+    from righttyper.generalize import lub
+    int_t = TypeInfo.from_type(int)
+    str_t = TypeInfo.from_type(str)
+    a = TypeInfo.from_type(tuple).replace(args=(int_t, Ellipsis))
+    b = TypeInfo.from_type(tuple).replace(args=(str_t, Ellipsis))
+    result = lub(a, b, for_variable=False)
+    assert result.type_obj is tuple
+    assert result.args[0].is_union()
+
+
+def test_lub_varlen_subsumes_fixed():
+    """lub(tuple[int,int], tuple[int,...]) = tuple[int,...]."""
+    from righttyper.generalize import lub
+    int_t = TypeInfo.from_type(int)
+    fixed = TypeInfo.from_type(tuple).replace(args=(int_t, int_t))
+    varlen = TypeInfo.from_type(tuple).replace(args=(int_t, Ellipsis))
+    assert lub(fixed, varlen) == varlen
+    assert lub(varlen, fixed) == varlen
+
+
+def test_lub_commutative():
+    """lub(a, b) == lub(b, a) for various type pairs."""
+    from righttyper.generalize import lub
+    pairs = [
+        (TypeInfo.from_type(int), TypeInfo.from_type(str)),
+        (TypeInfo.from_type(bool), TypeInfo.from_type(int)),
+        (TypeInfo.from_type(int), TypeInfo.from_type(float)),
+    ]
+    for a, b in pairs:
+        assert lub(a, b) == lub(b, a), f"lub not commutative for {a}, {b}"
+
+
+def test_lub_idempotent():
+    """lub(a, a) == a for various types."""
+    from righttyper.generalize import lub
+    for t in [int, str, float, list, dict]:
+        a = TypeInfo.from_type(t)
+        assert lub(a, a) == a

--- a/tests/test_generalize.py
+++ b/tests/test_generalize.py
@@ -941,6 +941,7 @@ def test_lub_same_container_no_merge_invariant():
     b = TypeInfo.from_type(list).replace(args=(str_t,))
     result = lub(a, b, for_variable=False)
     assert result.is_union()
+    assert result.to_set() == {a, b}
 
 
 def test_lub_same_container_subtype_args():
@@ -993,3 +994,70 @@ def test_lub_idempotent():
     for t in [int, str, float, list, dict]:
         a = TypeInfo.from_type(t)
         assert lub(a, a) == a
+
+
+def test_lub_empty_container_subsumed():
+    """lub(tuple[()], list[int]) → list[int] (empty subsumed by non-empty)."""
+    from righttyper.generalize import lub
+    int_t = TypeInfo.from_type(int)
+    empty = TypeInfo.from_type(tuple).replace(args=((),))
+    non_empty = TypeInfo.from_type(list).replace(args=(int_t,))
+    assert lub(empty, non_empty) == non_empty
+    assert lub(non_empty, empty) == non_empty
+
+
+def test_lub_empty_never_container_subsumed():
+    """lub(list[Never], list[int]) → list[int]."""
+    from righttyper.generalize import lub
+    int_t = TypeInfo.from_type(int)
+    empty = TypeInfo.from_type(list).replace(args=(TypeInfo.from_type(Never),))
+    non_empty = TypeInfo.from_type(list).replace(args=(int_t,))
+    assert lub(empty, non_empty) == non_empty
+    assert lub(non_empty, empty) == non_empty
+
+
+def test_lub_empty_container_incompatible():
+    """lub(dict[Never,Never], list[int]) stays as union (incompatible containers)."""
+    from righttyper.generalize import lub
+    int_t = TypeInfo.from_type(int)
+    empty_dict = TypeInfo.from_type(dict).replace(args=(TypeInfo.from_type(Never), TypeInfo.from_type(Never)))
+    list_int = TypeInfo.from_type(list).replace(args=(int_t,))
+    result = lub(empty_dict, list_int)
+    assert result.is_union()
+    assert result.to_set() == {empty_dict, list_int}
+
+
+def test_lub_empty_tuple_subsumed_by_varlen():
+    """lub(tuple[()], tuple[int, ...]) → tuple[int, ...] (empty subsumed by varlen)."""
+    from righttyper.generalize import lub
+    int_t = TypeInfo.from_type(int)
+    empty = TypeInfo.from_type(tuple).replace(args=((),))
+    varlen = TypeInfo.from_type(tuple).replace(args=(int_t, Ellipsis))
+    assert lub(empty, varlen) == varlen
+    assert lub(varlen, empty) == varlen
+
+
+def test_lub_mro_common_base():
+    """lub(ChildA, ChildB) → Base (common MRO supertype)."""
+    from righttyper.generalize import lub
+    a = TypeInfo.from_type(_ChildA)
+    b = TypeInfo.from_type(_ChildB)
+    result = lub(a, b)
+    assert not result.is_union()
+    assert result.type_obj is _Base
+
+
+def test_lub_mro_no_useful_base():
+    """lub(int, str) stays as union (only 'object' in common)."""
+    from righttyper.generalize import lub
+    a, b = TypeInfo.from_type(int), TypeInfo.from_type(str)
+    result = lub(a, b)
+    assert result.is_union()
+    assert result.to_set() == {a, b}
+
+
+def test_lub_mro_skips_numeric_widening():
+    """lub(int, float) uses numeric tower (rule 4), not MRO to complex."""
+    from righttyper.generalize import lub
+    result = lub(TypeInfo.from_type(int), TypeInfo.from_type(float))
+    assert result.type_obj is float  # numeric tower, not complex

--- a/tests/test_generalize.py
+++ b/tests/test_generalize.py
@@ -756,7 +756,7 @@ class _ChildB(_Base):
     extra_b: str = ""
 
 
-def test_simplify_with_accessed_attributes():
+def test_lub_with_accessed_attributes():
     """When accessed_attributes are provided and the common base has them, merge happens."""
     from righttyper.generalize import merged_types
 
@@ -768,7 +768,7 @@ def test_simplify_with_accessed_attributes():
     assert result.type_obj is _Base
 
 
-def test_simplify_without_accessed_attributes():
+def test_lub_without_accessed_attributes():
     """Without accessed_attributes, dir()-based MRO merge to common base."""
     from righttyper.generalize import merged_types
 
@@ -780,7 +780,7 @@ def test_simplify_without_accessed_attributes():
     assert result.type_obj is _Base
 
 
-def test_simplify_accessed_attrs_prevents_over_merge():
+def test_lub_accessed_attrs_prevents_over_merge():
     """When accessed_attributes include an attr not on the common base, merge is prevented."""
     from righttyper.generalize import merged_types
 
@@ -794,7 +794,7 @@ def test_simplify_accessed_attrs_prevents_over_merge():
     assert types == {_ChildA, _ChildB}
 
 
-def test_simplify_single_type_with_accessed_attributes():
+def test_lub_single_type_with_accessed_attributes():
     """Even a single type can be generalized to a base when accessed_attributes
     are all present on that base."""
     from righttyper.generalize import merged_types
@@ -806,7 +806,7 @@ def test_simplify_single_type_with_accessed_attributes():
     assert result.type_obj is _Base
 
 
-def test_simplify_single_type_no_generalization_without_attrs():
+def test_lub_single_type_no_generalization_without_attrs():
     """Without accessed_attributes, a single type stays as-is."""
     from righttyper.generalize import merged_types
 
@@ -831,7 +831,7 @@ class _IterableB:
     def __len__(self): return 0
 
 
-def test_simplify_abc_fallback():
+def test_lub_abc_fallback():
     """When types share no concrete base (only object), falls back to
     ABC matching. _IterableA and _IterableB both implement Iterable via
     __subclasshook__, so accessing __iter__ should merge to Iterable."""
@@ -846,7 +846,7 @@ def test_simplify_abc_fallback():
     assert issubclass(result.type_obj, abc.Iterable)
 
 
-def test_simplify_abc_not_used_when_concrete_base_exists():
+def test_lub_abc_not_used_when_concrete_base_exists():
     """When a concrete base exists and has the accessed attributes,
     prefer it over ABC matching."""
     from righttyper.generalize import merged_types
@@ -860,7 +860,7 @@ def test_simplify_abc_not_used_when_concrete_base_exists():
     assert result.type_obj is _Base
 
 
-def test_simplify_abc_single_type():
+def test_lub_abc_single_type():
     """A single type is not generalized to an ABC — ABC matching only
     reduces union size, not replaces a single concrete type."""
     from righttyper.generalize import merged_types

--- a/tests/test_generalize.py
+++ b/tests/test_generalize.py
@@ -1311,3 +1311,74 @@ def test_lub_abc_cross_container_different_args_for_variable():
     # Args should be merged: int|str
     assert result.args and result.args[0].is_union()
     assert result.args[0].to_set() == {TypeInfo.from_type(int), TypeInfo.from_type(str)}
+
+
+# =============================================================================
+# Tests inspired by mypy's JoinSuite (testtypes.py)
+# =============================================================================
+
+# Class hierarchy for mypy-style tests:
+#     object
+#    / |  \
+#   A  D   F(abstract via ABC)
+#  / \     |
+# B   C    E
+
+class _A_mypy: pass
+class _B_mypy(_A_mypy): pass
+class _C_mypy(_A_mypy): pass
+class _D_mypy: pass
+
+from abc import ABC
+class _F_mypy(ABC): pass
+class _E_mypy(_F_mypy): pass
+
+
+def test_lub_mypy_class_subtyping():
+    """From mypy JoinSuite.test_class_subtyping."""
+    from righttyper.generalize import lub
+    a, b, c, d, o = (TypeInfo.from_type(t) for t in (_A_mypy, _B_mypy, _C_mypy, _D_mypy, object))
+    # join(a, o) = o
+    assert lub(a, o) == o
+    # join(b, c) = a
+    assert lub(b, c).type_obj is _A_mypy
+    # join(b, d) = union (only object in common, excluded)
+    assert lub(b, d).is_union()
+    assert lub(b, d).to_set() == {b, d}
+    # join(a, d) = union
+    assert lub(a, d).is_union()
+    assert lub(a, d).to_set() == {a, d}
+
+
+def test_lub_mypy_interface_types():
+    """From mypy JoinSuite.test_join_interface_and_class_types.
+    E implements F (abstract). join(e, f) = f."""
+    from righttyper.generalize import lub
+    e = TypeInfo.from_type(_E_mypy)
+    f = TypeInfo.from_type(_F_mypy)
+    assert lub(e, f) == f
+    assert lub(f, e) == f
+
+
+def test_lub_mypy_unrelated_with_object():
+    """Unrelated types join to union (no useful base besides object)."""
+    from righttyper.generalize import lub
+    a = TypeInfo.from_type(_A_mypy)
+    d = TypeInfo.from_type(_D_mypy)
+    result = lub(a, d)
+    assert result.is_union()
+    assert result.to_set() == {a, d}
+
+
+def test_lub_mypy_varlen_tuples():
+    """From mypy JoinSuite.test_var_tuples.
+    join(tuple[a], tuple[a, ...]) = tuple[a, ...]."""
+    from righttyper.generalize import lub
+    a_t = TypeInfo.from_type(_A_mypy)
+    fixed = TypeInfo.from_type(tuple).replace(args=(a_t,))
+    varlen = TypeInfo.from_type(tuple).replace(args=(a_t, Ellipsis))
+    assert lub(fixed, varlen) == varlen
+    assert lub(varlen, fixed) == varlen
+    # join(tuple[a, ...], tuple[()]) = tuple[a, ...]
+    empty = TypeInfo.from_type(tuple).replace(args=((),))
+    assert lub(varlen, empty) == varlen

--- a/tests/test_generalize.py
+++ b/tests/test_generalize.py
@@ -1184,14 +1184,34 @@ def test_lub_subtype_narrowing():
     assert lub(base, a) == base
 
 
-def test_lub_fixed_tuple_different_lengths():
-    """tuple[int] | tuple[int, str] — different fixed lengths, stays as union."""
+def test_lub_fixed_tuple_different_lengths_to_varlen():
+    """tuple[int] | tuple[int, str] → tuple[int|str, ...] (from mypy's JoinSuite).
+    Different-length fixed tuples merge to varlen with unioned element types."""
     from righttyper.generalize import lub
-    a = TypeInfo.from_type(tuple).replace(args=(TypeInfo.from_type(int),))
-    b = TypeInfo.from_type(tuple).replace(args=(TypeInfo.from_type(int), TypeInfo.from_type(str)))
+    int_t = TypeInfo.from_type(int)
+    str_t = TypeInfo.from_type(str)
+    a = TypeInfo.from_type(tuple).replace(args=(int_t,))
+    b = TypeInfo.from_type(tuple).replace(args=(int_t, str_t))
     result = lub(a, b)
-    assert result.is_union()
-    assert result.to_set() == {a, b}
+    assert result.type_obj is tuple
+    assert not result.is_union()
+    # Should be tuple[int|str, ...]
+    assert len(result.args) == 2
+    assert result.args[1] is Ellipsis
+
+
+def test_lub_empty_and_fixed_tuple_to_varlen():
+    """tuple[()] | tuple[int] → tuple[int, ...] (from mypy's JoinSuite: line 727)."""
+    from righttyper.generalize import lub
+    int_t = TypeInfo.from_type(int)
+    empty = TypeInfo.from_type(tuple).replace(args=((),))
+    fixed = TypeInfo.from_type(tuple).replace(args=(int_t,))
+    result = lub(empty, fixed)
+    assert result.type_obj is tuple
+    assert not result.is_union()
+    assert len(result.args) == 2
+    assert result.args[1] is Ellipsis
+    assert result.args[0].type_obj is int
 
 
 def test_lub_fixed_tuple_same_length_merge():

--- a/tests/test_generalize.py
+++ b/tests/test_generalize.py
@@ -1175,6 +1175,49 @@ def test_lub_dict_and_list_of_tuples():
     assert result.to_set() == {d, lt}
 
 
+def test_lub_subtype_narrowing():
+    """lub(ChildA, Base) → Base (ChildA <: Base)."""
+    from righttyper.generalize import lub
+    a = TypeInfo.from_type(_ChildA)
+    base = TypeInfo.from_type(_Base)
+    assert lub(a, base) == base
+    assert lub(base, a) == base
+
+
+def test_lub_fixed_tuple_different_lengths():
+    """tuple[int] | tuple[int, str] — different fixed lengths, stays as union."""
+    from righttyper.generalize import lub
+    a = TypeInfo.from_type(tuple).replace(args=(TypeInfo.from_type(int),))
+    b = TypeInfo.from_type(tuple).replace(args=(TypeInfo.from_type(int), TypeInfo.from_type(str)))
+    result = lub(a, b)
+    assert result.is_union()
+    assert result.to_set() == {a, b}
+
+
+def test_lub_fixed_tuple_same_length_merge():
+    """tuple[int, str] | tuple[float, str] → tuple[int|float, str] (covariant, same length)."""
+    from righttyper.generalize import lub
+    a = TypeInfo.from_type(tuple).replace(args=(TypeInfo.from_type(int), TypeInfo.from_type(str)))
+    b = TypeInfo.from_type(tuple).replace(args=(TypeInfo.from_type(float), TypeInfo.from_type(str)))
+    result = lub(a, b)
+    assert result.type_obj is tuple
+    assert not result.is_union()
+    # First arg merged (int|float → float via numeric tower)
+    assert result.args[0].type_obj is float
+    assert result.args[1].type_obj is str
+
+
+def test_lub_multiple_lists_merge_args():
+    """list[int] | list[str] → list[int|str] when for_variable=True."""
+    from righttyper.generalize import lub
+    a = TypeInfo.from_type(list).replace(args=(TypeInfo.from_type(int),))
+    b = TypeInfo.from_type(list).replace(args=(TypeInfo.from_type(str),))
+    result = lub(a, b, for_variable=True)
+    assert result.type_obj is list
+    assert result.args[0].is_union()
+    assert result.args[0].to_set() == {TypeInfo.from_type(int), TypeInfo.from_type(str)}
+
+
 def test_lub_abc_fallback():
     """lub(IterableA, IterableB) → Iterable when no MRO base but both implement ABC."""
     import collections.abc

--- a/tests/test_generalize.py
+++ b/tests/test_generalize.py
@@ -1382,3 +1382,144 @@ def test_lub_mypy_varlen_tuples():
     # join(tuple[a, ...], tuple[()]) = tuple[a, ...]
     empty = TypeInfo.from_type(tuple).replace(args=((),))
     assert lub(varlen, empty) == varlen
+
+
+def test_lub_callable_same_signature():
+    """lub(Callable[[int], str], Callable[[int], str]) = Callable[[int], str]."""
+    import collections.abc
+    from righttyper.generalize import lub
+    int_t = TypeInfo.from_type(int)
+    str_t = TypeInfo.from_type(str)
+    params = TypeInfo.list([int_t])
+    a = TypeInfo.from_type(collections.abc.Callable).replace(args=(params, str_t))
+    assert lub(a, a) == a
+
+
+def test_lub_callable_different_return():
+    """lub(Callable[[int], int], Callable[[int], str]) merges return types (covariant)."""
+    import collections.abc
+    from righttyper.generalize import lub
+    int_t = TypeInfo.from_type(int)
+    str_t = TypeInfo.from_type(str)
+    a = TypeInfo.from_type(collections.abc.Callable).replace(
+        args=(TypeInfo.list([int_t]), int_t))
+    b = TypeInfo.from_type(collections.abc.Callable).replace(
+        args=(TypeInfo.list([int_t]), str_t))
+    result = lub(a, b, for_variable=True)
+    # Same params, different return → merge return to int|str
+    assert result.type_obj is collections.abc.Callable
+    assert not result.is_union()
+    # Return type (last arg) should be a union
+    assert result.args[-1].is_union()
+    assert result.args[-1].to_set() == {int_t, str_t}
+    # Params (first arg) should be unchanged
+    assert result.args[0].is_list()
+    assert result.args[0].args == (int_t,)
+
+
+def test_lub_callable_different_params():
+    """lub(Callable[[int], str], Callable[[float], str]) — different params stay as union."""
+    import collections.abc
+    from righttyper.generalize import lub
+    int_t = TypeInfo.from_type(int)
+    float_t = TypeInfo.from_type(float)
+    str_t = TypeInfo.from_type(str)
+    a = TypeInfo.from_type(collections.abc.Callable).replace(
+        args=(TypeInfo.list([int_t]), str_t))
+    b = TypeInfo.from_type(collections.abc.Callable).replace(
+        args=(TypeInfo.list([float_t]), str_t))
+    result = lub(a, b)
+    # Different param types, invariant by default → union
+    assert result.is_union()
+    assert result.to_set() == {a, b}
+
+
+def test_lub_callable_ellipsis_params():
+    """lub(Callable[..., int], Callable[..., str]) merges return types."""
+    import collections.abc
+    from righttyper.generalize import lub
+    int_t = TypeInfo.from_type(int)
+    str_t = TypeInfo.from_type(str)
+    a = TypeInfo.from_type(collections.abc.Callable).replace(args=(..., int_t))
+    b = TypeInfo.from_type(collections.abc.Callable).replace(args=(..., str_t))
+    result = lub(a, b, for_variable=True)
+    assert result.type_obj is collections.abc.Callable
+    assert not result.is_union()
+    assert result.args[0] is ...
+    assert result.args[-1].is_union()
+    assert result.args[-1].to_set() == {int_t, str_t}
+
+
+def test_lub_type_of_subtype():
+    """lub(type[B], type[C]) = type[A] when B, C both extend A."""
+    from righttyper.generalize import lub
+    b_t = TypeInfo.from_type(type).replace(args=(TypeInfo.from_type(_B_mypy),))
+    c_t = TypeInfo.from_type(type).replace(args=(TypeInfo.from_type(_C_mypy),))
+    result = lub(b_t, c_t)
+    assert result.type_obj is type
+    assert not result.is_union()
+    # type arg should be A (common base of B and C)
+    assert result.args[0].type_obj is _A_mypy
+
+
+def test_lub_type_of_same():
+    """lub(type[B], type[B]) = type[B]."""
+    from righttyper.generalize import lub
+    b_t = TypeInfo.from_type(type).replace(args=(TypeInfo.from_type(_B_mypy),))
+    assert lub(b_t, b_t) == b_t
+
+
+def test_lub_type_of_unrelated():
+    """lub(type[A], type[D]) = type[A|D] (covariant merge of unrelated args)."""
+    from righttyper.generalize import lub
+    a_ti = TypeInfo.from_type(_A_mypy)
+    d_ti = TypeInfo.from_type(_D_mypy)
+    a_t = TypeInfo.from_type(type).replace(args=(a_ti,))
+    d_t = TypeInfo.from_type(type).replace(args=(d_ti,))
+    result = lub(a_t, d_t)
+    assert result.type_obj is type
+    assert not result.is_union()
+    # Inner arg is the union A|D
+    assert result.args[0].is_union()
+    assert result.args[0].to_set() == {a_ti, d_ti}
+
+
+# --- Rule 4b: bare generic subsumes parametrized ---
+
+def test_lub_bare_type_subsumes_parametrized():
+    """lub(type, type[int]) = type (bare type subsumes type[int])."""
+    from righttyper.generalize import lub
+    bare = TypeInfo.from_type(type)
+    parametrized = TypeInfo.from_type(type).replace(args=(TypeInfo.from_type(int),))
+    assert lub(bare, parametrized) == bare
+    assert lub(parametrized, bare) == bare
+
+
+def test_lub_bare_awaitable_subsumes_parametrized():
+    """lub(Awaitable, Awaitable[int]) = Awaitable."""
+    from righttyper.generalize import lub
+    import collections.abc as abc
+    bare = TypeInfo.from_type(abc.Awaitable)
+    parametrized = TypeInfo.from_type(abc.Awaitable).replace(args=(TypeInfo.from_type(int),))
+    assert lub(bare, parametrized) == bare
+    assert lub(parametrized, bare) == bare
+
+
+def test_lub_bare_async_iterable_subsumes_parametrized():
+    """lub(AsyncIterable, AsyncIterable[str]) = AsyncIterable."""
+    from righttyper.generalize import lub
+    import collections.abc as abc
+    bare = TypeInfo.from_type(abc.AsyncIterable)
+    parametrized = TypeInfo.from_type(abc.AsyncIterable).replace(args=(TypeInfo.from_type(str),))
+    assert lub(bare, parametrized) == bare
+    assert lub(parametrized, bare) == bare
+
+
+def test_lub_bare_reversible_subsumes_parametrized():
+    """lub(Reversible, Reversible[float]) = Reversible."""
+    from righttyper.generalize import lub
+    import collections.abc as abc
+    bare = TypeInfo.from_type(abc.Reversible)
+    parametrized = TypeInfo.from_type(abc.Reversible).replace(args=(TypeInfo.from_type(float),))
+    assert lub(bare, parametrized) == bare
+    assert lub(parametrized, bare) == bare

--- a/tests/test_generalize.py
+++ b/tests/test_generalize.py
@@ -346,34 +346,34 @@ def test_generalize_type_and_never():
 # Tests for container superset merging
 
 def test_merge_container_supersets_list():
-    """list[int] | list[int|str] -> list[int|str] (int ⊆ int|str)"""
-    from righttyper.generalize import merge_container_supersets
+    """list[int] | list[int|str] -> list[int|str] for variables"""
+    from righttyper.generalize import merged_types
 
     int_t = TypeInfo.from_type(int)
     str_t = TypeInfo.from_type(str)
     list_int = TypeInfo.from_type(list).replace(args=(int_t,))
     list_int_str = TypeInfo.from_type(list).replace(args=(TypeInfo.from_set({int_t, str_t}),))
 
-    result = merge_container_supersets({list_int, list_int_str})
-    assert result == {list_int_str}
+    result = merged_types({list_int, list_int_str}, for_variable=True)
+    assert result == list_int_str
 
 
 def test_merge_container_supersets_no_subset():
-    """list[int] | list[str] -> unchanged (no subset relationship)"""
-    from righttyper.generalize import merge_container_supersets
+    """list[int] | list[str] -> list[int|str] for variables (merges args)"""
+    from righttyper.generalize import merged_types
 
     int_t = TypeInfo.from_type(int)
     str_t = TypeInfo.from_type(str)
     list_int = TypeInfo.from_type(list).replace(args=(int_t,))
     list_str = TypeInfo.from_type(list).replace(args=(str_t,))
 
-    result = merge_container_supersets({list_int, list_str})
-    assert result == {list_int, list_str}
+    result = merged_types({list_int, list_str}, for_variable=True)
+    assert result == TypeInfo.from_type(list).replace(args=(TypeInfo.from_set({int_t, str_t}),))
 
 
 def test_merge_container_supersets_chain():
-    """list[int] | list[int|str] | list[int|str|float] -> list[int|str|float]"""
-    from righttyper.generalize import merge_container_supersets
+    """list[int] | list[int|str] | list[int|str|float] -> list[int|str|float] for variables"""
+    from righttyper.generalize import merged_types
 
     int_t = TypeInfo.from_type(int)
     str_t = TypeInfo.from_type(str)
@@ -383,13 +383,13 @@ def test_merge_container_supersets_chain():
     list_int_str = TypeInfo.from_type(list).replace(args=(TypeInfo.from_set({int_t, str_t}),))
     list_all = TypeInfo.from_type(list).replace(args=(TypeInfo.from_set({int_t, str_t, float_t}),))
 
-    result = merge_container_supersets({list_int, list_int_str, list_all})
-    assert result == {list_all}
+    result = merged_types({list_int, list_int_str, list_all}, for_variable=True)
+    assert result == list_all
 
 
 def test_merge_container_supersets_nested():
-    """list[set[int]] | list[set[int|str]] -> list[set[int|str]]"""
-    from righttyper.generalize import merge_container_supersets
+    """list[set[int]] | list[set[int|str]] -> list[set[int|str]] for variables"""
+    from righttyper.generalize import merged_types
 
     int_t = TypeInfo.from_type(int)
     str_t = TypeInfo.from_type(str)
@@ -398,13 +398,13 @@ def test_merge_container_supersets_nested():
     list_set_int = TypeInfo.from_type(list).replace(args=(set_int,))
     list_set_int_str = TypeInfo.from_type(list).replace(args=(set_int_str,))
 
-    result = merge_container_supersets({list_set_int, list_set_int_str})
-    assert result == {list_set_int_str}
+    result = merged_types({list_set_int, list_set_int_str}, for_variable=True)
+    assert result == list_set_int_str
 
 
 def test_merge_container_supersets_dict():
-    """dict[str, int] | dict[str, int|float] -> dict[str, int|float]"""
-    from righttyper.generalize import merge_container_supersets
+    """dict[str, int] | dict[str, int|float] -> dict[str, int|float] for variables"""
+    from righttyper.generalize import merged_types
 
     str_t = TypeInfo.from_type(str)
     int_t = TypeInfo.from_type(int)
@@ -413,13 +413,13 @@ def test_merge_container_supersets_dict():
     dict_str_int = TypeInfo.from_type(dict).replace(args=(str_t, int_t))
     dict_str_int_float = TypeInfo.from_type(dict).replace(args=(str_t, TypeInfo.from_set({int_t, float_t})))
 
-    result = merge_container_supersets({dict_str_int, dict_str_int_float})
-    assert result == {dict_str_int_float}
+    result = merged_types({dict_str_int, dict_str_int_float}, for_variable=True)
+    assert result == dict_str_int_float
 
 
 def test_merge_container_supersets_dict_no_subset():
-    """dict[str, int] | dict[int, int] -> unchanged (no subset relationship in keys)"""
-    from righttyper.generalize import merge_container_supersets
+    """dict[str, int] | dict[int, int] -> dict[str|int, int] for variables (merges keys)"""
+    from righttyper.generalize import merged_types
 
     str_t = TypeInfo.from_type(str)
     int_t = TypeInfo.from_type(int)
@@ -427,13 +427,13 @@ def test_merge_container_supersets_dict_no_subset():
     dict_str_int = TypeInfo.from_type(dict).replace(args=(str_t, int_t))
     dict_int_int = TypeInfo.from_type(dict).replace(args=(int_t, int_t))
 
-    result = merge_container_supersets({dict_str_int, dict_int_int})
-    assert result == {dict_str_int, dict_int_int}
+    result = merged_types({dict_str_int, dict_int_int}, for_variable=True)
+    assert result == TypeInfo.from_type(dict).replace(args=(TypeInfo.from_set({str_t, int_t}), int_t))
 
 
 def test_merge_container_supersets_dict_key_subset():
-    """dict[str, int] | dict[str|int, int] -> dict[str|int, int] (str ⊆ str|int)"""
-    from righttyper.generalize import merge_container_supersets
+    """dict[str, int] | dict[str|int, int] -> dict[str|int, int] for variables"""
+    from righttyper.generalize import merged_types
 
     str_t = TypeInfo.from_type(str)
     int_t = TypeInfo.from_type(int)
@@ -441,13 +441,13 @@ def test_merge_container_supersets_dict_key_subset():
     dict_str_int = TypeInfo.from_type(dict).replace(args=(str_t, int_t))
     dict_str_or_int_int = TypeInfo.from_type(dict).replace(args=(TypeInfo.from_set({str_t, int_t}), int_t))
 
-    result = merge_container_supersets({dict_str_int, dict_str_or_int_int})
-    assert result == {dict_str_or_int_int}
+    result = merged_types({dict_str_int, dict_str_or_int_int}, for_variable=True)
+    assert result == dict_str_or_int_int
 
 
 def test_merge_container_supersets_mixed_containers():
-    """list[int] | set[int] | list[int|str] -> set[int] | list[int|str]"""
-    from righttyper.generalize import merge_container_supersets
+    """list[int] | set[int] | list[int|str] -> set[int] | list[int|str] for variables"""
+    from righttyper.generalize import merged_types
 
     int_t = TypeInfo.from_type(int)
     str_t = TypeInfo.from_type(str)
@@ -455,8 +455,8 @@ def test_merge_container_supersets_mixed_containers():
     list_int_str = TypeInfo.from_type(list).replace(args=(TypeInfo.from_set({int_t, str_t}),))
     set_int = TypeInfo.from_type(set).replace(args=(int_t,))
 
-    result = merge_container_supersets({list_int, set_int, list_int_str})
-    assert result == {set_int, list_int_str}
+    result = merged_types({list_int, set_int, list_int_str}, for_variable=True)
+    assert result == TypeInfo.from_set({set_int, list_int_str})
 
 
 # Tests for covariant type merging in merged_types
@@ -524,7 +524,12 @@ def test_merge_covariant_frozenset():
 
 
 def test_merge_covariant_tuple_different_lengths():
-    """tuple[int] | tuple[int, str] -> unchanged (different arities)"""
+    """tuple[int] | tuple[int, str] -> tuple[int|str, ...] (different arities → varlen).
+
+    This is a valid LUB but wider than the original union: it loses positional
+    type information and length constraints. Acceptable for runtime-inferred
+    annotations where observing multiple lengths implies variable-length usage.
+    """
     from righttyper.generalize import merged_types
 
     int_t = TypeInfo.from_type(int)
@@ -533,7 +538,9 @@ def test_merge_covariant_tuple_different_lengths():
     tuple_2 = TypeInfo.from_type(tuple).replace(args=(int_t, str_t))
 
     result = merged_types({tuple_1, tuple_2}, for_variable=False)
-    assert result == TypeInfo.from_set({tuple_1, tuple_2})
+    assert result == TypeInfo.from_type(tuple).replace(
+        args=(TypeInfo.from_set({int_t, str_t}), Ellipsis)
+    )
 
 
 def test_merge_covariant_tuple_fixed_vs_varlen():
@@ -713,7 +720,9 @@ def test_dict_and_ordered_dict_to_mapping():
 
 
 def test_list_and_empty_tuple_without_accessed_attrs():
-    """Without accessed_attributes, list[X] | tuple[()] stays as union."""
+    """list[X] | tuple[()] → Sequence[X] even without accessed_attributes,
+    since an empty tuple is compatible with any element type."""
+    import collections.abc as abc
     from righttyper.generalize import merged_types
 
     int_t = TypeInfo.from_type(int)
@@ -722,8 +731,9 @@ def test_list_and_empty_tuple_without_accessed_attrs():
     empty_tuple = TypeInfo.from_type(tuple).replace(args=((),))
 
     result = merged_types({list_of_tuples, empty_tuple})
-    # Without accessed attributes, no cross-container merge
-    assert result.is_union()
+    assert not result.is_union()
+    assert result.type_obj is abc.Sequence
+    assert result.args[0] == inner
 
 
 # =============================================================================
@@ -748,67 +758,62 @@ class _ChildB(_Base):
 
 def test_simplify_with_accessed_attributes():
     """When accessed_attributes are provided and the common base has them, merge happens."""
-    from righttyper.generalize import simplify
+    from righttyper.generalize import merged_types
 
     a = TypeInfo.from_type(_ChildA)
     b = TypeInfo.from_type(_ChildB)
 
-    result = simplify({a, b}, accessed_attributes={"name"})
-    assert len(result) == 1
-    merged = next(iter(result))
-    assert merged.type_obj is _Base
+    result = merged_types({a, b}, accessed_attributes={"name"})
+    assert not result.is_union()
+    assert result.type_obj is _Base
 
 
 def test_simplify_without_accessed_attributes():
-    """Without accessed_attributes, current dir()-based behavior is preserved."""
-    from righttyper.generalize import simplify
+    """Without accessed_attributes, dir()-based MRO merge to common base."""
+    from righttyper.generalize import merged_types
 
     a = TypeInfo.from_type(_ChildA)
     b = TypeInfo.from_type(_ChildB)
 
-    # dir()-based: ChildA and ChildB share many attrs via Base → merges to Base
-    result = simplify({a, b})
-    assert len(result) == 1
-    merged = next(iter(result))
-    assert merged.type_obj is _Base
+    result = merged_types({a, b})
+    assert not result.is_union()
+    assert result.type_obj is _Base
 
 
 def test_simplify_accessed_attrs_prevents_over_merge():
     """When accessed_attributes include an attr not on the common base, merge is prevented."""
-    from righttyper.generalize import simplify
+    from righttyper.generalize import merged_types
 
     a = TypeInfo.from_type(_ChildA)
     b = TypeInfo.from_type(_ChildB)
 
     # extra_a is only on ChildA, not on Base → can't merge to Base
-    result = simplify({a, b}, accessed_attributes={"extra_a"})
-    assert len(result) == 2
-    types = {t.type_obj for t in result}
+    result = merged_types({a, b}, accessed_attributes={"extra_a"})
+    assert result.is_union()
+    types = {t.type_obj for t in result.to_set()}
     assert types == {_ChildA, _ChildB}
 
 
 def test_simplify_single_type_with_accessed_attributes():
     """Even a single type can be generalized to a base when accessed_attributes
     are all present on that base."""
-    from righttyper.generalize import simplify
+    from righttyper.generalize import merged_types
 
     a = TypeInfo.from_type(_ChildA)
 
     # 'name' is on _Base → ChildA can be generalized to Base
-    result = simplify({a}, accessed_attributes={"name"})
-    assert len(result) == 1
-    assert next(iter(result)).type_obj is _Base
+    result = merged_types({a}, accessed_attributes={"name"})
+    assert result.type_obj is _Base
 
 
 def test_simplify_single_type_no_generalization_without_attrs():
-    """Without accessed_attributes, a single type is not generalized (nothing to merge)."""
-    from righttyper.generalize import simplify
+    """Without accessed_attributes, a single type stays as-is."""
+    from righttyper.generalize import merged_types
 
     a = TypeInfo.from_type(_ChildA)
 
-    result = simplify({a})
-    assert len(result) == 1
-    assert next(iter(result)).type_obj is _ChildA
+    result = merged_types({a})
+    assert result.type_obj is _ChildA
 
 
 # =============================================================================
@@ -827,45 +832,43 @@ class _IterableB:
 
 
 def test_simplify_abc_fallback():
-    """When types share no concrete base (only object), simplify falls back to
+    """When types share no concrete base (only object), falls back to
     ABC matching. _IterableA and _IterableB both implement Iterable via
     __subclasshook__, so accessing __iter__ should merge to Iterable."""
     import collections.abc as abc
-    from righttyper.generalize import simplify
+    from righttyper.generalize import merged_types
 
     a = TypeInfo.from_type(_IterableA)
     b = TypeInfo.from_type(_IterableB)
 
-    result = simplify({a, b}, accessed_attributes={"__iter__"})
-    assert len(result) == 1
-    result_type = next(iter(result)).type_obj
-    assert issubclass(result_type, abc.Iterable)
+    result = merged_types({a, b}, accessed_attributes={"__iter__"})
+    assert not result.is_union()
+    assert issubclass(result.type_obj, abc.Iterable)
 
 
 def test_simplify_abc_not_used_when_concrete_base_exists():
     """When a concrete base exists and has the accessed attributes,
     prefer it over ABC matching."""
-    from righttyper.generalize import simplify
+    from righttyper.generalize import merged_types
 
     a = TypeInfo.from_type(_ChildA)
     b = TypeInfo.from_type(_ChildB)
 
     # 'name' is on _Base → concrete merge to _Base, not to some ABC
-    result = simplify({a, b}, accessed_attributes={"name"})
-    assert len(result) == 1
-    assert next(iter(result)).type_obj is _Base
+    result = merged_types({a, b}, accessed_attributes={"name"})
+    assert not result.is_union()
+    assert result.type_obj is _Base
 
 
 def test_simplify_abc_single_type():
     """A single type is not generalized to an ABC — ABC matching only
     reduces union size, not replaces a single concrete type."""
-    from righttyper.generalize import simplify
+    from righttyper.generalize import merged_types
 
     a = TypeInfo.from_type(_IterableA)
 
-    result = simplify({a}, accessed_attributes={"__len__"})
-    assert len(result) == 1
-    assert next(iter(result)).type_obj is _IterableA
+    result = merged_types({a}, accessed_attributes={"__len__"})
+    assert result.type_obj is _IterableA
 
 
 # =============================================================================

--- a/tests/test_generalize.py
+++ b/tests/test_generalize.py
@@ -857,17 +857,12 @@ def test_simplify_abc_not_used_when_concrete_base_exists():
 
 
 def test_simplify_abc_single_type():
-    """A single type can be generalized to an ABC if the accessed attributes
-    match and there's no better concrete base."""
-    import collections.abc as abc
+    """A single type is not generalized to an ABC — ABC matching only
+    reduces union size, not replaces a single concrete type."""
     from righttyper.generalize import simplify
 
     a = TypeInfo.from_type(_IterableA)
 
-    # _IterableA has no useful concrete base, but implements Sized + Iterable.
-    # Should generalize to the ABC, not stay as _IterableA.
     result = simplify({a}, accessed_attributes={"__len__"})
     assert len(result) == 1
-    result_type = next(iter(result)).type_obj
-    assert result_type is not _IterableA
-    assert issubclass(result_type, abc.Sized)
+    assert next(iter(result)).type_obj is _IterableA

--- a/tests/test_generalize.py
+++ b/tests/test_generalize.py
@@ -626,3 +626,88 @@ def test_subsume_empty_tuple_by_varlen():
 
     result = merged_types({tuple_empty, tuple_var}, for_variable=False)
     assert result == tuple_var
+
+
+# =============================================================================
+# Tests for attribute-aware simplification
+# =============================================================================
+
+# Test hierarchy: Base has .name and .value; ChildA adds .extra_a; ChildB adds .extra_b.
+# Without accessed_attributes, simplify merges ChildA|ChildB → Base (common dir() attrs).
+# With accessed_attributes={'name'}, the merge should still work (Base has .name).
+# With accessed_attributes={'extra_a'}, merge should NOT happen (Base lacks .extra_a).
+
+class _Base:
+    name: str = ""
+    value: int = 0
+
+class _ChildA(_Base):
+    extra_a: str = ""
+
+class _ChildB(_Base):
+    extra_b: str = ""
+
+
+def test_simplify_with_accessed_attributes():
+    """When accessed_attributes are provided and the common base has them, merge happens."""
+    from righttyper.generalize import simplify
+
+    a = TypeInfo.from_type(_ChildA)
+    b = TypeInfo.from_type(_ChildB)
+
+    result = simplify({a, b}, accessed_attributes={"name"})
+    assert len(result) == 1
+    merged = next(iter(result))
+    assert merged.type_obj is _Base
+
+
+def test_simplify_without_accessed_attributes():
+    """Without accessed_attributes, current dir()-based behavior is preserved."""
+    from righttyper.generalize import simplify
+
+    a = TypeInfo.from_type(_ChildA)
+    b = TypeInfo.from_type(_ChildB)
+
+    # dir()-based: ChildA and ChildB share many attrs via Base → merges to Base
+    result = simplify({a, b})
+    assert len(result) == 1
+    merged = next(iter(result))
+    assert merged.type_obj is _Base
+
+
+def test_simplify_accessed_attrs_prevents_over_merge():
+    """When accessed_attributes include an attr not on the common base, merge is prevented."""
+    from righttyper.generalize import simplify
+
+    a = TypeInfo.from_type(_ChildA)
+    b = TypeInfo.from_type(_ChildB)
+
+    # extra_a is only on ChildA, not on Base → can't merge to Base
+    result = simplify({a, b}, accessed_attributes={"extra_a"})
+    assert len(result) == 2
+    types = {t.type_obj for t in result}
+    assert types == {_ChildA, _ChildB}
+
+
+def test_simplify_single_type_with_accessed_attributes():
+    """Even a single type can be generalized to a base when accessed_attributes
+    are all present on that base."""
+    from righttyper.generalize import simplify
+
+    a = TypeInfo.from_type(_ChildA)
+
+    # 'name' is on _Base → ChildA can be generalized to Base
+    result = simplify({a}, accessed_attributes={"name"})
+    assert len(result) == 1
+    assert next(iter(result)).type_obj is _Base
+
+
+def test_simplify_single_type_no_generalization_without_attrs():
+    """Without accessed_attributes, a single type is not generalized (nothing to merge)."""
+    from righttyper.generalize import simplify
+
+    a = TypeInfo.from_type(_ChildA)
+
+    result = simplify({a})
+    assert len(result) == 1
+    assert next(iter(result)).type_obj is _ChildA

--- a/tests/test_generalize.py
+++ b/tests/test_generalize.py
@@ -629,6 +629,104 @@ def test_subsume_empty_tuple_by_varlen():
 
 
 # =============================================================================
+# Tests for cross-container simplification
+# =============================================================================
+
+def test_list_and_empty_tuple_to_sequence():
+    """list[tuple[int, int]] | tuple[()] → Sequence[tuple[int, int]].
+    An empty tuple is an empty sequence, compatible with any element type."""
+    import collections.abc
+    from righttyper.generalize import merged_types
+
+    int_t = TypeInfo.from_type(int)
+    inner = TypeInfo.from_type(tuple).replace(args=(int_t, int_t))
+    list_of_tuples = TypeInfo.from_type(list).replace(args=(inner,))
+    empty_tuple = TypeInfo.from_type(tuple).replace(args=((),))
+
+    result = merged_types({list_of_tuples, empty_tuple},
+                          accessed_attributes={"__iter__"})
+
+    # Should merge to Sequence[tuple[int, int]], not stay as a union
+    assert not result.is_union(), f"Expected single type, got union: {result}"
+    assert result.type_obj is not None
+    assert issubclass(result.type_obj, collections.abc.Sequence)
+    # Element type should be preserved
+    assert result.args and isinstance(result.args[0], TypeInfo)
+    assert result.args[0] == inner
+
+
+def test_list_and_varlen_tuple_to_sequence():
+    """list[int] | tuple[int, ...] → Sequence[int] when accessed via sequence attrs.
+    Two non-empty containers with compatible element types merge to a common ABC."""
+    import collections.abc
+    from righttyper.generalize import merged_types
+
+    int_t = TypeInfo.from_type(int)
+    list_of_int = TypeInfo.from_type(list).replace(args=(int_t,))
+    tuple_of_int = TypeInfo.from_type(tuple).replace(args=(int_t, Ellipsis))
+
+    result = merged_types({list_of_int, tuple_of_int},
+                          accessed_attributes={"__iter__"})
+
+    assert not result.is_union(), f"Expected single type, got union: {result}"
+    assert isinstance(result.type_obj, type)
+    assert issubclass(result.type_obj, collections.abc.Sequence)
+    # Element type preserved
+    assert result.args and isinstance(result.args[0], TypeInfo)
+    assert result.args[0].type_obj is int
+
+
+def test_set_and_frozenset_to_abc_set():
+    """set[int] | frozenset[int] → Set[int]."""
+    import collections.abc
+    from righttyper.generalize import merged_types
+
+    int_t = TypeInfo.from_type(int)
+    s = TypeInfo.from_type(set).replace(args=(int_t,))
+    fs = TypeInfo.from_type(frozenset).replace(args=(int_t,))
+
+    result = merged_types({s, fs}, accessed_attributes={"__iter__"})
+    assert not result.is_union(), f"Expected single type, got union: {result}"
+    assert isinstance(result.type_obj, type)
+    assert issubclass(result.type_obj, collections.abc.Set)
+
+
+def test_dict_and_ordered_dict_to_mapping():
+    """dict[str, int] | OrderedDict[str, int] → Mapping[str, int] (2 type args)."""
+    import collections
+    import collections.abc
+    from righttyper.generalize import merged_types
+
+    str_t = TypeInfo.from_type(str)
+    int_t = TypeInfo.from_type(int)
+    d = TypeInfo.from_type(dict).replace(args=(str_t, int_t))
+    od = TypeInfo.from_type(collections.OrderedDict).replace(args=(str_t, int_t))
+
+    result = merged_types({d, od}, accessed_attributes={"items"})
+    assert not result.is_union(), f"Expected single type, got union: {result}"
+    assert isinstance(result.type_obj, type)
+    assert issubclass(result.type_obj, collections.abc.Mapping)
+    # Both key and value types preserved
+    assert len(result.args) == 2
+    assert result.args[0] == str_t
+    assert result.args[1] == int_t
+
+
+def test_list_and_empty_tuple_without_accessed_attrs():
+    """Without accessed_attributes, list[X] | tuple[()] stays as union."""
+    from righttyper.generalize import merged_types
+
+    int_t = TypeInfo.from_type(int)
+    inner = TypeInfo.from_type(tuple).replace(args=(int_t, int_t))
+    list_of_tuples = TypeInfo.from_type(list).replace(args=(inner,))
+    empty_tuple = TypeInfo.from_type(tuple).replace(args=((),))
+
+    result = merged_types({list_of_tuples, empty_tuple})
+    # Without accessed attributes, no cross-container merge
+    assert result.is_union()
+
+
+# =============================================================================
 # Tests for attribute-aware simplification
 # =============================================================================
 

--- a/tests/test_generalize.py
+++ b/tests/test_generalize.py
@@ -1612,3 +1612,16 @@ def test_lub_skips_private_mro_ancestors():
     result = lub(a, b)
     # Should NOT merge to _Base (private) — should be a union
     assert result.is_union(), f"expected union, got {result}"
+
+
+def test_merged_types_single_type_skips_private_ancestor():
+    """merged_types with a single type and accessed_attributes should not
+    generalize to an ancestor in a private module."""
+    from righttyper.generalize import merged_types
+
+    _Base = type('_Base', (object,), {'__module__': '_internal.base', 'do_thing': lambda self: None})
+    Concrete = type('Concrete', (_Base,), {'__module__': 'mypkg'})
+
+    result = merged_types({TypeInfo.from_type(Concrete)}, accessed_attributes={'do_thing'})
+    # Should stay as Concrete, not generalize to _Base
+    assert result == TypeInfo.from_type(Concrete)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2779,6 +2779,29 @@ def test_var_assigned_constructor_uses_typeshed_return(tmp_cwd):
     assert "-> Path" in output, output
 
 
+@pytest.mark.dont_run_mypy  # without widening, `Path() -> Path` is assigned to a `PosixPath`-typed variable; mypy rejects.
+def test_no_use_constructor_types_disables_widening(tmp_cwd):
+    """`--no-use-constructor-types` skips both AST capture (so `.rt` files
+    don't carry constructor_types) and load-time application (so a `.rt`
+    recorded with the feature on is honored at process time).  The
+    variable falls back to the runtime-observed type."""
+    Path("t.py").write_text(textwrap.dedent("""\
+        from pathlib import Path
+
+        def f():
+            p = Path("/tmp")
+            return p
+        f()
+        """))
+
+    rt_run('--no-use-constructor-types', 't.py')
+    output = Path("t.py").read_text()
+
+    # Without the feature, the variable shows the runtime-observed
+    # PosixPath rather than being widened to Path.
+    assert "PosixPath" in output, output
+
+
 def test_direct_return_uses_typeshed_return(tmp_cwd):
     """A function directly returning Constructor(...) gets the typeshed-
     declared return type as its return annotation."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2815,6 +2815,46 @@ def test_var_assigned_typeshed_factory_uses_declared_return(tmp_cwd):
     assert "p: Path" in output, output
 
 
+def test_constructor_type_preserves_container_parametrization(tmp_cwd):
+    """Bare constructor types must not clobber parametrized observations
+    via lub Rule 4b ("bare subsumes parametrized"). Uses an imported
+    generic so the constructor-type resolution actually fires —
+    builtin sets/lists/dicts are skipped at resolution."""
+    Path("t.py").write_text(textwrap.dedent("""\
+        from collections import OrderedDict
+        def f():
+            d = OrderedDict()
+            d["x"] = 1
+            return d
+        f()
+        """))
+
+    rt_run('t.py')
+    output = Path("t.py").read_text()
+
+    assert "d: OrderedDict[str, int]" in output, output
+
+
+def test_constructor_type_round_trip(tmp_cwd):
+    """Constructor-type widening survives the .rt round-trip: collect with
+    --only-collect, then process. The resulting annotations must match what
+    a single-pass run produces (`p: Path`, `f() -> Path`)."""
+    Path("t.py").write_text(textwrap.dedent("""\
+        from pathlib import Path
+        def f():
+            p = Path("/tmp")
+            return p
+        f()
+        """))
+
+    rt_run('--only-collect', 't.py')
+    rt_run('process', '--output-files', '--overwrite')
+    output = Path("t.py").read_text()
+
+    assert "p: Path" in output, output
+    assert "-> Path" in output, output
+
+
 def test_alias_resolution_does_not_leak_across_functions():
     """Same-named variables in different functions should be independent.
     Here `y` in f is aliased to global `g`; `y` in h is just an unrelated

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2779,7 +2779,7 @@ def test_var_assigned_constructor_uses_typeshed_return(tmp_cwd):
     assert "-> Path" in output, output
 
 
-@pytest.mark.dont_run_mypy  # without widening, `Path() -> Path` is assigned to a `PosixPath`-typed variable; mypy rejects.
+@pytest.mark.dont_run_mypy  # without widening, the runtime subtype (Posix/WindowsPath) leaks; mypy rejects.
 def test_no_use_constructor_types_disables_widening(tmp_cwd):
     """`--no-use-constructor-types` skips both AST capture (so `.rt` files
     don't carry constructor_types) and load-time application (so a `.rt`
@@ -2797,9 +2797,12 @@ def test_no_use_constructor_types_disables_widening(tmp_cwd):
     rt_run('--no-use-constructor-types', 't.py')
     output = Path("t.py").read_text()
 
-    # Without the feature, the variable shows the runtime-observed
-    # PosixPath rather than being widened to Path.
-    assert "PosixPath" in output, output
+    # Without the feature, the variable shows the runtime-observed concrete
+    # subtype (PosixPath on POSIX, WindowsPath on Windows) rather than being
+    # widened to Path.
+    concrete = type(Path("/")).__name__
+    assert concrete in output, output
+    assert concrete != "Path"  # sanity: we are checking a real subtype
 
 
 def test_direct_return_uses_typeshed_return(tmp_cwd):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2747,7 +2747,7 @@ def test_lub_local_variable_uses_accessed_attributes():
         f(_Derived())
         """))
 
-    rt_run('t.py')
+    rt_run('--use-attribute-simplification', 't.py')
     output = Path("t.py").read_text()
 
     # _Derived is private; only .name is accessed on y → de-privatize to Base.
@@ -2772,7 +2772,7 @@ def test_var_assigned_constructor_uses_typeshed_return(tmp_cwd):
         f()
         """))
 
-    rt_run('t.py')
+    rt_run('--use-constructor-types', 't.py')
     output = Path("t.py").read_text()
 
     assert "p: Path" in output, output
@@ -2813,7 +2813,7 @@ def test_direct_return_uses_typeshed_return(tmp_cwd):
         f()
         """))
 
-    rt_run('t.py')
+    rt_run('--use-constructor-types', 't.py')
     output = Path("t.py").read_text()
 
     assert "-> Path" in output, output
@@ -2832,7 +2832,7 @@ def test_var_assigned_typeshed_factory_uses_declared_return(tmp_cwd):
         f()
         """))
 
-    rt_run('t.py')
+    rt_run('--use-constructor-types', 't.py')
     output = Path("t.py").read_text()
 
     assert "p: Path" in output, output
@@ -2852,7 +2852,7 @@ def test_constructor_type_preserves_container_parametrization(tmp_cwd):
         f()
         """))
 
-    rt_run('t.py')
+    rt_run('--use-constructor-types', 't.py')
     output = Path("t.py").read_text()
 
     assert "d: OrderedDict[str, int]" in output, output
@@ -2874,8 +2874,8 @@ def test_constructor_type_skips_newtype_callable(tmp_cwd):
         f()
         """))
 
-    rt_run('--only-collect', 't.py')
-    rt_run('process', '--output-files', '--overwrite')
+    rt_run('--use-constructor-types', '--only-collect', 't.py')
+    rt_run('process', '--use-constructor-types', '--output-files', '--overwrite')
     output = Path("t.py").read_text()
 
     # The variable is annotated as int (the underlying type from NewType
@@ -2903,8 +2903,8 @@ def test_constructor_type_round_trip(tmp_cwd):
         f()
         """))
 
-    rt_run('--only-collect', 't.py')
-    rt_run('process', '--output-files', '--overwrite')
+    rt_run('--use-constructor-types', '--only-collect', 't.py')
+    rt_run('process', '--use-constructor-types', '--output-files', '--overwrite')
     output = Path("t.py").read_text()
 
     assert "p: Path" in output, output
@@ -2940,7 +2940,7 @@ def test_alias_resolution_does_not_leak_across_functions():
         h(_Derived())
         """))
 
-    rt_run('t.py')
+    rt_run('--use-attribute-simplification', 't.py')
     output = Path("t.py").read_text()
 
     # Only .name is accessed on g (via f's alias y = g).
@@ -7801,8 +7801,8 @@ def test_accessed_attributes_survive_collect_process():
         f(_Sub())
     """))
 
-    rt_run('--only-collect', 't.py')
-    rt_run('process')
+    rt_run('--use-attribute-simplification', '--only-collect', 't.py')
+    rt_run('process', '--use-attribute-simplification')
     output = Path("t.py").read_text()
     code = cst.parse_module(output)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2633,6 +2633,66 @@ def test_discovered_function_type_in_yield():
     """)
 
 
+def test_simplify_uses_accessed_attributes():
+    """When a function accesses an attribute on a parameter, simplify() should use
+    that to make better type merging decisions — merging to the common base that
+    has the accessed attribute rather than relying on dir() overlap.
+    """
+    Path("t.py").write_text(textwrap.dedent("""\
+        class Base:
+            def get_name(self):
+                return ""
+
+        class ChildA(Base):
+            def extra_a(self):
+                return "a"
+
+        class ChildB(Base):
+            def extra_b(self):
+                return "b"
+
+        def process(x):
+            return x.get_name()
+
+        process(ChildA())
+        process(ChildB())
+        """))
+
+    rt_run('t.py')
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+
+    # With accessed-attribute-aware simplification, x is accessed via .get_name()
+    # which exists on Base, so ChildA|ChildB should merge to Base.
+    assert get_function(code, 'process') == textwrap.dedent("""\
+        def process(x: Base) -> str: ...
+    """)
+
+
+def test_simplify_single_type_with_accessed_attributes():
+    """Even with a single observed type, accessed attributes can simplify it
+    to a more general base. Path('.') produces PosixPath at runtime, but if
+    the function only accesses .name (from PurePath), the annotation should
+    use a more general type.
+    """
+    Path("t.py").write_text(textwrap.dedent("""\
+        from pathlib import Path
+
+        def get_name(p):
+            return p.name
+
+        get_name(Path("."))
+        """))
+
+    rt_run('t.py')
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+
+    func = get_function(code, 'get_name')
+    # Should be Path or PurePath, not PosixPath
+    assert 'PosixPath' not in func
+
+
 def test_nested_callable_resolution():
     """When a function returns another function that itself returns a function,
     the nested Callable types should be fully resolved.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3078,7 +3078,7 @@ def test_varargs():
     output = Path("t.py").read_text()
     code = cst.parse_module(output)
     assert get_function(code, 'foo') == textwrap.dedent("""\
-        def foo(x: bool, *args: float|int|str) -> None: ...
+        def foo(x: bool, *args: float|str) -> None: ...
     """)
 
 
@@ -3115,7 +3115,7 @@ def test_varargs_json():
     print(data)
 
     foo = data['files'][str(Path('t.py').resolve())]['functions']['foo']
-    assert "tuple[float|int|str, ...]" == foo['args']['rest']
+    assert "tuple[float|str, ...]" == foo['args']['rest']
 
 
 def test_kwargs():
@@ -3131,7 +3131,7 @@ def test_kwargs():
     output = Path("t.py").read_text()
     code = cst.parse_module(output)
     assert get_function(code, 'foo') == textwrap.dedent("""\
-        def foo(x: bool, **kwargs: float|int|str) -> None: ...
+        def foo(x: bool, **kwargs: float|str) -> None: ...
     """)
 
 
@@ -3168,7 +3168,7 @@ def test_kwargs_json():
     print(data)
 
     foo = data['files'][str(Path('t.py').resolve())]['functions']['foo']
-    assert "dict[str, float|int|str]" == foo['args']['kwargs']
+    assert "dict[str, float|str]" == foo['args']['kwargs']
 
 
 def test_none_arg():
@@ -4571,6 +4571,45 @@ def test_self_widen_callable_retval(python_version):
         assert 'Self' not in output, (
             f"unexpected typing.Self in {python_version}-target output:\n{output}"
         )
+
+
+def test_widen_flattens_unions_for_lub(tmp_cwd):
+    """Phase 2 widens an abstract parent's args from its children. When one
+    child has already merged its observations into a union (e.g. `int | str`)
+    and another child has a type that is a subtype of one component of that
+    union (e.g. `bool ⊆ int`), the merge set passed to `merged_types` looks
+    like `{int | str, bool}`. Without flattening unions on entry to
+    `_merge_set`, lub treats the union opaquely (its `type_obj` isn't a real
+    `type`) and never compares `bool` against `int`, so the parent ends up
+    with `int | str | bool` instead of collapsing `bool` into `int`.
+    """
+    Path("t.py").write_text(textwrap.dedent("""\
+        from abc import ABC, abstractmethod
+        class Base(ABC):
+            @abstractmethod
+            def m(self, x): ...
+        class C1(Base):
+            def m(self, x):
+                pass
+        class C2(Base):
+            def m(self, x):
+                pass
+        C1().m(1)
+        C1().m("a")
+        C2().m(True)
+        """))
+
+    rt_run('--python-version=3.11', 't.py')
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+
+    # With flattening, the merge set becomes {int, str, bool}; pairwise lub
+    # collapses bool into int, leaving int|str. Without flattening, bool
+    # survives and the annotation is `int|bool|str` (or similar order).
+    assert get_function(code, 'Base.m') == textwrap.dedent("""\
+        @abstractmethod
+        def m(self: Self, x: int|str) -> None: ...
+    """)
 
 
 def test_returns_or_yields_generator():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7665,7 +7665,9 @@ def test_accessed_attributes_survive_collect_process():
     # f only accesses .greet() (inherited, not overridden), so Sub should
     # simplify to Base.  This requires accessed_attributes to survive the
     # .rt round-trip.
-    assert 'Base' in get_function(code, 'f')
+    func = get_function(code, 'f')
+    assert func is not None
+    assert 'Base' in func
 
 
 def test_parent_type_propagation_classmethod():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7634,6 +7634,40 @@ def test_self_detection_through_collect_and_process():
     """)
 
 
+def test_accessed_attributes_survive_collect_process():
+    """accessed_attributes must survive the --only-collect / process
+    round-trip so that attribute-based simplification works."""
+    # Types in an imported module so LoadTypeObjT can resolve them.
+    # Sub inherits greet() without overriding, and adds extra() which
+    # Base lacks.  Without accessed_attributes, lub's dir() intersection
+    # includes extra(), blocking generalization to Base.
+    Path("mylib.py").write_text(textwrap.dedent("""\
+        class Base:
+            def greet(self): return "hi"
+
+        class Sub(Base):
+            def extra(self): pass  # not on Base; greet() inherited
+    """))
+    Path("t.py").write_text(textwrap.dedent("""\
+        from mylib import Sub
+
+        def f(x):
+            return x.greet()
+
+        f(Sub())
+    """))
+
+    rt_run('--only-collect', 't.py')
+    rt_run('process')
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+
+    # f only accesses .greet() (inherited, not overridden), so Sub should
+    # simplify to Base.  This requires accessed_attributes to survive the
+    # .rt round-trip.
+    assert 'Base' in get_function(code, 'f')
+
+
 def test_parent_type_propagation_classmethod():
     """Unobserved parent classmethod gets arg types from child."""
     Path("t.py").write_text(textwrap.dedent("""\

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2669,7 +2669,6 @@ def test_simplify_uses_accessed_attributes():
     """)
 
 
-@pytest.mark.xfail(reason="On 3.13+ Linux, pathlib._local.Path isn't remapped; needs TypeMap serialization")
 def test_simplify_single_type_with_accessed_attributes():
     """Even with a single observed type, accessed attributes can simplify it
     to a more general base. Path('.') produces PosixPath at runtime, but if

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2725,8 +2725,9 @@ def test_lub_single_type_with_accessed_attributes():
     code = cst.parse_module(output)
 
     func = get_function(code, 'get_name')
-    # Should be Path or PurePath, not PosixPath
-    assert 'PosixPath' not in func
+    assert func is not None
+    # Should simplify to Path or PurePath (a base of PosixPath that has .name).
+    assert 'p: Path' in func or 'p: PurePath' in func, func
 
 
 def test_lub_local_variable_uses_accessed_attributes():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2796,17 +2796,11 @@ def test_direct_return_uses_typeshed_return(tmp_cwd):
     assert "-> Path" in output, output
 
 
-@pytest.mark.xfail(
-    reason="needs typeshed lookup: Path.cwd resolves to a classmethod, not "
-           "a type, so the live-frame resolution can't supply a ceiling. "
-           "Typeshed declares Path.cwd() -> Self (= Path).",
-)
 def test_var_assigned_typeshed_factory_uses_declared_return(tmp_cwd):
     """A variable assigned the result of a typeshed-known factory (a callable
-    that is not itself a type — here a classmethod) should still get the
-    typeshed-declared return type as its ceiling. Phase A only resolves
-    callees that are `type` instances; extending to typeshed signature
-    lookup would handle the factory case."""
+    that isn't itself a type — here a classmethod) gets the typeshed-declared
+    return type as its ceiling. Path.cwd is declared `-> Self`; since the
+    walk passes through Path, Self resolves to Path."""
     Path("t.py").write_text(textwrap.dedent("""\
         from pathlib import Path
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2705,12 +2705,10 @@ def test_lub_uses_accessed_attributes():
     """)
 
 
-def test_lub_single_type_with_accessed_attributes():
-    """Even with a single observed type, accessed attributes can simplify it
-    to a more general base. Path('.') produces PosixPath at runtime, but if
-    the function only accesses .name (from PurePath), the annotation should
-    use a more general type.
-    """
+@pytest.mark.xfail(reason="PosixPath is platform-specific; needs generalization to Path")
+def test_lub_single_type_public_stays():
+    """A single public observed type should not be generalized to a base,
+    even with accessed_attributes. Only private types get de-privatized."""
     Path("t.py").write_text(textwrap.dedent("""\
         from pathlib import Path
 
@@ -2726,92 +2724,35 @@ def test_lub_single_type_with_accessed_attributes():
 
     func = get_function(code, 'get_name')
     assert func is not None
-    # Should simplify to Path or PurePath (a base of PosixPath that has .name).
-    assert 'p: Path' in func or 'p: PurePath' in func, func
-
-
-def test_no_use_attribute_simplification_disables_simplification():
-    """With --no-use-attribute-simplification, the static-analysis-driven
-    simplification should not run; the parameter keeps its observed concrete
-    type instead of being widened to a base via accessed_attributes."""
-    Path("t.py").write_text(textwrap.dedent("""\
-        class Base:
-            name = ""
-
-        class Derived(Base):
-            extra = ""
-
-        def get_name(p):
-            return p.name
-
-        get_name(Derived())
-        """))
-
-    rt_run('--no-use-attribute-simplification', 't.py')
-    output = Path("t.py").read_text()
-    code = cst.parse_module(output)
-
-    func = get_function(code, 'get_name')
-    assert func is not None
-    # Without the simplification, p stays as the observed Derived (not Base).
-    assert 'Derived' in func, func
+    # PosixPath is public — stays as the concrete observed type.
+    assert 'PosixPath' in func or 'WindowsPath' in func or 'p: Path' in func, func
 
 
 def test_lub_local_variable_uses_accessed_attributes():
-    """Same simplification should apply to local variables as to args:
-    a local that only accesses an attribute defined on a base class
-    should be annotated as that base, not the observed subclass.
+    """Attribute-based simplification should apply to local variables as to args:
+    a local whose private type only accesses attributes on a public base
+    should be de-privatized to that base.
     """
     Path("t.py").write_text(textwrap.dedent("""\
         class Base:
             name = ""
 
-        class Derived(Base):
+        class _Derived(Base):
             extra = ""
 
         def f(p):
             y = p
             return y.name
 
-        f(Derived())
+        f(_Derived())
         """))
 
     rt_run('t.py')
     output = Path("t.py").read_text()
 
-    # The local 'y' only accesses .name (on Base), so it should be
-    # simplified to Base, not left as the observed Derived.
-    assert 'y: "Derived"' not in output and 'y: Derived' not in output, (
-        f"local 'y' annotation should be simplified to Base, got:\n{output}"
-    )
-
-
-def test_lub_module_variable_uses_accessed_attributes():
-    """Module-level variables should also be simplified using accessed
-    attributes — same mechanism as args and local variables.
-    """
-    Path("t.py").write_text(textwrap.dedent("""\
-        class Base:
-            name = ""
-
-        class Derived(Base):
-            extra = ""
-
-        g = Derived()
-
-        def f():
-            return g.name
-
-        f()
-        """))
-
-    rt_run('t.py')
-    output = Path("t.py").read_text()
-
-    # The module-level 'g' only has .name accessed (in f), so it should be
-    # simplified to Base, not left as the observed Derived.
-    assert 'g: Derived' not in output and 'g: "Derived"' not in output, (
-        f"module 'g' annotation should be simplified to Base, got:\n{output}"
+    # _Derived is private; only .name is accessed on y → de-privatize to Base.
+    assert 'y: Base' in output or 'y: "Base"' in output, (
+        f"local 'y' should de-privatize to Base, got:\n{output}"
     )
 
 
@@ -2819,15 +2760,18 @@ def test_alias_resolution_does_not_leak_across_functions():
     """Same-named variables in different functions should be independent.
     Here `y` in f is aliased to global `g`; `y` in h is just an unrelated
     parameter. h's access to y.extra should NOT be attributed to g.
+
+    Uses a _-prefixed (private) type so that de-privatization fires and the
+    accessed_attributes set actually matters for the outcome.
     """
     Path("t.py").write_text(textwrap.dedent("""\
         class Base:
             name = ""
 
-        class Derived(Base):
+        class _Derived(Base):
             extra = ""
 
-        g = Derived()
+        g = _Derived()
 
         def f():
             y = g
@@ -2837,7 +2781,7 @@ def test_alias_resolution_does_not_leak_across_functions():
             return y.extra
 
         f()
-        h(Derived())
+        h(_Derived())
         """))
 
     rt_run('t.py')
@@ -2845,9 +2789,12 @@ def test_alias_resolution_does_not_leak_across_functions():
 
     # Only .name is accessed on g (via f's alias y = g).
     # h's access on its own parameter y must not leak onto g.
-    # With cross-function alias leakage, g's accessed_attributes would also
-    # include 'extra' — preventing simplification to Base.
-    assert 'g: Derived' not in output and 'g: "Derived"' not in output, output
+    # With correct scoping, g de-privatizes to Base (only .name accessed).
+    # With leaking, g's accessed_attributes would also include 'extra',
+    # blocking de-privatization (Base doesn't have extra).
+    assert 'g: Base' in output or 'g: "Base"' in output, (
+        f"g should de-privatize to Base (only .name accessed), got:\n{output}"
+    )
 
 
 @pytest.mark.xfail(
@@ -2862,17 +2809,19 @@ def test_lub_class_attribute_uses_accessed_attributes():
     This requires capturing chained attribute accesses (Attribute(Attribute(
     Name('self'), 'x'), 'append')) which the current visit_Attribute doesn't
     handle (it only records when node.value is a Name).
+
+    Uses _-prefixed types so de-privatization fires.
     """
     Path("t.py").write_text(textwrap.dedent("""\
         class Base:
             name = ""
 
-        class Derived(Base):
+        class _Derived(Base):
             extra = ""
 
         class C:
             def __init__(self):
-                self.x = Derived()
+                self.x = _Derived()
 
             def use(self):
                 return self.x.name
@@ -2884,9 +2833,9 @@ def test_lub_class_attribute_uses_accessed_attributes():
     rt_run('t.py')
     output = Path("t.py").read_text()
 
-    # The class attribute 'x' only has .name accessed, so it should be
-    # simplified to Base, not left as the observed Derived.
-    assert 'x: Derived' not in output and 'x: "Derived"' not in output, output
+    # The class attribute 'x' only has .name accessed, so _Derived should
+    # de-privatize to Base, not stay as the private _Derived.
+    assert 'x: _Derived' not in output and 'x: "_Derived"' not in output, output
 
 
 def test_nested_callable_resolution():
@@ -7676,24 +7625,24 @@ def test_self_detection_through_collect_and_process():
 def test_accessed_attributes_survive_collect_process():
     """accessed_attributes must survive the --only-collect / process
     round-trip so that attribute-based simplification works."""
-    # Types in an imported module so LoadTypeObjT can resolve them.
-    # Sub inherits greet() without overriding, and adds extra() which
-    # Base lacks.  Without accessed_attributes, lub's dir() intersection
-    # includes extra(), blocking generalization to Base.
+    # Uses _-prefixed type so de-privatization fires.
+    # _Sub inherits greet() without overriding, and adds extra() which
+    # Base lacks.  Without accessed_attributes, the dir() fallback
+    # includes extra(), blocking de-privatization to Base.
     Path("mylib.py").write_text(textwrap.dedent("""\
         class Base:
             def greet(self): return "hi"
 
-        class Sub(Base):
+        class _Sub(Base):
             def extra(self): pass  # not on Base; greet() inherited
     """))
     Path("t.py").write_text(textwrap.dedent("""\
-        from mylib import Sub
+        from mylib import _Sub
 
         def f(x):
             return x.greet()
 
-        f(Sub())
+        f(_Sub())
     """))
 
     rt_run('--only-collect', 't.py')
@@ -7701,9 +7650,9 @@ def test_accessed_attributes_survive_collect_process():
     output = Path("t.py").read_text()
     code = cst.parse_module(output)
 
-    # f only accesses .greet() (inherited, not overridden), so Sub should
-    # simplify to Base.  This requires accessed_attributes to survive the
-    # .rt round-trip.
+    # f only accesses .greet() (inherited, not overridden), so _Sub should
+    # de-privatize to Base.  This requires accessed_attributes to survive
+    # the .rt round-trip.
     func = get_function(code, 'f')
     assert func is not None
     assert 'Base' in func

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2756,6 +2756,71 @@ def test_lub_local_variable_uses_accessed_attributes():
     )
 
 
+def test_var_assigned_constructor_uses_typeshed_return(tmp_cwd):
+    """A variable assigned the result of a typeshed-known constructor gets
+    the constructor's declared return as its annotation, not the runtime
+    subtype. When the variable is returned, the function's return widens
+    consistently so mypy stays happy. Path('/tmp') returns PosixPath at
+    runtime; typeshed declares Path. No attribute access so the existing
+    accessed-attribute MRO walk does not fire."""
+    Path("t.py").write_text(textwrap.dedent("""\
+        from pathlib import Path
+
+        def f():
+            p = Path("/tmp")
+            return p
+        f()
+        """))
+
+    rt_run('t.py')
+    output = Path("t.py").read_text()
+
+    assert "p: Path" in output, output
+    assert "-> Path" in output, output
+
+
+def test_direct_return_uses_typeshed_return(tmp_cwd):
+    """A function directly returning Constructor(...) gets the typeshed-
+    declared return type as its return annotation."""
+    Path("t.py").write_text(textwrap.dedent("""\
+        from pathlib import Path
+
+        def f():
+            return Path("/tmp")
+        f()
+        """))
+
+    rt_run('t.py')
+    output = Path("t.py").read_text()
+
+    assert "-> Path" in output, output
+
+
+@pytest.mark.xfail(
+    reason="needs typeshed lookup: Path.cwd resolves to a classmethod, not "
+           "a type, so the live-frame resolution can't supply a ceiling. "
+           "Typeshed declares Path.cwd() -> Self (= Path).",
+)
+def test_var_assigned_typeshed_factory_uses_declared_return(tmp_cwd):
+    """A variable assigned the result of a typeshed-known factory (a callable
+    that is not itself a type — here a classmethod) should still get the
+    typeshed-declared return type as its ceiling. Phase A only resolves
+    callees that are `type` instances; extending to typeshed signature
+    lookup would handle the factory case."""
+    Path("t.py").write_text(textwrap.dedent("""\
+        from pathlib import Path
+
+        def f():
+            p = Path.cwd()
+        f()
+        """))
+
+    rt_run('t.py')
+    output = Path("t.py").read_text()
+
+    assert "p: Path" in output, output
+
+
 def test_alias_resolution_does_not_leak_across_functions():
     """Same-named variables in different functions should be independent.
     Here `y` in f is aliased to global `g`; `y` in h is just an unrelated

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -8134,3 +8134,27 @@ def test_main_module_defined_class_not_leaked():
     assert "MyWidget" not in output, (
         f"runner-defined MyWidget leaked into pkg's annotations:\n{output}"
     )
+
+
+@pytest.mark.dont_run_mypy
+def test_typeddict_does_not_crash_constructor_ceiling():
+    """TypedDict overrides __subclasscheck__ to raise TypeError.
+    The constructor ceiling must not crash on TypedDict-typed variables."""
+    Path("t.py").write_text(textwrap.dedent("""\
+        from typing import TypedDict
+
+        class Config(TypedDict):
+            name: str
+            value: int
+
+        def make_config():
+            c = Config(name="x", value=1)
+            return c
+
+        make_config()
+    """))
+
+    rt_run('t.py')
+    output = Path("t.py").read_text()
+    # Just verify it doesn't crash; the annotation content is secondary.
+    assert 'def make_config' in output

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2705,6 +2705,138 @@ def test_lub_single_type_with_accessed_attributes():
     assert 'PosixPath' not in func
 
 
+def test_lub_local_variable_uses_accessed_attributes():
+    """Same simplification should apply to local variables as to args:
+    a local that only accesses an attribute defined on a base class
+    should be annotated as that base, not the observed subclass.
+    """
+    Path("t.py").write_text(textwrap.dedent("""\
+        class Base:
+            name = ""
+
+        class Derived(Base):
+            extra = ""
+
+        def f(p):
+            y = p
+            return y.name
+
+        f(Derived())
+        """))
+
+    rt_run('t.py')
+    output = Path("t.py").read_text()
+
+    # The local 'y' only accesses .name (on Base), so it should be
+    # simplified to Base, not left as the observed Derived.
+    assert 'y: "Derived"' not in output and 'y: Derived' not in output, (
+        f"local 'y' annotation should be simplified to Base, got:\n{output}"
+    )
+
+
+def test_lub_module_variable_uses_accessed_attributes():
+    """Module-level variables should also be simplified using accessed
+    attributes — same mechanism as args and local variables.
+    """
+    Path("t.py").write_text(textwrap.dedent("""\
+        class Base:
+            name = ""
+
+        class Derived(Base):
+            extra = ""
+
+        g = Derived()
+
+        def f():
+            return g.name
+
+        f()
+        """))
+
+    rt_run('t.py')
+    output = Path("t.py").read_text()
+
+    # The module-level 'g' only has .name accessed (in f), so it should be
+    # simplified to Base, not left as the observed Derived.
+    assert 'g: Derived' not in output and 'g: "Derived"' not in output, (
+        f"module 'g' annotation should be simplified to Base, got:\n{output}"
+    )
+
+
+def test_alias_resolution_does_not_leak_across_functions():
+    """Same-named variables in different functions should be independent.
+    Here `y` in f is aliased to global `g`; `y` in h is just an unrelated
+    parameter. h's access to y.extra should NOT be attributed to g.
+    """
+    Path("t.py").write_text(textwrap.dedent("""\
+        class Base:
+            name = ""
+
+        class Derived(Base):
+            extra = ""
+
+        g = Derived()
+
+        def f():
+            y = g
+            return y.name
+
+        def h(y):
+            return y.extra
+
+        f()
+        h(Derived())
+        """))
+
+    rt_run('t.py')
+    output = Path("t.py").read_text()
+
+    # Only .name is accessed on g (via f's alias y = g).
+    # h's access on its own parameter y must not leak onto g.
+    # With cross-function alias leakage, g's accessed_attributes would also
+    # include 'extra' — preventing simplification to Base.
+    assert 'g: Derived' not in output and 'g: "Derived"' not in output, output
+
+
+@pytest.mark.xfail(
+    reason="class-attribute simplification needs chained attribute path tracking; "
+           "see CodeVars.attributes / class_attributes flow"
+)
+def test_lub_class_attribute_uses_accessed_attributes():
+    """Class attributes should also be simplified using accessed attributes —
+    e.g., `self.x.append(...)` should record `append` as accessed on attribute
+    x, allowing simplification from the runtime type to a base that has append.
+
+    This requires capturing chained attribute accesses (Attribute(Attribute(
+    Name('self'), 'x'), 'append')) which the current visit_Attribute doesn't
+    handle (it only records when node.value is a Name).
+    """
+    Path("t.py").write_text(textwrap.dedent("""\
+        class Base:
+            name = ""
+
+        class Derived(Base):
+            extra = ""
+
+        class C:
+            def __init__(self):
+                self.x = Derived()
+
+            def use(self):
+                return self.x.name
+
+        c = C()
+        c.use()
+        """))
+
+    rt_run('t.py')
+    output = Path("t.py").read_text()
+
+    # The class attribute 'x' only has .name accessed, so it should be
+    # simplified to Base, not left as the observed Derived.
+    assert 'x: Derived' not in output and 'x: "Derived"' not in output, output
+
+
 def test_nested_callable_resolution():
     """When a function returns another function that itself returns a function,
     the nested Callable types should be fully resolved.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2645,8 +2645,8 @@ def test_discovered_function_type_in_yield():
     """)
 
 
-def test_simplify_uses_accessed_attributes():
-    """When a function accesses an attribute on a parameter, simplify() should use
+def test_lub_uses_accessed_attributes():
+    """When a function accesses an attribute on a parameter, lub should use
     that to make better type merging decisions — merging to the common base that
     has the accessed attribute rather than relying on dir() overlap.
     """
@@ -2681,7 +2681,7 @@ def test_simplify_uses_accessed_attributes():
     """)
 
 
-def test_simplify_single_type_with_accessed_attributes():
+def test_lub_single_type_with_accessed_attributes():
     """Even with a single observed type, accessed attributes can simplify it
     to a more general base. Path('.') produces PosixPath at runtime, but if
     the function only accesses .name (from PurePath), the annotation should

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2669,6 +2669,7 @@ def test_simplify_uses_accessed_attributes():
     """)
 
 
+@pytest.mark.xfail(reason="On 3.13+ Linux, pathlib._local.Path isn't remapped; needs TypeMap serialization")
 def test_simplify_single_type_with_accessed_attributes():
     """Even with a single observed type, accessed attributes can simplify it
     to a more general base. Path('.') produces PosixPath at runtime, but if

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4672,18 +4672,20 @@ def test_empty_container(python_version, opt):
     output = Path("t.py").read_text()
     code = cst.parse_module(output)
 
+    # f accesses only __len__; lub picks Collection as the tightest ABC that
+    # covers both list and dict — preferred over keeping them as a union.
     if python_version == "3.11" and opt == '--use-typing-never':
         assert get_function(code, 'f', body=True) == textwrap.dedent("""\
-            def f(x: dict[Never, Never]|list[Never]) -> int:
-                y: dict[Never, Never]|list[Never] = x
+            def f(x: Collection[Never]) -> int:
+                y: Collection[Never] = x
                 return len(y)
         """)
         assert "g: dict[Never, Never] = {}" in output
 
     else:
         assert get_function(code, 'f', body=True) == textwrap.dedent("""\
-            def f(x: dict[Any, Any]|list[Any]) -> int:
-                y: dict[Any, Any]|list[Any] = x
+            def f(x: Collection[Any]) -> int:
+                y: Collection[Any] = x
                 return len(y)
         """)
         assert "g: dict[Any, Any] = {}" in output

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2730,6 +2730,33 @@ def test_lub_single_type_with_accessed_attributes():
     assert 'p: Path' in func or 'p: PurePath' in func, func
 
 
+def test_no_use_attribute_simplification_disables_simplification():
+    """With --no-use-attribute-simplification, the static-analysis-driven
+    simplification should not run; the parameter keeps its observed concrete
+    type instead of being widened to a base via accessed_attributes."""
+    Path("t.py").write_text(textwrap.dedent("""\
+        class Base:
+            name = ""
+
+        class Derived(Base):
+            extra = ""
+
+        def get_name(p):
+            return p.name
+
+        get_name(Derived())
+        """))
+
+    rt_run('--no-use-attribute-simplification', 't.py')
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+
+    func = get_function(code, 'get_name')
+    assert func is not None
+    # Without the simplification, p stays as the observed Derived (not Base).
+    assert 'Derived' in func, func
+
+
 def test_lub_local_variable_uses_accessed_attributes():
     """Same simplification should apply to local variables as to args:
     a local that only accesses an attribute defined on a base class

--- a/tests/test_typeshed.py
+++ b/tests/test_typeshed.py
@@ -10,8 +10,8 @@ def test_names_builtin():
         def f(x: int): pass
     """))
     pars = get_func_params(code, "foo", "f")
-    assert pars == [TypeInfo('', 'int')]
-    assert pars[0].type_obj is int
+    assert pars == [TypeInfo('', 'int'), None]
+    assert pars[0] is not None and pars[0].type_obj is int
 
 
 def test_names_import():
@@ -24,6 +24,7 @@ def test_names_import():
     assert get_func_params(code, "foo", "f") == [
         TypeInfo('a.b', 'c.d'),
         TypeInfo('b.c', 'd.e'),
+        None,
     ]
 
 
@@ -37,6 +38,7 @@ def test_names_import_from():
         TypeInfo('a.b', 'c.d'),
         TypeInfo('a.b', 'd.f.g'),
         TypeInfo('a.b', 'e'),
+        None,
     ]
 
 
@@ -48,7 +50,8 @@ def test_names_local():
         def f(x: A.B): pass
     """))
     assert get_func_params(code, "foo", "f") == [
-        TypeInfo("foo", "A.B")
+        TypeInfo("foo", "A.B"),
+        None,
     ]
 
 
@@ -61,7 +64,8 @@ def test_names_local_override():
         def f(x: int): pass
     """))
     assert get_func_params(code, "foo", "f") == [
-        TypeInfo("foo", "int")
+        TypeInfo("foo", "int"),
+        None,
     ]
 
 
@@ -70,7 +74,8 @@ def test_names_undefined():
         def f(x: "dunno"): pass
     """))
     assert get_func_params(code, "foo", "f") == [
-        TypeInfo("foo", "dunno")
+        TypeInfo("foo", "dunno"),
+        None,
     ]
 
 
@@ -78,12 +83,12 @@ def test_type_parsing():
     code = cst.parse_module(textwrap.dedent("""\
         def f(x): pass
     """))
-    assert get_func_params(code, "foo", "f") == [None]
+    assert get_func_params(code, "foo", "f") == [None, None]
 
     code = cst.parse_module(textwrap.dedent("""\
         def f(x: int): pass
     """))
-    assert get_func_params(code, "foo", "f") == [TypeInfo('', 'int')]
+    assert get_func_params(code, "foo", "f") == [TypeInfo('', 'int'), None]
 
     code = cst.parse_module(textwrap.dedent("""\
         def f(x: list[int]): pass
@@ -91,7 +96,8 @@ def test_type_parsing():
     assert get_func_params(code, "foo", "f") == [
         TypeInfo('', 'list', args=(
             TypeInfo('', 'int'),
-        ))
+        )),
+        None,
     ]
 
     code = cst.parse_module(textwrap.dedent("""\
@@ -101,7 +107,8 @@ def test_type_parsing():
         TypeInfo.from_set({
             TypeInfo('', 'int'),
             TypeInfo('', 'str'),
-        })
+        }),
+        None,
     ]
 
     code = cst.parse_module(textwrap.dedent("""\
@@ -111,7 +118,8 @@ def test_type_parsing():
         TypeInfo.from_set({
             TypeInfo('', 'int'),
             TypeInfo('', 'str'),
-        })
+        }),
+        None,
     ]
 
     code = cst.parse_module(textwrap.dedent("""\
@@ -123,7 +131,8 @@ def test_type_parsing():
                 TypeInfo('', 'int'),
                 TypeInfo('', 'str'),
             }),
-        ))
+        )),
+        None,
     ]
 
     code = cst.parse_module(textwrap.dedent("""\
@@ -136,7 +145,8 @@ def test_type_parsing():
                 TypeInfo('', 'int'),
             ]),
             TypeInfo('', 'None'),
-        ))
+        )),
+        None,
     ]
 
     code = cst.parse_module(textwrap.dedent("""\
@@ -146,7 +156,8 @@ def test_type_parsing():
         TypeInfo('', 'tuple', args=(
             TypeInfo('', 'int'),
             ...
-        ))
+        )),
+        None,
     ]
 
     code = cst.parse_module(textwrap.dedent("""\
@@ -155,7 +166,8 @@ def test_type_parsing():
     assert get_func_params(code, "foo", "f") == [
         TypeInfo('', 'tuple', args=(
             (),
-        ))
+        )),
+        None,
     ]
 
     code = cst.parse_module(textwrap.dedent("""\
@@ -168,7 +180,8 @@ def test_type_parsing():
         TypeInfo('jaxtyping', 'Float16', args=(
             TypeInfo('numpy', 'ndarray'),
             "1 1 1"
-        ))
+        )),
+        None,
     ]
 
 
@@ -176,4 +189,5 @@ def test_from_typeshed():
     assert get_typeshed_func_params("builtins", "object.__eq__") == [
         None,   # self
         TypeInfo.from_type(object),
+        TypeInfo.from_type(bool),  # return type
     ]

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -822,16 +822,14 @@ def test_merged_types_for_variable_different_containers():
 
 
 def test_merged_types_for_variable_different_arity():
-    """Test that generics with different number of args are not merged."""
-    # tuple[int] | tuple[int, str] should stay separate
+    """Different-arity tuples merge to varlen (wider but valid, see test_generalize.py)."""
     result = str(merged_types({
             TypeInfo.from_type(tuple, args=(TypeInfo.from_type(int),)),
             TypeInfo.from_type(tuple, args=(TypeInfo.from_type(int), TypeInfo.from_type(str)))
         },
         for_variable=True
     ))
-    # Check both types are present as separate union members
-    assert result == "tuple[int]|tuple[int, str]" or result == "tuple[int, str]|tuple[int]"
+    assert result == "tuple[int|str, ...]"
 
 
 # =============================================================================

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -777,7 +777,7 @@ def test_merged_types_for_variable_simple():
     ))
 
     # With for_variable=True, should merge type arguments.
-    # bool is a subtype of int, so simplify() further reduces to list[int]
+    # bool is a subtype of int, so lub further reduces to list[int]
     assert "list[int]" == str(merged_types({
             TypeInfo.from_type(list, args=(TypeInfo.from_type(int),)),
             TypeInfo.from_type(list, args=(TypeInfo.from_type(bool),))

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -197,6 +197,21 @@ def test_local_type_module_invalid(monkeypatch, adjust_type_names):
     assert get_type_name(Invalid).module == "does_not_exist"
 
 
+def test_to_name_map_skips_non_string_module():
+    """to_name_map must skip types whose __module__ is not a string (e.g. Cython metaclasses)."""
+    # Simulate a C extension type whose __module__ is a descriptor, not a string
+    bad_type = type('CythonLike', (object,), {})
+    bad_type.__module__ = property(lambda self: 'fake')  # non-string descriptor  # type: ignore
+
+    tm = TypeMap({})
+    # Force-register: _map stores type → [TypeName, ...]
+    tm._map[bad_type] = [('some_module', 'CythonLike')]
+
+    name_map = tm.to_name_map()
+    # bad_type should be skipped — no key with 'CythonLike' in the map
+    assert not any('CythonLike' in k[1] for k in name_map)
+
+
 def test_items_from_typing():
     assert TypeInfo("typing", "Any") == get_type_name(Any)
     assert TypeInfo("typing", "Self") == get_type_name(Self)

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -201,7 +201,7 @@ def test_to_name_map_skips_non_string_module():
     """to_name_map must skip types whose __module__ is not a string (e.g. Cython metaclasses)."""
     # Simulate a C extension type whose __module__ is a descriptor, not a string
     bad_type = type('CythonLike', (object,), {})
-    bad_type.__module__ = property(lambda self: 'fake')  # non-string descriptor  # type: ignore
+    bad_type.__module__ = property(lambda self: 'fake')  # type: ignore[assignment]  # non-string descriptor
 
     tm = TypeMap({})
     # Force-register: _map stores type → [TypeName, ...]

--- a/tests/test_variable_capture.py
+++ b/tests/test_variable_capture.py
@@ -914,3 +914,198 @@ def test_accessed_attributes_non_name_assignment_no_alias():
     # y is not an alias for x — y.name is on y, and x.child is on x
     assert attrs.get("y") == {"name"}
     assert attrs.get("x") == {"child"}
+
+
+# =============================================================================
+# Tests for operator/builtin desugaring to dunder attributes
+# =============================================================================
+
+def test_desugar_subscript_getitem():
+    """x[i] → __getitem__ on x."""
+    src = textwrap.dedent("""
+        def f(x, i):
+            return x[i]
+        """)
+    m = map_variables(src)
+    attrs = get_accessed_attributes(m, "f")
+    assert "__getitem__" in attrs.get("x", set())
+
+
+def test_desugar_subscript_setitem():
+    """x[i] = v → __setitem__ on x."""
+    src = textwrap.dedent("""
+        def f(x, i, v):
+            x[i] = v
+        """)
+    m = map_variables(src)
+    attrs = get_accessed_attributes(m, "f")
+    assert "__setitem__" in attrs.get("x", set())
+
+
+def test_desugar_subscript_delitem():
+    """del x[i] → __delitem__ on x."""
+    src = textwrap.dedent("""
+        def f(x, i):
+            del x[i]
+        """)
+    m = map_variables(src)
+    attrs = get_accessed_attributes(m, "f")
+    assert "__delitem__" in attrs.get("x", set())
+
+
+def test_desugar_for_iter():
+    """for item in x → __iter__ on x."""
+    src = textwrap.dedent("""
+        def f(x):
+            for item in x:
+                pass
+        """)
+    m = map_variables(src)
+    attrs = get_accessed_attributes(m, "f")
+    assert "__iter__" in attrs.get("x", set())
+
+
+def test_desugar_comprehension_iter():
+    """[... for item in x] → __iter__ on x."""
+    src = textwrap.dedent("""
+        def f(x):
+            return [item for item in x]
+        """)
+    m = map_variables(src)
+    attrs = get_accessed_attributes(m, "f")
+    assert "__iter__" in attrs.get("x", set())
+
+
+def test_desugar_binop():
+    """x + y → __add__ on x."""
+    src = textwrap.dedent("""
+        def f(x, y):
+            return x + y
+        """)
+    m = map_variables(src)
+    attrs = get_accessed_attributes(m, "f")
+    assert "__add__" in attrs.get("x", set())
+
+
+def test_desugar_augassign():
+    """x += y → __iadd__ on x."""
+    src = textwrap.dedent("""
+        def f(x, y):
+            x += y
+        """)
+    m = map_variables(src)
+    attrs = get_accessed_attributes(m, "f")
+    assert "__iadd__" in attrs.get("x", set())
+
+
+def test_desugar_unaryop():
+    """-x → __neg__ on x."""
+    src = textwrap.dedent("""
+        def f(x):
+            return -x
+        """)
+    m = map_variables(src)
+    attrs = get_accessed_attributes(m, "f")
+    assert "__neg__" in attrs.get("x", set())
+
+
+def test_desugar_compare():
+    """x < y → __lt__ on x."""
+    src = textwrap.dedent("""
+        def f(x, y):
+            return x < y
+        """)
+    m = map_variables(src)
+    attrs = get_accessed_attributes(m, "f")
+    assert "__lt__" in attrs.get("x", set())
+
+
+def test_desugar_contains():
+    """item in x → __contains__ on x (right operand)."""
+    src = textwrap.dedent("""
+        def f(item, x):
+            return item in x
+        """)
+    m = map_variables(src)
+    attrs = get_accessed_attributes(m, "f")
+    assert "__contains__" in attrs.get("x", set())
+
+
+def test_desugar_with():
+    """with x: → __enter__ and __exit__ on x."""
+    src = textwrap.dedent("""
+        def f(x):
+            with x:
+                pass
+        """)
+    m = map_variables(src)
+    attrs = get_accessed_attributes(m, "f")
+    assert "__enter__" in attrs.get("x", set())
+    assert "__exit__" in attrs.get("x", set())
+
+
+def test_desugar_builtin_len():
+    """len(x) → __len__ on x."""
+    src = textwrap.dedent("""
+        def f(x):
+            return len(x)
+        """)
+    m = map_variables(src)
+    attrs = get_accessed_attributes(m, "f")
+    assert "__len__" in attrs.get("x", set())
+
+
+def test_desugar_builtin_iter():
+    """iter(x) → __iter__ on x."""
+    src = textwrap.dedent("""
+        def f(x):
+            return iter(x)
+        """)
+    m = map_variables(src)
+    attrs = get_accessed_attributes(m, "f")
+    assert "__iter__" in attrs.get("x", set())
+
+
+def test_desugar_builtin_reversed():
+    """reversed(x) → __reversed__ on x."""
+    src = textwrap.dedent("""
+        def f(x):
+            return reversed(x)
+        """)
+    m = map_variables(src)
+    attrs = get_accessed_attributes(m, "f")
+    assert "__reversed__" in attrs.get("x", set())
+
+
+def test_desugar_builtin_shadowed():
+    """If len is shadowed by a local, don't desugar."""
+    src = textwrap.dedent("""
+        def f(x):
+            len = lambda y: 42
+            return len(x)
+        """)
+    m = map_variables(src)
+    attrs = get_accessed_attributes(m, "f")
+    assert "__len__" not in attrs.get("x", set())
+
+
+def test_desugar_builtin_shadowed_by_param():
+    """If len is a parameter name, don't desugar."""
+    src = textwrap.dedent("""
+        def f(len, x):
+            return len(x)
+        """)
+    m = map_variables(src)
+    attrs = get_accessed_attributes(m, "f")
+    assert "__len__" not in attrs.get("x", set())
+
+
+def test_desugar_await():
+    """await x → __await__ on x."""
+    src = textwrap.dedent("""
+        async def f(x):
+            return await x
+        """)
+    m = map_variables(src)
+    attrs = get_accessed_attributes(m, "f")
+    assert "__await__" in attrs.get("x", set())

--- a/tests/test_variable_capture.py
+++ b/tests/test_variable_capture.py
@@ -377,10 +377,11 @@ def test_match_as_simple_name_only(map_variables):
 
 
 def get_initial_constants(mapping: dict[types.CodeType, variables.CodeVars], name: str):
-    """Returns initial constants mapping by code name (variables where value is not None)."""
+    """Returns initial constants mapping by code name (variables whose value
+    is a Python type — i.e. recorded from a literal constant assignment)."""
     for co, codevars in mapping.items():
         if co.co_qualname == name:
-            return {k: v for k, v in codevars.variables.items() if v is not None}
+            return {k: v for k, v in codevars.variables.items() if isinstance(v, type)}
     return {}
 
 
@@ -1191,3 +1192,197 @@ def test_desugar_await(map_variables, track_attributes):
     m = map_variables(src)
     attrs = get_accessed_attributes(m, "f")
     assert "__await__" in attrs.get("x", set())
+
+
+# =============================================================================
+# Tests for variable-constructor / return-constructor capture
+# =============================================================================
+
+def get_variable(mapping, name, var):
+    """Return the `variables[var]` entry for code object `name`."""
+    for co, codevars in mapping.items():
+        if co.co_qualname == name:
+            return codevars.variables.get(var)
+    return None
+
+
+def get_return_constructor(mapping, name):
+    """Return `return_constructor` for code object `name`."""
+    for co, codevars in mapping.items():
+        if co.co_qualname == name:
+            return codevars.return_constructor
+    return None
+
+
+def test_constructor_simple_name(map_variables):
+    """`p = Path(...)` records Constructor(['Path']) on p."""
+    src = textwrap.dedent("""
+        def f():
+            p = Path("/tmp")
+        """)
+    m = map_variables(src)
+    assert get_variable(m, "f", "p") == variables.Constructor(parts=["Path"])
+
+
+def test_constructor_attribute_chain(map_variables):
+    """`p = pathlib.Path(...)` records Constructor(['pathlib', 'Path'])."""
+    src = textwrap.dedent("""
+        def f():
+            p = pathlib.Path("/tmp")
+        """)
+    m = map_variables(src)
+    assert get_variable(m, "f", "p") == variables.Constructor(parts=["pathlib", "Path"])
+
+
+def test_constructor_consistent_reassignment_keeps(map_variables):
+    """Two assignments with the same callee → Constructor preserved."""
+    src = textwrap.dedent("""
+        def f():
+            p = Path("/a")
+            p = Path("/b")
+        """)
+    m = map_variables(src)
+    assert get_variable(m, "f", "p") == variables.Constructor(parts=["Path"])
+
+
+def test_constructor_inconsistent_callee_kills(map_variables):
+    """Two assignments with different callees → entry killed (None).
+    Sibling `q` (not reassigned) must still carry its Constructor — that
+    asserts the kill is from mismatch, not from the impl being absent."""
+    src = textwrap.dedent("""
+        def f():
+            p = Path("/a")
+            p = PurePath("/b")
+            q = Path("/c")
+        """)
+    m = map_variables(src)
+    assert get_variable(m, "f", "p") is None
+    assert get_variable(m, "f", "q") == variables.Constructor(parts=["Path"])
+
+
+def test_constructor_non_call_reassignment_kills(map_variables):
+    """A non-Call reassignment after a Constructor entry kills it."""
+    src = textwrap.dedent("""
+        def f():
+            p = Path("/a")
+            p = something
+            q = Path("/c")
+        """)
+    m = map_variables(src)
+    assert get_variable(m, "f", "p") is None
+    assert get_variable(m, "f", "q") == variables.Constructor(parts=["Path"])
+
+
+def test_constructor_dynamic_call_target_no_entry(map_variables):
+    """`p = factories[i](...)` (non-Name/Attribute func) records None."""
+    src = textwrap.dedent("""
+        def f():
+            p = factories[i]("/tmp")
+            q = Path("/c")
+        """)
+    m = map_variables(src)
+    assert get_variable(m, "f", "p") is None
+    assert get_variable(m, "f", "q") == variables.Constructor(parts=["Path"])
+
+
+def test_constant_assignment_records_type(map_variables):
+    """Existing semantics preserved: `x = 1` records int."""
+    src = textwrap.dedent("""
+        def f():
+            x = 1
+        """)
+    m = map_variables(src)
+    assert get_variable(m, "f", "x") is int
+
+
+def test_return_direct_call(map_variables):
+    """`return Path(...)` sets return_constructor."""
+    src = textwrap.dedent("""
+        def f():
+            return Path("/tmp")
+        """)
+    m = map_variables(src)
+    assert get_return_constructor(m, "f") == variables.Constructor(parts=["Path"])
+
+
+def test_return_variable_with_constructor(map_variables):
+    """`return p` where p was assigned Path(...) → return_constructor set."""
+    src = textwrap.dedent("""
+        def f():
+            p = Path("/tmp")
+            return p
+        """)
+    m = map_variables(src)
+    assert get_return_constructor(m, "f") == variables.Constructor(parts=["Path"])
+
+
+def test_return_bare_kills(map_variables):
+    """A bare `return` kills return_constructor.
+    Sibling `g` confirms the impl is live (otherwise both would be None
+    for the wrong reason)."""
+    src = textwrap.dedent("""
+        def f():
+            if cond:
+                return Path("/tmp")
+            return
+        def g():
+            return Path("/g")
+        """)
+    m = map_variables(src)
+    assert get_return_constructor(m, "f") is None
+    assert get_return_constructor(m, "g") == variables.Constructor(parts=["Path"])
+
+
+def test_return_mismatched_callees_kill(map_variables):
+    """Multiple returns with different callees → return_constructor killed."""
+    src = textwrap.dedent("""
+        def f(x):
+            if x:
+                return Path("/a")
+            return PurePath("/b")
+        def g():
+            return Path("/g")
+        """)
+    m = map_variables(src)
+    assert get_return_constructor(m, "f") is None
+    assert get_return_constructor(m, "g") == variables.Constructor(parts=["Path"])
+
+
+def test_no_returns_no_constructor(map_variables):
+    """Function with no explicit returns → return_constructor stays None."""
+    src = textwrap.dedent("""
+        def f():
+            x = 1
+        def g():
+            return Path("/g")
+        """)
+    m = map_variables(src)
+    assert get_return_constructor(m, "f") is None
+    assert get_return_constructor(m, "g") == variables.Constructor(parts=["Path"])
+
+
+def test_return_variable_without_constructor_kills(map_variables):
+    """`return p` where p is a parameter (no Constructor entry) → killed."""
+    src = textwrap.dedent("""
+        def f(p):
+            return p
+        def g():
+            return Path("/g")
+        """)
+    m = map_variables(src)
+    assert get_return_constructor(m, "f") is None
+    assert get_return_constructor(m, "g") == variables.Constructor(parts=["Path"])
+
+
+def test_inner_function_isolated(map_variables):
+    """An inner function's returns don't leak into the outer's
+    return_constructor, and vice versa."""
+    src = textwrap.dedent("""
+        def outer():
+            def inner():
+                return Path("/inner")
+            return PurePath("/outer")
+        """)
+    m = map_variables(src)
+    assert get_return_constructor(m, "outer") == variables.Constructor(parts=["PurePath"])
+    assert get_return_constructor(m, "outer.<locals>.inner") == variables.Constructor(parts=["Path"])

--- a/tests/test_variable_capture.py
+++ b/tests/test_variable_capture.py
@@ -749,3 +749,168 @@ def test_regular_method_no_cls():
             break
     else:
         assert False, "C.method not found"
+
+
+# =============================================================================
+# Tests for accessed attribute collection
+# =============================================================================
+
+def get_accessed_attributes(mapping: dict[types.CodeType, variables.CodeVars], name: str):
+    """Returns accessed_attributes by code name."""
+    for co, codevars in mapping.items():
+        if co.co_qualname == name:
+            return codevars.accessed_attributes
+    return {}
+
+
+def test_accessed_attributes_simple():
+    """x.foo collects 'foo' on parameter x."""
+    src = textwrap.dedent("""
+        def f(x):
+            return x.name
+        """)
+    m = map_variables(src)
+    attrs = get_accessed_attributes(m, "f")
+    assert attrs.get("x") == {"name"}
+
+
+def test_accessed_attributes_method_call():
+    """x.foo() still collects 'foo' — it's an attribute access followed by a call."""
+    src = textwrap.dedent("""
+        def f(x):
+            return x.process()
+        """)
+    m = map_variables(src)
+    attrs = get_accessed_attributes(m, "f")
+    assert attrs.get("x") == {"process"}
+
+
+def test_accessed_attributes_multiple_vars():
+    """Different attributes on different variables are tracked separately."""
+    src = textwrap.dedent("""
+        def f(x, y):
+            return x.name + y.value
+        """)
+    m = map_variables(src)
+    attrs = get_accessed_attributes(m, "f")
+    assert attrs.get("x") == {"name"}
+    assert attrs.get("y") == {"value"}
+
+
+def test_accessed_attributes_multiple_on_same_var():
+    """Multiple attributes on the same variable are all collected."""
+    src = textwrap.dedent("""
+        def f(x):
+            return x.name + x.value
+        """)
+    m = map_variables(src)
+    attrs = get_accessed_attributes(m, "f")
+    assert attrs.get("x") == {"name", "value"}
+
+
+def test_accessed_attributes_chained():
+    """x.foo.bar collects 'foo' on x (bar is on foo's result, not x)."""
+    src = textwrap.dedent("""
+        def f(x):
+            return x.parent.name
+        """)
+    m = map_variables(src)
+    attrs = get_accessed_attributes(m, "f")
+    assert attrs.get("x") == {"parent"}
+    assert "name" not in attrs.get("x", set())
+
+
+def test_accessed_attributes_includes_writes():
+    """x.foo = val is still an attribute access — the type needs to support it."""
+    src = textwrap.dedent("""
+        def f(x):
+            x.name = "hello"
+        """)
+    m = map_variables(src)
+    attrs = get_accessed_attributes(m, "f")
+    assert "name" in attrs.get("x", set())
+
+
+def test_accessed_attributes_locals():
+    """Attribute access on local variables, not just parameters."""
+    src = textwrap.dedent("""
+        def f():
+            result = get_result()
+            return result.count
+        """)
+    m = map_variables(src)
+    attrs = get_accessed_attributes(m, "f")
+    assert attrs.get("result") == {"count"}
+
+
+def test_accessed_attributes_alias():
+    """y = x; y.name records 'name' on x."""
+    src = textwrap.dedent("""
+        def f(x):
+            y = x
+            return y.name
+        """)
+    m = map_variables(src)
+    attrs = get_accessed_attributes(m, "f")
+    assert "name" in attrs.get("x", set())
+
+
+def test_accessed_attributes_transitive_alias():
+    """z = y; y = x; z still aliases through to x."""
+    src = textwrap.dedent("""
+        def f(x):
+            y = x
+            z = y
+            return z.name
+        """)
+    m = map_variables(src)
+    attrs = get_accessed_attributes(m, "f")
+    assert "name" in attrs.get("x", set())
+
+
+def test_accessed_attributes_alias_reassigned():
+    """Reassignment after alias: conservatively keeps the alias (could be a branch)."""
+    src = textwrap.dedent("""
+        def f(x):
+            y = x
+            y = something_else()
+            return y.name
+        """)
+    m = map_variables(src)
+    attrs = get_accessed_attributes(m, "f")
+    # Without flow analysis, we can't distinguish sequential reassignment from
+    # branches, so we conservatively keep the alias. This over-approximates
+    # (records 'name' on x even though y was reassigned), which is safe —
+    # it just makes simplification slightly more conservative.
+    assert "name" in attrs.get("x", set())
+
+
+def test_accessed_attributes_alias_branch_conservative():
+    """Aliases from different branches are unioned (conservative)."""
+    src = textwrap.dedent("""
+        def f(x, y):
+            if True:
+                z = x
+            else:
+                z = y
+            return z.value
+        """)
+    m = map_variables(src)
+    attrs = get_accessed_attributes(m, "f")
+    # z could be x or y, so 'value' should be recorded on both
+    assert "value" in attrs.get("x", set())
+    assert "value" in attrs.get("y", set())
+
+
+def test_accessed_attributes_non_name_assignment_no_alias():
+    """y = x.child is not an alias — attribute access on y stays on y."""
+    src = textwrap.dedent("""
+        def f(x):
+            y = x.child
+            return y.name
+        """)
+    m = map_variables(src)
+    attrs = get_accessed_attributes(m, "f")
+    # y is not an alias for x — y.name is on y, and x.child is on x
+    assert attrs.get("y") == {"name"}
+    assert attrs.get("x") == {"child"}

--- a/tests/test_variable_capture.py
+++ b/tests/test_variable_capture.py
@@ -902,6 +902,49 @@ def test_accessed_attributes_alias_branch_conservative():
     assert "value" in attrs.get("y", set())
 
 
+def test_aliases_do_not_leak_across_sibling_functions():
+    """An alias recorded in one function (y = x) must not be visible to a
+    sibling function's same-named variable. With shared alias state, h's
+    y.foo would erroneously be recorded as foo on x — even though h's y is
+    its own parameter, unrelated to f's y."""
+    src = textwrap.dedent("""
+        def f(x):
+            y = x
+            return y.shared
+
+        def h(y):
+            return y.h_only
+        """)
+    m = map_variables(src)
+    f_attrs = get_accessed_attributes(m, "f")
+    h_attrs = get_accessed_attributes(m, "h")
+
+    # f sees 'shared' on x via the alias y = x.
+    assert "shared" in f_attrs.get("x", set())
+    # h's y.h_only must not leak to f's x.
+    assert "h_only" not in f_attrs.get("x", set()), (
+        f"h's y.h_only leaked to f's x via shared alias state: {f_attrs}"
+    )
+    # And h itself records h_only on its own y.
+    assert "h_only" in h_attrs.get("y", set())
+
+
+def test_aliases_propagate_into_nested_functions():
+    """Closures should still see their enclosing scope's aliases."""
+    src = textwrap.dedent("""
+        def f(x):
+            y = x
+            def inner():
+                return y.name
+            return inner
+        """)
+    m = map_variables(src)
+    f_attrs = get_accessed_attributes(m, "f")
+    inner_attrs = get_accessed_attributes(m, "f.<locals>.inner")
+    # inner's access on y should propagate to x via f's alias.
+    assert "name" in f_attrs.get("x", set()) or "name" in inner_attrs.get("x", set())
+
+
 def test_accessed_attributes_non_name_assignment_no_alias():
     """y = x.child is not an alias — attribute access on y stays on y."""
     src = textwrap.dedent("""

--- a/tests/test_variable_capture.py
+++ b/tests/test_variable_capture.py
@@ -5,10 +5,18 @@ import ast
 import types
 
 
-def map_variables(source: str) -> dict[types.CodeType, variables.CodeVars]:
-    tree = ast.parse(source)
-    code = compile(tree, "<string>", "exec", optimize=0)
-    return variables.map_variables(tree, code)
+@pytest.fixture(params=[True, False], ids=['track_attrs', 'no_track_attrs'])
+def track_attributes(request):
+    return request.param
+
+
+@pytest.fixture
+def map_variables(track_attributes):
+    def _impl(source: str) -> dict[types.CodeType, variables.CodeVars]:
+        tree = ast.parse(source)
+        code = compile(tree, "<string>", "exec", optimize=0)
+        return variables.map_variables(tree, code, track_attributes=track_attributes)
+    return _impl
 
 
 def get(mapping: dict[types.CodeType, variables.CodeVars], name: str):
@@ -22,7 +30,7 @@ def get(mapping: dict[types.CodeType, variables.CodeVars], name: str):
     return set()
 
 
-def test_simple_assign_and_augassign():
+def test_simple_assign_and_augassign(map_variables):
     src = textwrap.dedent("""
         x = 1
         def f(y):
@@ -36,7 +44,7 @@ def test_simple_assign_and_augassign():
     assert get(m, "f") == {"a"}
 
 
-def test_annassign_requires_value():
+def test_annassign_requires_value(map_variables):
     src = textwrap.dedent("""
         x: int
         y: int = 3
@@ -45,7 +53,7 @@ def test_annassign_requires_value():
     assert get(m, "<module>") == {"y"}
 
 
-def test_typealias():
+def test_typealias(map_variables):
     src = textwrap.dedent("""
         type x = int
         type y[T: int] = list[T]
@@ -54,7 +62,7 @@ def test_typealias():
     assert get(m, "<module>") == {"x", "y"}
 
 
-def test_unpacking_tuple_list_starred():
+def test_unpacking_tuple_list_starred(map_variables):
     src = textwrap.dedent("""
         (a, (b, *c)) = (1, (2, 3, 4))
         """)
@@ -62,7 +70,7 @@ def test_unpacking_tuple_list_starred():
     assert get(m, "<module>") == {"a", "b", "c"}
 
 
-def test_namedexpr_walrus_and_nested():
+def test_namedexpr_walrus_and_nested(map_variables):
     src = textwrap.dedent("""
         def g():
             d = (e := 10)
@@ -72,7 +80,7 @@ def test_namedexpr_walrus_and_nested():
     assert get(m, "g") == {"d", "e", "f", "h", "i"}
 
 
-def test_attribute_chains_and_subscripts():
+def test_attribute_chains_and_subscripts(map_variables):
     src = textwrap.dedent("""
         x.y = 1
         z[2] = None
@@ -81,7 +89,7 @@ def test_attribute_chains_and_subscripts():
     assert get(m, "<module>") == set()
 
 
-def test_for_asyncfor_with_targets():
+def test_for_asyncfor_with_targets(map_variables):
     src = textwrap.dedent("""
         async def a():
             async for (x, y) in agen():
@@ -96,7 +104,7 @@ def test_for_asyncfor_with_targets():
     assert {"u", "v"}.issubset(get(m, "b"))
 
 
-def test_with_and_asyncwith():
+def test_with_and_asyncwith(map_variables):
     src = textwrap.dedent("""
         from contextlib import asynccontextmanager, contextmanager
 
@@ -119,7 +127,7 @@ def test_with_and_asyncwith():
     assert "aw" in get(m, "g")
 
 
-def test_except_handler_name():
+def test_except_handler_name(map_variables):
     src = textwrap.dedent("""
         def f():
             try:
@@ -131,7 +139,7 @@ def test_except_handler_name():
     assert get(m, "f") == {"e", "msg"}
 
 
-def test_import():
+def test_import(map_variables):
     src = textwrap.dedent("""
         import os as myos
         from math import sin as mysin, cos
@@ -140,7 +148,7 @@ def test_import():
     assert get(m, "<module>") == set()
 
 
-def test_class_and_method_bodies():
+def test_class_and_method_bodies(map_variables):
     src = textwrap.dedent("""
         class A:
             def __init__(myself):
@@ -170,7 +178,7 @@ def test_class_and_method_bodies():
     assert get(m, "C.__init__") == {"self.z", "self.a"}
 
 
-def test_class_and_method_bodies_nested():
+def test_class_and_method_bodies_nested(map_variables):
     src = textwrap.dedent("""
         def f():
             class C:
@@ -188,7 +196,7 @@ def test_class_and_method_bodies_nested():
     assert get(m, "f.<locals>.C.__init__") == {"self.z"}
 
 
-def test_self_not_in_method():
+def test_self_not_in_method(map_variables):
     src = textwrap.dedent("""
         def __init__(self):
             self.a = None
@@ -209,7 +217,7 @@ def test_self_not_in_method():
     assert get(m, "C.bar") == set()
 
 
-def test_self_nested_in_method():
+def test_self_nested_in_method(map_variables):
     src = textwrap.dedent("""
         class C:
             def f1(self):
@@ -235,7 +243,7 @@ def test_self_nested_in_method():
     assert get(m, "C.f3.<locals>.f.<locals>.g") == set()
 
 
-def test_self_attribute_in_various_methods():
+def test_self_attribute_in_various_methods(map_variables):
     src = textwrap.dedent("""
         class C:
             def __init__(self):
@@ -265,7 +273,7 @@ def test_self_attribute_in_various_methods():
     assert get(m, "C.f3") == {"self.x", "self.y", "self.z"}
 
 
-def test_lambdas_and_comprehensions_have_their_own_code_objects():
+def test_lambdas_and_comprehensions_have_their_own_code_objects(map_variables):
     src = textwrap.dedent("""
         L = [(a:=w) for w in range(2)]
         S = {(b:=w) for w in range(2)}
@@ -280,7 +288,7 @@ def test_lambdas_and_comprehensions_have_their_own_code_objects():
     assert get(mapping, "<lambda>") == set()
 
 
-def test_match_tuple_pattern():
+def test_match_tuple_pattern(map_variables):
     src = textwrap.dedent("""
         def f(data):
             match data:
@@ -291,7 +299,7 @@ def test_match_tuple_pattern():
     assert get(m, "f") == {"x", "y", "z"}
 
 
-def test_match_class_pattern_with_fields():
+def test_match_class_pattern_with_fields(map_variables):
     src = textwrap.dedent("""
         def f(obj):
             match obj:
@@ -302,7 +310,7 @@ def test_match_class_pattern_with_fields():
     assert get(m, "f") == {"a", "b", "total"}
 
 
-def test_match_nested_mapping_and_sequence():
+def test_match_nested_mapping_and_sequence(map_variables):
     src = textwrap.dedent("""
         def f(record):
             match record:
@@ -313,7 +321,7 @@ def test_match_nested_mapping_and_sequence():
     assert get(m, "f") == {"uid", "name", "seen"}
 
 
-def test_match_sequence_starred_and_count():
+def test_match_sequence_starred_and_count(map_variables):
     src = textwrap.dedent("""
         def f(seq):
             match seq:
@@ -324,7 +332,7 @@ def test_match_sequence_starred_and_count():
     assert get(m, "f") == {"first", "rest", "count"}
 
 
-def test_match_or_requires_same_bindings():
+def test_match_or_requires_same_bindings(map_variables):
     src = textwrap.dedent("""
         def f(value):
             match value:
@@ -335,7 +343,7 @@ def test_match_or_requires_same_bindings():
     assert get(m, "f") == {"n", "result"}
 
 
-def test_match_mapping_with_rest():
+def test_match_mapping_with_rest(map_variables):
     src = textwrap.dedent("""
         def f(d):
             match d:
@@ -346,7 +354,7 @@ def test_match_mapping_with_rest():
     assert get(m, "f") == {"x", "rest"}
 
 
-def test_match_class_pattern_with_as_binding():
+def test_match_class_pattern_with_as_binding(map_variables):
     src = textwrap.dedent("""
         def f(node):
             match node:
@@ -357,7 +365,7 @@ def test_match_class_pattern_with_as_binding():
     assert get(m, "f") == {"l", "r", "tree", "depth"}
 
 
-def test_match_as_simple_name_only():
+def test_match_as_simple_name_only(map_variables):
     src = textwrap.dedent("""
         def f(x):
             match x:
@@ -376,7 +384,7 @@ def get_initial_constants(mapping: dict[types.CodeType, variables.CodeVars], nam
     return {}
 
 
-def test_initial_constant_none_captured():
+def test_initial_constant_none_captured(map_variables):
     """Test that x = None captures NoneType as initial constant."""
     src = textwrap.dedent("""
         def foo():
@@ -389,7 +397,7 @@ def test_initial_constant_none_captured():
     assert consts.get("x") == type(None)
 
 
-def test_initial_constant_int_captured():
+def test_initial_constant_int_captured(map_variables):
     """Test that x = 0 captures int as initial constant."""
     src = textwrap.dedent("""
         def foo():
@@ -402,7 +410,7 @@ def test_initial_constant_int_captured():
     assert consts.get("x") == int
 
 
-def test_initial_constant_str_captured():
+def test_initial_constant_str_captured(map_variables):
     """Test that x = "" captures str as initial constant."""
     src = textwrap.dedent("""
         def foo():
@@ -414,7 +422,7 @@ def test_initial_constant_str_captured():
     assert consts.get("x") == str
 
 
-def test_non_constant_not_captured():
+def test_non_constant_not_captured(map_variables):
     """Test that x = [] does NOT capture (not ast.Constant)."""
     src = textwrap.dedent("""
         def foo():
@@ -426,7 +434,7 @@ def test_non_constant_not_captured():
     assert "x" not in consts
 
 
-def test_function_call_not_captured():
+def test_function_call_not_captured(map_variables):
     """Test that x = foo() does NOT capture (not ast.Constant)."""
     src = textwrap.dedent("""
         def foo():
@@ -438,7 +446,7 @@ def test_function_call_not_captured():
     assert "x" not in consts
 
 
-def test_reassignment_preserves_initial():
+def test_reassignment_preserves_initial(map_variables):
     """Test that reassignment doesn't overwrite initial constant."""
     src = textwrap.dedent("""
         def foo():
@@ -453,7 +461,7 @@ def test_reassignment_preserves_initial():
     assert consts.get("x") == type(None)
 
 
-def test_initial_constant_bool_captured():
+def test_initial_constant_bool_captured(map_variables):
     """Test that x = True captures bool as initial constant."""
     src = textwrap.dedent("""
         def foo():
@@ -465,7 +473,7 @@ def test_initial_constant_bool_captured():
     assert consts.get("x") == bool
 
 
-def test_initial_constant_float_captured():
+def test_initial_constant_float_captured(map_variables):
     """Test that x = 3.14 captures float as initial constant."""
     src = textwrap.dedent("""
         def foo():
@@ -477,7 +485,7 @@ def test_initial_constant_float_captured():
     assert consts.get("x") == float
 
 
-def test_module_level_initial_constant():
+def test_module_level_initial_constant(map_variables):
     """Test initial constants at module level."""
     src = textwrap.dedent("""
         x = None
@@ -491,7 +499,7 @@ def test_module_level_initial_constant():
     assert "z" not in consts
 
 
-def test_annotated_assignment_initial_constant():
+def test_annotated_assignment_initial_constant(map_variables):
     """Test that x: int = None captures NoneType."""
     src = textwrap.dedent("""
         def foo():
@@ -503,7 +511,7 @@ def test_annotated_assignment_initial_constant():
     assert consts.get("x") == type(None)
 
 
-def test_declaration_without_assignment_not_captured():
+def test_declaration_without_assignment_not_captured(map_variables):
     """Test that x: str (no value) does NOT capture anything from declaration."""
     src = textwrap.dedent("""
         def foo():
@@ -518,7 +526,7 @@ def test_declaration_without_assignment_not_captured():
     assert consts.get("x") == int
 
 
-def test_tuple_unpacking_not_captured():
+def test_tuple_unpacking_not_captured(map_variables):
     """Test that a, b = 0, 1 does NOT capture (can't match values to targets)."""
     src = textwrap.dedent("""
         def foo():
@@ -542,7 +550,7 @@ def get_attribute_initial_constants(mapping: dict[types.CodeType, variables.Code
     return {}
 
 
-def test_attribute_initial_constant_none_captured():
+def test_attribute_initial_constant_none_captured(map_variables):
     """Test that self.x = None captures NoneType for attribute."""
     src = textwrap.dedent("""
         class C:
@@ -556,7 +564,7 @@ def test_attribute_initial_constant_none_captured():
     assert consts.get("x") == type(None)
 
 
-def test_attribute_initial_constant_int_captured():
+def test_attribute_initial_constant_int_captured(map_variables):
     """Test that self.x = 0 captures int for attribute."""
     src = textwrap.dedent("""
         class C:
@@ -568,7 +576,7 @@ def test_attribute_initial_constant_int_captured():
     assert consts.get("x") == int
 
 
-def test_attribute_non_constant_not_captured():
+def test_attribute_non_constant_not_captured(map_variables):
     """Test that self.x = foo() does NOT capture."""
     src = textwrap.dedent("""
         class C:
@@ -602,7 +610,7 @@ def get_class_attribute_initial_constants(mapping: dict[types.CodeType, variable
     return {}
 
 
-def test_class_body_attribute_captured():
+def test_class_body_attribute_captured(map_variables):
     """Class body assignment like `monitor = None` captures class attribute."""
     src = textwrap.dedent("""
         class C:
@@ -615,7 +623,7 @@ def test_class_body_attribute_captured():
     assert "monitor" in attrs
 
 
-def test_class_body_attribute_initial_constant():
+def test_class_body_attribute_initial_constant(map_variables):
     """Class body assignment `x = None` captures NoneType as initial constant."""
     src = textwrap.dedent("""
         class C:
@@ -626,7 +634,7 @@ def test_class_body_attribute_initial_constant():
     assert consts.get("x") == type(None)
 
 
-def test_class_body_non_constant_not_captured():
+def test_class_body_non_constant_not_captured(map_variables):
     """Class body assignment `x = []` does NOT capture initial constant."""
     src = textwrap.dedent("""
         class C:
@@ -637,7 +645,7 @@ def test_class_body_non_constant_not_captured():
     assert "x" not in consts
 
 
-def test_cls_assignment_captured():
+def test_cls_assignment_captured(map_variables):
     """cls.x = value in classmethod captures class attribute."""
     src = textwrap.dedent("""
         class C:
@@ -651,7 +659,7 @@ def test_cls_assignment_captured():
     assert "monitor" in attrs
 
 
-def test_cls_assignment_initial_constant():
+def test_cls_assignment_initial_constant(map_variables):
     """cls.x = None in classmethod captures NoneType as initial constant."""
     src = textwrap.dedent("""
         class C:
@@ -664,7 +672,7 @@ def test_cls_assignment_initial_constant():
     assert consts.get("x") == type(None)
 
 
-def test_cls_assignment_non_constant():
+def test_cls_assignment_non_constant(map_variables):
     """cls.x = foo() in classmethod does NOT capture initial constant."""
     src = textwrap.dedent("""
         class C:
@@ -677,7 +685,7 @@ def test_cls_assignment_non_constant():
     assert "x" not in consts
 
 
-def test_class_body_and_cls_combined():
+def test_class_body_and_cls_combined(map_variables):
     """Class body + classmethod assignments both contribute to class_attributes."""
     src = textwrap.dedent("""
         class C:
@@ -698,7 +706,7 @@ def test_class_body_and_cls_combined():
     assert "monitor" in method_attrs
 
 
-def test_cls_parameter_tracked():
+def test_cls_parameter_tracked(map_variables):
     """The cls parameter is tracked for classmethods."""
     src = textwrap.dedent("""
         class C:
@@ -716,7 +724,7 @@ def test_cls_parameter_tracked():
         assert False, "C.setup not found"
 
 
-def test_staticmethod_no_cls():
+def test_staticmethod_no_cls(map_variables):
     """Static methods should not have cls tracked."""
     src = textwrap.dedent("""
         class C:
@@ -734,7 +742,7 @@ def test_staticmethod_no_cls():
         assert False, "C.helper not found"
 
 
-def test_regular_method_no_cls():
+def test_regular_method_no_cls(map_variables):
     """Regular methods should have self but not cls."""
     src = textwrap.dedent("""
         class C:
@@ -763,7 +771,8 @@ def get_accessed_attributes(mapping: dict[types.CodeType, variables.CodeVars], n
     return {}
 
 
-def test_accessed_attributes_simple():
+def test_accessed_attributes_simple(map_variables, track_attributes):
+    if not track_attributes: pytest.skip("requires attribute tracking")
     """x.foo collects 'foo' on parameter x."""
     src = textwrap.dedent("""
         def f(x):
@@ -774,7 +783,8 @@ def test_accessed_attributes_simple():
     assert attrs.get("x") == {"name"}
 
 
-def test_accessed_attributes_method_call():
+def test_accessed_attributes_method_call(map_variables, track_attributes):
+    if not track_attributes: pytest.skip("requires attribute tracking")
     """x.foo() still collects 'foo' — it's an attribute access followed by a call."""
     src = textwrap.dedent("""
         def f(x):
@@ -785,7 +795,8 @@ def test_accessed_attributes_method_call():
     assert attrs.get("x") == {"process"}
 
 
-def test_accessed_attributes_multiple_vars():
+def test_accessed_attributes_multiple_vars(map_variables, track_attributes):
+    if not track_attributes: pytest.skip("requires attribute tracking")
     """Different attributes on different variables are tracked separately."""
     src = textwrap.dedent("""
         def f(x, y):
@@ -797,7 +808,8 @@ def test_accessed_attributes_multiple_vars():
     assert attrs.get("y") == {"value"}
 
 
-def test_accessed_attributes_multiple_on_same_var():
+def test_accessed_attributes_multiple_on_same_var(map_variables, track_attributes):
+    if not track_attributes: pytest.skip("requires attribute tracking")
     """Multiple attributes on the same variable are all collected."""
     src = textwrap.dedent("""
         def f(x):
@@ -808,7 +820,8 @@ def test_accessed_attributes_multiple_on_same_var():
     assert attrs.get("x") == {"name", "value"}
 
 
-def test_accessed_attributes_chained():
+def test_accessed_attributes_chained(map_variables, track_attributes):
+    if not track_attributes: pytest.skip("requires attribute tracking")
     """x.foo.bar collects 'foo' on x (bar is on foo's result, not x)."""
     src = textwrap.dedent("""
         def f(x):
@@ -820,7 +833,8 @@ def test_accessed_attributes_chained():
     assert "name" not in attrs.get("x", set())
 
 
-def test_accessed_attributes_includes_writes():
+def test_accessed_attributes_includes_writes(map_variables, track_attributes):
+    if not track_attributes: pytest.skip("requires attribute tracking")
     """x.foo = val is still an attribute access — the type needs to support it."""
     src = textwrap.dedent("""
         def f(x):
@@ -831,7 +845,8 @@ def test_accessed_attributes_includes_writes():
     assert "name" in attrs.get("x", set())
 
 
-def test_accessed_attributes_locals():
+def test_accessed_attributes_locals(map_variables, track_attributes):
+    if not track_attributes: pytest.skip("requires attribute tracking")
     """Attribute access on local variables, not just parameters."""
     src = textwrap.dedent("""
         def f():
@@ -843,7 +858,8 @@ def test_accessed_attributes_locals():
     assert attrs.get("result") == {"count"}
 
 
-def test_accessed_attributes_alias():
+def test_accessed_attributes_alias(map_variables, track_attributes):
+    if not track_attributes: pytest.skip("requires attribute tracking")
     """y = x; y.name records 'name' on x."""
     src = textwrap.dedent("""
         def f(x):
@@ -855,7 +871,8 @@ def test_accessed_attributes_alias():
     assert "name" in attrs.get("x", set())
 
 
-def test_accessed_attributes_transitive_alias():
+def test_accessed_attributes_transitive_alias(map_variables, track_attributes):
+    if not track_attributes: pytest.skip("requires attribute tracking")
     """z = y; y = x; z still aliases through to x."""
     src = textwrap.dedent("""
         def f(x):
@@ -868,7 +885,8 @@ def test_accessed_attributes_transitive_alias():
     assert "name" in attrs.get("x", set())
 
 
-def test_accessed_attributes_alias_reassigned():
+def test_accessed_attributes_alias_reassigned(map_variables, track_attributes):
+    if not track_attributes: pytest.skip("requires attribute tracking")
     """Reassignment after alias: conservatively keeps the alias (could be a branch)."""
     src = textwrap.dedent("""
         def f(x):
@@ -885,7 +903,8 @@ def test_accessed_attributes_alias_reassigned():
     assert "name" in attrs.get("x", set())
 
 
-def test_accessed_attributes_alias_branch_conservative():
+def test_accessed_attributes_alias_branch_conservative(map_variables, track_attributes):
+    if not track_attributes: pytest.skip("requires attribute tracking")
     """Aliases from different branches are unioned (conservative)."""
     src = textwrap.dedent("""
         def f(x, y):
@@ -902,7 +921,8 @@ def test_accessed_attributes_alias_branch_conservative():
     assert "value" in attrs.get("y", set())
 
 
-def test_aliases_do_not_leak_across_sibling_functions():
+def test_aliases_do_not_leak_across_sibling_functions(map_variables, track_attributes):
+    if not track_attributes: pytest.skip("requires attribute tracking")
     """An alias recorded in one function (y = x) must not be visible to a
     sibling function's same-named variable. With shared alias state, h's
     y.foo would erroneously be recorded as foo on x — even though h's y is
@@ -929,7 +949,8 @@ def test_aliases_do_not_leak_across_sibling_functions():
     assert "h_only" in h_attrs.get("y", set())
 
 
-def test_aliases_propagate_into_nested_functions():
+def test_aliases_propagate_into_nested_functions(map_variables, track_attributes):
+    if not track_attributes: pytest.skip("requires attribute tracking")
     """Closures should still see their enclosing scope's aliases."""
     src = textwrap.dedent("""
         def f(x):
@@ -945,7 +966,8 @@ def test_aliases_propagate_into_nested_functions():
     assert "name" in f_attrs.get("x", set()) or "name" in inner_attrs.get("x", set())
 
 
-def test_accessed_attributes_non_name_assignment_no_alias():
+def test_accessed_attributes_non_name_assignment_no_alias(map_variables, track_attributes):
+    if not track_attributes: pytest.skip("requires attribute tracking")
     """y = x.child is not an alias — attribute access on y stays on y."""
     src = textwrap.dedent("""
         def f(x):
@@ -963,7 +985,8 @@ def test_accessed_attributes_non_name_assignment_no_alias():
 # Tests for operator/builtin desugaring to dunder attributes
 # =============================================================================
 
-def test_desugar_subscript_getitem():
+def test_desugar_subscript_getitem(map_variables, track_attributes):
+    if not track_attributes: pytest.skip("requires attribute tracking")
     """x[i] → __getitem__ on x."""
     src = textwrap.dedent("""
         def f(x, i):
@@ -974,7 +997,8 @@ def test_desugar_subscript_getitem():
     assert "__getitem__" in attrs.get("x", set())
 
 
-def test_desugar_subscript_setitem():
+def test_desugar_subscript_setitem(map_variables, track_attributes):
+    if not track_attributes: pytest.skip("requires attribute tracking")
     """x[i] = v → __setitem__ on x."""
     src = textwrap.dedent("""
         def f(x, i, v):
@@ -985,7 +1009,8 @@ def test_desugar_subscript_setitem():
     assert "__setitem__" in attrs.get("x", set())
 
 
-def test_desugar_subscript_delitem():
+def test_desugar_subscript_delitem(map_variables, track_attributes):
+    if not track_attributes: pytest.skip("requires attribute tracking")
     """del x[i] → __delitem__ on x."""
     src = textwrap.dedent("""
         def f(x, i):
@@ -996,7 +1021,8 @@ def test_desugar_subscript_delitem():
     assert "__delitem__" in attrs.get("x", set())
 
 
-def test_desugar_for_iter():
+def test_desugar_for_iter(map_variables, track_attributes):
+    if not track_attributes: pytest.skip("requires attribute tracking")
     """for item in x → __iter__ on x."""
     src = textwrap.dedent("""
         def f(x):
@@ -1008,7 +1034,8 @@ def test_desugar_for_iter():
     assert "__iter__" in attrs.get("x", set())
 
 
-def test_desugar_comprehension_iter():
+def test_desugar_comprehension_iter(map_variables, track_attributes):
+    if not track_attributes: pytest.skip("requires attribute tracking")
     """[... for item in x] → __iter__ on x."""
     src = textwrap.dedent("""
         def f(x):
@@ -1019,7 +1046,8 @@ def test_desugar_comprehension_iter():
     assert "__iter__" in attrs.get("x", set())
 
 
-def test_desugar_binop():
+def test_desugar_binop(map_variables, track_attributes):
+    if not track_attributes: pytest.skip("requires attribute tracking")
     """x + y → __add__ on x."""
     src = textwrap.dedent("""
         def f(x, y):
@@ -1030,7 +1058,8 @@ def test_desugar_binop():
     assert "__add__" in attrs.get("x", set())
 
 
-def test_desugar_augassign():
+def test_desugar_augassign(map_variables, track_attributes):
+    if not track_attributes: pytest.skip("requires attribute tracking")
     """x += y → __iadd__ on x."""
     src = textwrap.dedent("""
         def f(x, y):
@@ -1041,7 +1070,8 @@ def test_desugar_augassign():
     assert "__iadd__" in attrs.get("x", set())
 
 
-def test_desugar_unaryop():
+def test_desugar_unaryop(map_variables, track_attributes):
+    if not track_attributes: pytest.skip("requires attribute tracking")
     """-x → __neg__ on x."""
     src = textwrap.dedent("""
         def f(x):
@@ -1052,7 +1082,8 @@ def test_desugar_unaryop():
     assert "__neg__" in attrs.get("x", set())
 
 
-def test_desugar_compare():
+def test_desugar_compare(map_variables, track_attributes):
+    if not track_attributes: pytest.skip("requires attribute tracking")
     """x < y → __lt__ on x."""
     src = textwrap.dedent("""
         def f(x, y):
@@ -1063,7 +1094,8 @@ def test_desugar_compare():
     assert "__lt__" in attrs.get("x", set())
 
 
-def test_desugar_contains():
+def test_desugar_contains(map_variables, track_attributes):
+    if not track_attributes: pytest.skip("requires attribute tracking")
     """item in x → __contains__ on x (right operand)."""
     src = textwrap.dedent("""
         def f(item, x):
@@ -1074,7 +1106,8 @@ def test_desugar_contains():
     assert "__contains__" in attrs.get("x", set())
 
 
-def test_desugar_with():
+def test_desugar_with(map_variables, track_attributes):
+    if not track_attributes: pytest.skip("requires attribute tracking")
     """with x: → __enter__ and __exit__ on x."""
     src = textwrap.dedent("""
         def f(x):
@@ -1087,7 +1120,8 @@ def test_desugar_with():
     assert "__exit__" in attrs.get("x", set())
 
 
-def test_desugar_builtin_len():
+def test_desugar_builtin_len(map_variables, track_attributes):
+    if not track_attributes: pytest.skip("requires attribute tracking")
     """len(x) → __len__ on x."""
     src = textwrap.dedent("""
         def f(x):
@@ -1098,7 +1132,8 @@ def test_desugar_builtin_len():
     assert "__len__" in attrs.get("x", set())
 
 
-def test_desugar_builtin_iter():
+def test_desugar_builtin_iter(map_variables, track_attributes):
+    if not track_attributes: pytest.skip("requires attribute tracking")
     """iter(x) → __iter__ on x."""
     src = textwrap.dedent("""
         def f(x):
@@ -1109,7 +1144,8 @@ def test_desugar_builtin_iter():
     assert "__iter__" in attrs.get("x", set())
 
 
-def test_desugar_builtin_reversed():
+def test_desugar_builtin_reversed(map_variables, track_attributes):
+    if not track_attributes: pytest.skip("requires attribute tracking")
     """reversed(x) → __reversed__ on x."""
     src = textwrap.dedent("""
         def f(x):
@@ -1120,7 +1156,8 @@ def test_desugar_builtin_reversed():
     assert "__reversed__" in attrs.get("x", set())
 
 
-def test_desugar_builtin_shadowed():
+def test_desugar_builtin_shadowed(map_variables, track_attributes):
+    if not track_attributes: pytest.skip("requires attribute tracking")
     """If len is shadowed by a local, don't desugar."""
     src = textwrap.dedent("""
         def f(x):
@@ -1132,7 +1169,8 @@ def test_desugar_builtin_shadowed():
     assert "__len__" not in attrs.get("x", set())
 
 
-def test_desugar_builtin_shadowed_by_param():
+def test_desugar_builtin_shadowed_by_param(map_variables, track_attributes):
+    if not track_attributes: pytest.skip("requires attribute tracking")
     """If len is a parameter name, don't desugar."""
     src = textwrap.dedent("""
         def f(len, x):
@@ -1143,7 +1181,8 @@ def test_desugar_builtin_shadowed_by_param():
     assert "__len__" not in attrs.get("x", set())
 
 
-def test_desugar_await():
+def test_desugar_await(map_variables, track_attributes):
+    if not track_attributes: pytest.skip("requires attribute tracking")
     """await x → __await__ on x."""
     src = textwrap.dedent("""
         async def f(x):


### PR DESCRIPTION
## Summary

Restructures `merged_types` around a new **lub** (least upper bound) algorithm, and adds two new opt-in features driven by static analysis of source.

### lub-based merging

`merged_types` now goes through `_merge_set`, built on `lub()` (rules 1-8 covering subtype narrowing, fixed/varlen tuples, container ABCs, MRO common supertypes, Callable/`type[X]` joins, etc.). The transition was guarded by dual-run validation against the prior implementation; each divergence surfaced was inspected and resolved before the switch. Subclasses of `int` are now promoted via the numeric tower in `_is_subtype`.

### `--use-attribute-simplification` (opt-in, default off)

Uses AST analysis of the attributes a variable is actually accessed for to inform type simplification — when a value is only used via attributes available on a public ancestor, the inferred type is widened to that ancestor (de-privatization). Includes operator/builtin/syntax desugaring to dunder accesses, an ABC fallback via structural subtyping, and parallel MRO+ABC simplification picking the shortest result. `accessed_attributes` is serialized in `.rt` files so `process` can use it.

### `--use-constructor-types` (opt-in, default off)

Constructor-type widening: when source has `p = Path(...)` and the runtime observes `PosixPath`, annotate `p: Path` rather than the runtime concrete subtype. AST capture of `var = Foo(...)` and `return Foo(...)` shapes, frame-walked to a class at record time, canonicalized via `TypeMap` and consulted against typeshed (`__new__` for direct calls, named methods for factory patterns like `Path.cwd()`) at `finish_recording`. Applied post-merge via `FuncInfo.constructor_types` so it doesn't clobber parametrized observations (`imports = set()` keeps `set[str]`) or runtime-divergent ones (`attr.Factory(set)` → runtime `set`).

Both features ship default-off because they are still under development.

### Other changes

- `TypeInfo.type_obj` is stripped at `.rt` save via `Pickler.dispatch_table`, preventing live class references (often `__main__`-defined) from overriding canonical names at process time.
- `TypeMap.to_name_map` produces a serializable `(orig_module, orig_name) → (canonical_module, canonical_name)` map; `Observations.type_name_map` carries it through `process` so types introduced by `lub` (e.g. `pathlib._local.Path` → `pathlib.Path`) get canonicalized in the output.
