### PR TITLE
Annotation diagnostics + return-type lub generalization + container-snapshot rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,8 +258,16 @@ Options:
                                   directory) is used.
   --poisson-rate FLOAT RANGE      Expected sample captures per second (Poisson
                                   process rate).  [default: 2.0; x>=0.1]
-  --sampling / --no-sampling      Whether to sample calls or to use every one.
-                                  [default: sampling]
+  --poisson-warmup-samples INTEGER RANGE
+                                  Capture this many initial calls per function
+                                  before Poisson sampling kicks in. Higher
+                                  values catch rare per-call variants (e.g.
+                                  exception paths through __exit__) that the
+                                  sampler may otherwise miss; lower is faster.
+                                  [default: 5; x>=0]
+  --call-sampling / --no-call-sampling
+                                  Whether to sample calls or to use every one.
+                                  [default: call-sampling]
   --no-sampling-for REGEX         Rather than sample, record every invocation
                                   of any functions matching the given regular
                                   expression. Can be passed multiple times.
@@ -289,6 +297,10 @@ Options:
   --container-check-probability FLOAT RANGE
                                   Probability of spot-checking a container for
                                   new types.  [default: 0.5; 0.0<=x<=1.0]
+  --container-caching / --no-container-caching
+                                  Cache container scan results; --no-
+                                  container-caching forces rescan every visit.
+                                  [default: container-caching]
   --max-union-size INTEGER RANGE  Maximum distinct types in a union before
                                   collapsing to Any.  [default: 32; x>=1]
   --resolve-mocks / --no-resolve-mocks
@@ -388,5 +400,34 @@ Options:
                                   observed types next to annotations with
                                   multiple types.  [default: no-type-
                                   distribution-comments]
+    --type-parameters / --no-type-parameters
+                                  Whether to infer type parameters (T1, T2,
+                                  ...) for correlated argument types. Disable
+                                  for plain union annotations.  [default:
+                                  type-parameters]
+    --inline-generics / --no-inline-generics
+                                  Whether to use PEP 695 inline type parameter
+                                  syntax (Python 3.12+). Disable for module-
+                                  level TypeVar declarations.  [default:
+                                  inline-generics]
+    --use-attribute-simplification / --no-use-attribute-simplification
+                                  Whether to widen types via static analysis
+                                  of which attributes the code actually
+                                  accesses, generalizing to a base class when
+                                  the code only uses attributes inherited from
+                                  it.  [default: no-use-attribute-
+                                  simplification]
+    --use-constructor-types / --no-use-constructor-types
+                                  Whether to use a variable's source-level
+                                  constructor or factory call (e.g., `p =
+                                  Path("/tmp")` or `p = Path.cwd()`) as its
+                                  annotation, when the observed runtime type
+                                  is consistent with the call's declared
+                                  return.  [default: no-use-constructor-types]
+    --with-coverage / --no-with-coverage
+                                  Capture branch and line coverage (using
+                                  SlipCover) to identify exercise-driver gaps
+                                  behind degenerate annotations.  [default:
+                                  no-with-coverage]
   --help                          Show this message and exit.
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,8 @@ dependencies = [
     "rich >= 13.7.1",
     "wcmatch >= 10.0",
     "typeshed_client >= 2.7.0",
-    "dill >= 0.4.0"
+    "dill >= 0.4.0",
+    "slipcover >= 1.0.16"
 ]
 	 
 description = "A fast runtime type hint assistant for Python code."

--- a/righttyper/atomic.py
+++ b/righttyper/atomic.py
@@ -15,8 +15,12 @@ class AtomicCounter:
         self._count = itertools.count()
         self._last = 0
 
-    def inc(self) -> None:
-        next(self._count)
+    def inc(self) -> int:
+        """Increment and return the new value (the count *before* this
+        call, since ``itertools.count`` starts at 0 and yields then
+        advances).  Callers using this only as a side-effecting increment
+        can ignore the return."""
+        return next(self._count)
 
     def count_and_clear(self) -> int:
         # This operation isn't, by itself, atomic, but safe as long as only one thread

--- a/righttyper/coverage.py
+++ b/righttyper/coverage.py
@@ -1,0 +1,80 @@
+"""Adapter for slipcover-based line coverage during a RightTyper run.
+
+Off by default. `enable()` constructs a singleton Slipcover instance and
+registers its sys.monitoring LINE callback as a side effect of
+``Slipcover.__init__``. The rest of RT reaches into this module via
+``is_enabled()``, ``preinstrument()`` (called from the loader's AST
+pipeline), and ``snapshot()`` (called when the .rt pickle is written).
+
+Slipcover is lazy-imported inside ``enable()``. Nothing else in this module
+imports it, so when ``--with-coverage`` is not set the off-by-default code
+path is free of slipcover overhead.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+import types
+from typing import Any
+
+_sci: Any | None = None
+
+
+class CoverageSetupError(RuntimeError):
+    """Raised when ``--with-coverage`` cannot be honored."""
+
+
+def enable(source: str) -> None:
+    """Construct the singleton ``Slipcover`` instance with branch
+    instrumentation. Registers slipcover's LINE callback on
+    ``sys.monitoring`` as a side effect of the constructor.
+
+    Preflight: SlipCover hard-codes ``sys.monitoring.COVERAGE_ID``. If
+    another tool already holds it, construction would raise a bare
+    ``ValueError`` — we intercept and re-raise with an actionable message.
+    """
+    global _sci
+    cov_id = sys.monitoring.COVERAGE_ID
+    holder = sys.monitoring.get_tool(cov_id)
+    if holder is not None and holder != "SlipCover":
+        raise CoverageSetupError(
+            f"Cannot enable --with-coverage: sys.monitoring COVERAGE_ID "
+            f"(={cov_id}) is already held by {holder!r}. Disable that tool "
+            f"or omit --with-coverage."
+        )
+    from slipcover import Slipcover
+
+    _sci = Slipcover(branch=True, source=[source])
+
+
+def is_enabled() -> bool:
+    return _sci is not None
+
+
+def preinstrument(tree: ast.Module) -> ast.Module:
+    """Apply slipcover's branch-instrumentation AST pass. No-op when not
+    enabled, so callers can drop this in unconditionally.
+    """
+    if _sci is None:
+        return tree
+    from slipcover import branch as sc_branch
+
+    return sc_branch.preinstrument(tree)
+
+
+def instrument_code(code: types.CodeType) -> types.CodeType:
+    """Register a compiled module's code with slipcover. Enables LINE events
+    on the code object and records its line/branch universe so missing-
+    coverage data is computable. No-op when not enabled.
+    """
+    if _sci is None:
+        return code
+    return _sci.instrument(code)
+
+
+def snapshot() -> dict[str, Any] | None:
+    """Return slipcover's coverage dict, or ``None`` if not enabled."""
+    if _sci is None:
+        return None
+    return _sci.get_coverage()

--- a/righttyper/coverage.py
+++ b/righttyper/coverage.py
@@ -20,6 +20,15 @@ from typing import Any
 
 _sci: Any | None = None
 
+# Per-code-object line sets, populated as the loader instruments each module.
+# Keyed by (filename, qualname, first_lineno) -- the same triple RT's CodeId
+# already uses, and exactly what SlipCover would key on if it tracked this
+# natively. When SlipCover gains the feature, drop this map and read the
+# information off the slipcover instance instead. The on-disk shape we emit
+# (a "functions" subdict inside each file's coverage entry) already mirrors
+# the planned SlipCover output, so consumers won't need to change.
+_lines_per_code: dict[tuple[str, str, int], set[int]] = {}
+
 
 class CoverageSetupError(RuntimeError):
     """Raised when ``--with-coverage`` cannot be honored."""
@@ -67,14 +76,75 @@ def instrument_code(code: types.CodeType) -> types.CodeType:
     """Register a compiled module's code with slipcover. Enables LINE events
     on the code object and records its line/branch universe so missing-
     coverage data is computable. No-op when not enabled.
+
+    Also walks the code object recursively to populate ``_lines_per_code``
+    -- the per-code-object line bookkeeping that's the RT-side stand-in
+    for a SlipCover feature.
     """
     if _sci is None:
         return code
-    return _sci.instrument(code)
+    instrumented = _sci.instrument(code)
+    _register_code_recursively(instrumented)
+    return instrumented
+
+
+def _register_code_recursively(code: types.CodeType) -> None:
+    """Populate `_lines_per_code` for `code` and every nested code object,
+    using the same traversal SlipCover does for instrumentation.
+    """
+    key = (code.co_filename, code.co_qualname, code.co_firstlineno)
+    _lines_per_code[key] = _own_lines(code)
+    for c in code.co_consts:
+        if isinstance(c, types.CodeType) and c.co_name != "__annotate__":
+            _register_code_recursively(c)
+
+
+def _own_lines(code: types.CodeType) -> set[int]:
+    """Lines belonging to *this* code object, excluding nested code objects
+    (each of which gets its own entry) and SlipCover's branch-marker fake
+    line numbers.
+    """
+    from dis import findlinestarts
+    from slipcover import branch as sc_branch
+
+    return {
+        line for _, line in findlinestarts(code)
+        if line and not sc_branch.is_branch(line)
+    }
 
 
 def snapshot() -> dict[str, Any] | None:
-    """Return slipcover's coverage dict, or ``None`` if not enabled."""
+    """Return slipcover's coverage dict, augmented with a per-function block
+    under each file's entry, or ``None`` if not enabled.
+
+    All ``files`` keys are normalized to resolved absolute paths so that
+    the per-function additions and SlipCover's per-file data sit under
+    the same key, and downstream consumers don't have to canonicalize on
+    lookup.
+
+    Per-function layout (mirrors the shape SlipCover would naturally
+    expose if it tracked this):
+
+        coverage["files"][resolved_path]["functions"][f"{qualname}@{firstline}"]
+            = {"lines": [int, ...]}
+    """
     if _sci is None:
         return None
-    return _sci.get_coverage()
+    from pathlib import Path
+
+    cov = _sci.get_coverage()
+
+    def _canonical(p: str) -> str:
+        try:
+            return str(Path(p).resolve())
+        except OSError:
+            return p
+
+    files = {_canonical(k): v for k, v in cov.get("files", {}).items()}
+    for (filename, qualname, first_line), lines in _lines_per_code.items():
+        entry = files.setdefault(_canonical(filename), {"executed_lines": []})
+        entry.setdefault("functions", {})[f"{qualname}@{first_line}"] = {
+            "lines": sorted(lines),
+        }
+    cov["files"] = files
+    return cov

--- a/righttyper/diagnostics.py
+++ b/righttyper/diagnostics.py
@@ -107,10 +107,18 @@ def emit(
             continue
         n_observations = sum(traces.values())
 
-        # Return slot: last element of each CallTrace.
+        # Return slot: last element of each CallTrace. ``always-none-optional``
+        # is too noisy on returns -- __init__, descriptor __set__, and
+        # procedural methods that exist for their side effect (e.g.
+        # ``Flask.add_url_rule`` returns None on every call by design) all
+        # land here intentionally. Without comparing to the declared
+        # annotation we can't tell those apart from a real signal like
+        # ``def first(xs) -> int | None: return xs[0] if xs else None``
+        # observed to always return None, so we drop the shape for return
+        # slots and keep it only on args.
         return_obs = {t[-1] for t in traces}
         return_shape = degenerate_shape(return_obs)
-        if return_shape:
+        if return_shape and return_shape != "always-none-optional":
             n_empty = sum(c for t, c in traces.items() if _matches_shape(t[-1], return_shape))
             records.append(
                 _make_record(

--- a/righttyper/diagnostics.py
+++ b/righttyper/diagnostics.py
@@ -1,0 +1,135 @@
+"""Emit per-degenerate-slot diagnostics JSON at `process` time.
+
+One record per slot whose observation multiset is uniformly degenerate (see
+``generalize.degenerate_shape``). The artifact lets follow-up tooling
+distinguish "exercise-driver gap" from "developer-broader annotation"
+without re-running the workload.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from righttyper.generalize import (
+    _is_empty_container,
+    _is_never_advanced,
+    degenerate_shape,
+)
+from righttyper.observations import Observations
+from righttyper.typeinfo import NoneTypeInfo, TypeInfo
+
+
+ARTIFACT_NAME = "righttyper-diagnostics.json"
+
+
+def _matches_shape(t: TypeInfo, shape: str) -> bool:
+    if shape == "empty-container":
+        return _is_empty_container(t)
+    if shape == "never-advanced-generator":
+        return _is_never_advanced(t)
+    if shape == "always-none-optional":
+        return t == NoneTypeInfo
+    return False
+
+
+def _coverage_block(
+    file: str,
+    qpath: str,
+    first_line: int,
+    coverage_by_file: dict[str, dict] | None,
+) -> dict[str, Any] | None:
+    if coverage_by_file is None:
+        return None
+    entry = coverage_by_file.get(file)
+    if entry is None:
+        return None
+    executed = set(entry.get("executed_lines", []))
+    func_block = entry.get("functions", {}).get(f"{qpath}@{first_line}")
+    if func_block is not None:
+        executed &= set(func_block.get("lines", []))
+    return {"function_executed": sorted(executed)}
+
+
+def _make_record(
+    code_id,
+    slot: str,
+    kind: str,
+    observations: set[TypeInfo],
+    shape: str,
+    n_observations: int,
+    n_empty: int,
+    coverage_by_file: dict[str, dict] | None,
+) -> dict[str, Any]:
+    raw_concrete = str(next(iter(observations)))
+    return {
+        "file": str(code_id.file_name),
+        "qpath": str(code_id.func_name),
+        "slot": slot,
+        "kind": kind,
+        "emitted_annotation": raw_concrete,
+        "degeneracy": {
+            "shape": shape,
+            "always_empty": n_empty == n_observations,
+            "n_observations": n_observations,
+            "n_empty": n_empty,
+            "raw_concrete": raw_concrete,
+        },
+        "coverage": _coverage_block(
+            str(code_id.file_name),
+            str(code_id.func_name),
+            code_id.first_code_line,
+            coverage_by_file,
+        ),
+    }
+
+
+def emit(
+    obs: Observations,
+    coverage: dict[str, Any] | None,
+    out_path: Path,
+) -> None:
+    """Walk `obs.func_info`, emit one JSON record per degenerate slot."""
+    coverage_by_file = coverage["files"] if coverage and "files" in coverage else None
+    if coverage is None:
+        print(
+            "warning: --with-coverage was passed to process but no coverage "
+            "data was found in the .rt pickle(s); the coverage block will be null",
+            file=sys.stderr,
+        )
+
+    records: list[dict[str, Any]] = []
+    for code_id, finfo in obs.func_info.items():
+        traces = finfo.traces
+        if not traces:
+            continue
+        n_observations = sum(traces.values())
+
+        # Return slot: last element of each CallTrace.
+        return_obs = {t[-1] for t in traces}
+        return_shape = degenerate_shape(return_obs)
+        if return_shape:
+            n_empty = sum(c for t, c in traces.items() if _matches_shape(t[-1], return_shape))
+            records.append(
+                _make_record(
+                    code_id, "return", "return", return_obs, return_shape,
+                    n_observations, n_empty, coverage_by_file,
+                )
+            )
+
+        # Positional args: index 0..len(args)-1 in each trace.
+        for i, arg_info in enumerate(finfo.args):
+            arg_obs = {t[i] for t in traces}
+            arg_shape = degenerate_shape(arg_obs)
+            if arg_shape:
+                n_empty = sum(c for t, c in traces.items() if _matches_shape(t[i], arg_shape))
+                records.append(
+                    _make_record(
+                        code_id, str(arg_info.arg_name), "arg",
+                        arg_obs, arg_shape, n_observations, n_empty, coverage_by_file,
+                    )
+                )
+
+    out_path.write_text(json.dumps(records, indent=2))

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -330,7 +330,7 @@ def lub(
         and isinstance(a.type_obj, type) and isinstance(b.type_obj, type)
     ):
         a_obj, b_obj = cast(type, a.type_obj), cast(type, b.type_obj)
-        common: type | None = None
+        common = None
         if issubclass(a_obj, b_obj):
             common = b_obj
         elif issubclass(b_obj, a_obj):

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -231,8 +231,15 @@ def lub(
                 is_covariant = issubclass(a.type_obj, _COVARIANT_TYPES) or a.type_obj is type
                 if for_variable or is_covariant:
                     can_merge = all(
-                        (isinstance(aa, TypeInfo) and isinstance(ba, TypeInfo))
-                        or aa is ba
+                        aa is ba or (
+                            isinstance(aa, TypeInfo) and isinstance(ba, TypeInfo)
+                            # ListTypeInfo (Callable's parameter list) only
+                            # merges cleanly when the arities match; otherwise
+                            # the elementwise lub yields a list-union that
+                            # renders as Callable[[A]|[B], R] — invalid syntax.
+                            and not (aa.is_list() and ba.is_list()
+                                     and len(aa.args) != len(ba.args))
+                        )
                         for aa, ba in zip(a.args, b.args)
                     )
                     if can_merge:

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -125,9 +125,14 @@ def _is_private_type(cls: type) -> bool:
     mod = getattr(cls, '__module__', '') or ''
     if mod == '__main__' or not any(p.startswith('_') for p in mod.split('.')):
         return False
-    # Private module — but check if any public module re-exports this type
+    # Private module — but check if any public module re-exports this type.
+    # Snapshot sys.modules: ``getattr(m, name, None)`` below can trigger a
+    # module-level ``__getattr__`` that performs a lazy import (httpx and
+    # several lazy-import frameworks do this), mutating sys.modules
+    # mid-iteration → RuntimeError.  Use a list snapshot, same defensive
+    # idiom as ``typemap.py:44``.
     name = getattr(cls, '__name__', '')
-    for m in sys.modules.values():
+    for m in list(sys.modules.values()):
         m_name = getattr(m, '__name__', '')
         if m_name and not any(p.startswith('_') for p in m_name.split('.')):
             if getattr(m, name, None) is cls:

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -5,7 +5,7 @@ from collections import Counter
 from functools import cache
 from types import EllipsisType
 import sys
-from righttyper.typeinfo import TypeInfo, ListTypeInfo, CallTrace
+from righttyper.typeinfo import TypeInfo, ListTypeInfo, CallTrace, NoneTypeInfo
 from righttyper.type_id import get_type_name
 from righttyper.options import output_options
 
@@ -464,6 +464,47 @@ def _is_empty_container(t: TypeInfo) -> bool:
                 and isinstance(t.type_obj, type) and issubclass(t.type_obj, abc.Container)
                 and all(isinstance(a, TypeInfo) and a.type_obj is Never
                         for a in t.args))
+
+
+def _is_never_advanced(t: TypeInfo) -> bool:
+    """True for a Generator/AsyncGenerator/Iterator/AsyncIterator with a
+    None yield type, or a Coroutine whose return type is None: the iterator
+    was constructed but never driven past first yield (or the coroutine was
+    never awaited to a useful return).
+    """
+    if t.type_obj in (abc.Generator, abc.AsyncGenerator, abc.Iterator, abc.AsyncIterator) and t.args:
+        first = t.args[0]
+        return isinstance(first, TypeInfo) and first == NoneTypeInfo
+    if t.type_obj is abc.Coroutine and len(t.args) == 3:
+        last = t.args[2]
+        return isinstance(last, TypeInfo) and last == NoneTypeInfo
+    return False
+
+
+def degenerate_shape(observations: abc.Iterable[TypeInfo]) -> str | None:
+    """Classify an observation multiset for the diagnostics artifact.
+
+    Returns one of:
+      - "empty-container":          every observation is an empty container
+      - "never-advanced-generator": every observation is a never-advanced
+                                    Generator/Iterator/Coroutine
+      - "always-none-optional":     every observation is None
+      - None:                       not (uniformly) degenerate
+
+    Mixed shapes (e.g. one observation that is an empty list plus another
+    that is a never-advanced iterator) abstain: the predicate refuses to
+    pick a misleading shape and returns None.
+    """
+    obs = set(observations)
+    if not obs:
+        return None
+    if all(t == NoneTypeInfo for t in obs):
+        return "always-none-optional"
+    if all(_is_empty_container(t) for t in obs):
+        return "empty-container"
+    if all(_is_never_advanced(t) for t in obs):
+        return "never-advanced-generator"
+    return None
 
 
 def merged_types(

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -14,6 +14,23 @@ from righttyper.options import output_options
 # is safe even for function parameters and return types.
 _COVARIANT_TYPES = (tuple, frozenset)
 
+# Single-arg generics whose lone type parameter is covariant in typeshed.
+# Used as Rule 6.5's allowlist of "safe" common ancestors: collapsing
+# ``list[X] | Iterable[Y]`` to ``Iterable[lub(X, Y)]`` is only sound
+# when the destination ABC is covariant in its arg. The mixed-variance
+# generics — ``Mapping`` (invariant key), ``Generator`` / ``Coroutine``
+# (contravariant send) — are intentionally excluded; collapsing them
+# would lie about variance.
+_FULLY_COVARIANT_SINGLE_ARG_TYPES = (
+    frozenset,
+    abc.Iterable, abc.Iterator,
+    abc.AsyncIterable, abc.AsyncIterator,
+    abc.Reversible, abc.Container, abc.Collection,
+    abc.Sequence, abc.Set,
+    abc.Awaitable,
+    abc.KeysView, abc.ValuesView,
+)
+
 # Generic types where bare form (no args) means "Any args" and subsumes parametrized forms.
 # Containers are handled separately via issubclass(t, abc.Container).
 # abc.Callable etc. are typing special forms, not types — silence mypy.
@@ -297,6 +314,35 @@ def lub(
                 nparams = 2 if issubclass(common, abc.Mapping) else 1
                 args = tuple(a for a in nonempty.args[:nparams] if isinstance(a, TypeInfo))
                 return get_type_name(common).replace(args=args)
+
+    # Rule 6.5: Both non-empty parametrized + one's outer is an MRO
+    # subclass of the other's, and the supertype is in the
+    # ``_FULLY_COVARIANT_SINGLE_ARG_TYPES`` allowlist → collapse to
+    # that supertype with one lub'd type arg. E.g.,
+    # ``list[X] | Iterable[Y] → Iterable[lub(X, Y)]``.
+    # The allowlist is the soundness guard: only members whose lone
+    # type parameter is covariant in typeshed qualify. Mixed-variance
+    # generics (``Mapping``, ``Generator``, ``Callable``…) deliberately
+    # fall through to a union rather than being collapsed unsoundly.
+    if (
+        a.type_obj is not b.type_obj
+        and a.args and b.args
+        and isinstance(a.type_obj, type) and isinstance(b.type_obj, type)
+    ):
+        a_obj, b_obj = cast(type, a.type_obj), cast(type, b.type_obj)
+        common: type | None = None
+        if issubclass(a_obj, b_obj):
+            common = b_obj
+        elif issubclass(b_obj, a_obj):
+            common = a_obj
+        if (
+            common is not None
+            and common in _FULLY_COVARIANT_SINGLE_ARG_TYPES
+        ):
+            a0, b0 = a.args[0], b.args[0]
+            if isinstance(a0, TypeInfo) and isinstance(b0, TypeInfo):
+                merged = lub(a0, b0, assume_covariant=True)
+                return get_type_name(common).replace(args=(merged,))
 
     # Rule 7: MRO common supertype (non-generic types only).
     if not a.args and not b.args:

--- a/righttyper/generalize.py
+++ b/righttyper/generalize.py
@@ -144,13 +144,21 @@ def _is_subtype(a: type, b: type) -> bool:
 def lub(
     a: TypeInfo,
     b: TypeInfo,
-    for_variable: bool = False,
+    assume_covariant: bool = False,
     accessed_attributes: set[str] | None = None,
 ) -> TypeInfo:
     """Compute the least upper bound (most specific common supertype) of two types.
 
     Returns a single TypeInfo that contains both a and b. Falls back to
     a union (a | b) when no better merge is available.
+
+    ``assume_covariant=True`` tells lub to treat ordinarily-invariant
+    containers (``list``, ``dict``, ``set``) as if they were covariant
+    for the purpose of arg-merging — so ``lub(list[X], list[Y])`` becomes
+    ``list[lub(X, Y)]`` instead of leaving the union ``list[X] | list[Y]``
+    intact. Use it when the type being computed describes a value being
+    produced (return values, locals) rather than a slot that has to
+    accept caller-supplied values invariantly (function parameters).
     """
     # Rule 1: Identity
     if a == b:
@@ -229,7 +237,7 @@ def lub(
             if len(a.args) == len(b.args):
                 # type[X] is covariant (type[B] <: type[A] when B <: A)
                 is_covariant = issubclass(a.type_obj, _COVARIANT_TYPES) or a.type_obj is type
-                if for_variable or is_covariant:
+                if assume_covariant or is_covariant:
                     can_merge = all(
                         aa is ba or (
                             isinstance(aa, TypeInfo) and isinstance(ba, TypeInfo)
@@ -244,7 +252,7 @@ def lub(
                     )
                     if can_merge:
                         merged_args = tuple(
-                            lub(cast(TypeInfo, aa), cast(TypeInfo, ba), for_variable=True)
+                            lub(cast(TypeInfo, aa), cast(TypeInfo, ba), assume_covariant=True)
                             if isinstance(aa, TypeInfo) and isinstance(ba, TypeInfo)
                             else aa
                             for aa, ba in zip(a.args, b.args)
@@ -339,9 +347,9 @@ def lub(
                         or issubclass(b.type_obj, _COVARIANT_TYPES)
                         or a.type_obj is type or b.type_obj is type
                     )
-                    if for_variable or either_immutable:
+                    if assume_covariant or either_immutable:
                         merged_args = tuple(
-                            lub(a_ti[i], b_ti[i], for_variable=True)
+                            lub(a_ti[i], b_ti[i], assume_covariant=True)
                             for i in range(n)
                         )
                         return get_type_name(best).replace(args=merged_args)
@@ -358,7 +366,7 @@ def lub(
 
 def _merge_set(
     typeinfoset: set[TypeInfo],
-    for_variable: bool = False,
+    assume_covariant: bool = False,
     accessed_attributes: set[str] | None = None,
 ) -> TypeInfo:
     """Reduce a set of types using pairwise lub, then form the final union."""
@@ -418,7 +426,7 @@ def _merge_set(
         while i < len(types):
             j = i + 1
             while j < len(types):
-                merged = lub(types[i], types[j], for_variable, accessed_attributes)
+                merged = lub(types[i], types[j], assume_covariant, accessed_attributes)
                 if not merged.is_union():
                     # lub produced a single type — replace both with it
                     types[i] = merged
@@ -516,7 +524,7 @@ def degenerate_shape(observations: abc.Iterable[TypeInfo]) -> str | None:
 
 def merged_types(
     typeinfoset: set[TypeInfo],
-    for_variable: bool = False,
+    assume_covariant: bool = False,
     accessed_attributes: set[str] | None = None,
 ) -> TypeInfo:
     """Attempts to merge types in a set before forming their union."""
@@ -525,7 +533,7 @@ def merged_types(
         # is gated separately; honor the flag here so callers don't need to.
         if not output_options.use_attribute_simplification:
             accessed_attributes = None
-        return _merge_set(typeinfoset, for_variable, accessed_attributes)
+        return _merge_set(typeinfoset, assume_covariant, accessed_attributes)
     return TypeInfo.from_set(typeinfoset)
 
 

--- a/righttyper/loader.py
+++ b/righttyper/loader.py
@@ -141,13 +141,14 @@ class PathEntryHook:
 def pytest_patcher():
     """Patches pytest to allow instrumentation."""
 
+    pyrewrite: typing.Any = None
     orig_rewrite_asserts: typing.Any = None
     orig_read_pyc: typing.Any = None
     orig_write_pyc: typing.Any = None
 
     try:
-        import _pytest.assertion.rewrite as pyrewrite
-
+        import _pytest.assertion.rewrite as pyrewrite_mod
+        pyrewrite = pyrewrite_mod
         orig_rewrite_asserts = pyrewrite.rewrite_asserts
         orig_read_pyc = pyrewrite._read_pyc
         orig_write_pyc = pyrewrite._write_pyc
@@ -161,20 +162,20 @@ def pytest_patcher():
 
     def read_pyc(*args, **kwargs):
         # don't read any cached pyc, forcing it to go to source
-        return None 
+        return None
 
     def write_pyc(*args, **kwargs):
         # don't save our patched bytecode... this might be slow
         pass
 
-    if orig_rewrite_asserts:
+    if pyrewrite is not None:
         pyrewrite.rewrite_asserts = rewrite_asserts
         pyrewrite._read_pyc = read_pyc
         pyrewrite._write_pyc = write_pyc
 
     yield   # return control a la pytest fixture
 
-    if orig_rewrite_asserts:
+    if pyrewrite is not None:
         # now clean up
         pyrewrite.rewrite_asserts = orig_rewrite_asserts
         pyrewrite._read_pyc = orig_read_pyc

--- a/righttyper/loader.py
+++ b/righttyper/loader.py
@@ -14,6 +14,7 @@ from righttyper.variable_capture import code2variables, map_variables
 from righttyper.righttyper_utils import skip_this_file, skip_this_code
 from righttyper.righttyper_tool import setup_monitoring_for_code
 from righttyper.options import output_options
+from righttyper import coverage as rt_coverage
 
 
 class RightTyperLoader(ExecutionLoader):
@@ -44,7 +45,11 @@ class RightTyperLoader(ExecutionLoader):
     def get_code(self, fullname: str) -> types.CodeType:
         tree = ast.parse(self.get_source(fullname))
         tree = instrument(tree, replace_dict=self.replace_dict)
+        if rt_coverage.is_enabled():
+            tree = rt_coverage.preinstrument(tree)
         code = compile(tree, str(self.path), "exec")
+        if rt_coverage.is_enabled():
+            code = rt_coverage.instrument_code(code)
         code2variables.update(map_variables(
             tree, code,
             track_attributes=output_options.use_attribute_simplification,

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -541,8 +541,57 @@ class Observations:
                 ct_dict[var_name] = set(tr.visit(t) for t in ct_types)
 
 
+    def _check_line_shifted_conflict(self, obs2: "Observations") -> None:
+        """Refuse to merge .rt files that come from different source revisions.
+
+        The merge keys on ``CodeId``, which embeds ``first_code_line``. If
+        two .rt files were recorded against versions of the same source file
+        whose line numbers differ (e.g. one before and one after
+        ``process --output-files`` rewrote annotations), the same
+        ``(file_name, func_name)`` ends up with different ``CodeId``s and
+        the merge silently keeps both entries as orphans — leaving the
+        downstream emitter to pick one and drop the other's observations.
+        Detect this and raise so the caller can re-collect against a
+        consistent source state.
+
+        Skips synthetic names (``<listcomp>``, ``<genexpr>``, ``<lambda>``,
+        ``<dictcomp>``, ``<setcomp>``) since those legitimately recur at
+        different lines in the same file.
+        """
+        if not self.func_info or not obs2.func_info:
+            return
+
+        def is_synthetic(name: "FunctionName") -> bool:
+            return name.startswith("<")
+
+        existing: dict[tuple["Filename", "FunctionName"], int] = {}
+        for fid in self.func_info:
+            if is_synthetic(fid.func_name):
+                continue
+            existing.setdefault(
+                (fid.file_name, fid.func_name), fid.first_code_line,
+            )
+
+        for fid in obs2.func_info:
+            if is_synthetic(fid.func_name):
+                continue
+            other_line = existing.get((fid.file_name, fid.func_name))
+            if other_line is None or other_line == fid.first_code_line:
+                continue
+            raise ValueError(
+                f"Refusing to merge: {fid.func_name!r} in {fid.file_name} "
+                f"has first_code_line {other_line} in one observation set "
+                f"and {fid.first_code_line} in the other. The .rt files "
+                f"were recorded against different source revisions (often "
+                f"because ``process --output-files`` rewrote annotations "
+                f"between collections). Remedy: delete righttyper-*.rt "
+                f"and re-collect against a consistent source state."
+            )
+
     def merge_observations(self, obs2: "Observations") -> None:
         """Merges other observations into this one."""
+
+        self._check_line_shifted_conflict(obs2)
 
         for func_id, func_info2 in obs2.func_info.items():
             if (func_info := self.func_info.get(func_id)):

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -977,15 +977,8 @@ class Observations:
             for var_name, var_types in func_info.variables.items()
         }
 
-        # Re-process the return-position type through ``merged_types`` with
-        # ``assume_covariant=True``: return values are produced by the
-        # function (not invariant input slots), so lub's covariant-arg-
-        # merging rule can collapse ``list[X] | list[X|Y]``-style refinement
-        # fragments that ``generalize`` left intact when the surrounding
-        # union also had outer-container heterogeneity (e.g. a ``tuple``
-        # mixed in alongside ``list`` returns).
         retval = _apply_constructor_type(
-            merged_types(signature[-1].to_set(), assume_covariant=True),
+            signature[-1],
             func_info.constructor_types.get(RETURN_CONSTRUCTOR_KEY, set()),
         )
 

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -556,15 +556,27 @@ class Observations:
         getter/setter, or two named closures in adjacent branches of one
         enclosing function) hash to different ``bytecode_hash`` values
         and don't collide here.
+
+        Synthetic functions (``<lambda>``, ``<listcomp>``, ``<genexpr>``,
+        ``<dictcomp>``, ``<setcomp>``) are exempt: Python compiles a
+        genexp / comprehension so the iterable is passed in as ``.0``
+        rather than referenced from the body, so two physically distinct
+        synthetics in the same enclosing function frequently share body
+        bytecode.  They are distinct sites, not drift.
         """
         if not self.func_info or not obs2.func_info:
             return
+
+        def is_synthetic(name: "FunctionName") -> bool:
+            return name.startswith("<") or name.rsplit(".", 1)[-1].startswith("<")
 
         def lines_by_content(
             obs: "Observations",
         ) -> dict[tuple["Filename", int], tuple[int, "FunctionName"]]:
             out: dict[tuple["Filename", int], tuple[int, "FunctionName"]] = {}
             for fi in obs.func_info.values():
+                if is_synthetic(fi.code_id.func_name):
+                    continue
                 key = (fi.code_id.file_name, fi.code_id.bytecode_hash)
                 out[key] = (fi.code_id.first_code_line, fi.code_id.func_name)
             return out

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -896,6 +896,7 @@ class Observations:
         # process this trace, any nested Callable/Generator code_ids it contains
         # have ready annotations. This lets the Self detection below recurse
         # into resolved types (e.g., a lambda's retval that matches self_class).
+        resolver: ResolvingT | None = None
         if annotations:
             resolver = ResolvingT(
                 annotations,
@@ -967,7 +968,7 @@ class Observations:
         variables = {
             var_name: _apply_constructor_type(
                 merged_types(
-                    {resolver.visit(t) for t in var_types} if annotations else var_types,
+                    {resolver.visit(t) for t in var_types} if resolver is not None else var_types,
                     for_variable=True,
                     accessed_attributes=accessed_attributes.get(var_name) if accessed_attributes else None,
                 ),

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -969,7 +969,7 @@ class Observations:
             var_name: _apply_constructor_type(
                 merged_types(
                     {resolver.visit(t) for t in var_types} if resolver is not None else var_types,
-                    for_variable=True,
+                    assume_covariant=True,
                     accessed_attributes=accessed_attributes.get(var_name) if accessed_attributes else None,
                 ),
                 func_info.constructor_types.get(var_name, set()),
@@ -977,8 +977,15 @@ class Observations:
             for var_name, var_types in func_info.variables.items()
         }
 
+        # Re-process the return-position type through ``merged_types`` with
+        # ``assume_covariant=True``: return values are produced by the
+        # function (not invariant input slots), so lub's covariant-arg-
+        # merging rule can collapse ``list[X] | list[X|Y]``-style refinement
+        # fragments that ``generalize`` left intact when the surrounding
+        # union also had outer-container heterogeneity (e.g. a ``tuple``
+        # mixed in alongside ``list`` returns).
         retval = _apply_constructor_type(
-            signature[-1],
+            merged_types(signature[-1].to_set(), assume_covariant=True),
             func_info.constructor_types.get(RETURN_CONSTRUCTOR_KEY, set()),
         )
 
@@ -1085,7 +1092,7 @@ class Observations:
                 var_name: _apply_constructor_type(
                     mv_resolver.visit(merged_types(
                         var_types,
-                        for_variable=True,
+                        assume_covariant=True,
                         accessed_attributes=module_accessed.get(filename, {}).get(var_name) or None,
                     )),
                     self.module_constructor_types.get(filename, {}).get(var_name, set()),

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -22,7 +22,7 @@ from righttyper.type_transformers import (
     LoadTypeObjT
 )
 from righttyper.typeinfo import TypeInfo, TypeInfoArg, UnknownTypeInfo, UnionTypeInfo, CallTrace
-from righttyper.righttyper_types import ArgumentName, VariableName, Filename, CodeId
+from righttyper.righttyper_types import ArgumentName, FunctionName, VariableName, Filename, CodeId
 from righttyper.annotation import FuncAnnotation, ModuleVars, TraceDistribution
 from righttyper.type_id import PostponedArg0, get_type_name
 from righttyper.typeshed import get_typeshed_func_signature

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -575,7 +575,12 @@ class Observations:
             return
 
         def is_synthetic(name: "FunctionName") -> bool:
-            return name.startswith("<")
+            # Synthetic functions (<lambda>, <listcomp>, <genexpr>,
+            # <dictcomp>, <setcomp>) legitimately recur at different
+            # lines in the same file with the same parameter shape.
+            # CPython qualnames them either as the bare synthetic
+            # (top-level) or as ``Outer.<locals>.<synthetic>`` (nested).
+            return name.startswith("<") or name.rsplit(".", 1)[-1].startswith("<")
 
         # The key disambiguates entries that legitimately share
         # (file_name, func_name) at distinct lines — property

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -22,7 +22,7 @@ from righttyper.type_transformers import (
     LoadTypeObjT
 )
 from righttyper.typeinfo import TypeInfo, TypeInfoArg, UnknownTypeInfo, UnionTypeInfo, CallTrace
-from righttyper.righttyper_types import ArgumentName, FunctionName, VariableName, Filename, CodeId
+from righttyper.righttyper_types import ArgumentName, FunctionName, VariableName, Filename, CodeId, FuncLoc
 from righttyper.annotation import FuncAnnotation, ModuleVars, TraceDistribution
 from righttyper.type_id import PostponedArg0, get_type_name
 from righttyper.typeshed import get_typeshed_func_signature
@@ -544,89 +544,46 @@ class Observations:
     def _check_line_shifted_conflict(self, obs2: "Observations") -> None:
         """Refuse to merge .rt files that come from different source revisions.
 
-        The merge keys on ``CodeId``, which embeds ``first_code_line``. If
-        two .rt files were recorded against versions of the same source file
-        whose line numbers differ (e.g. one before and one after
-        ``process --output-files`` rewrote annotations), the same
-        ``(file_name, func_name)`` ends up with different ``CodeId``s and
-        the merge silently keeps both entries as orphans — leaving the
-        downstream emitter to pick one and drop the other's observations.
-        Detect this and raise so the caller can re-collect against a
-        consistent source state.
+        Two FuncInfos sharing ``(file_name, bytecode_hash)`` at distinct
+        ``first_code_line`` values were recorded against versions of the
+        same source file whose line numbers differ (e.g. one before and
+        one after ``process --output-files`` rewrote annotations) — the
+        bytecode is identical but the function moved. Merging them
+        silently would attribute observations to the wrong source
+        location.
 
-        Some legitimate cases share a ``(file_name, func_name)`` across
-        distinct ``first_code_line`` values without being a conflict:
-
-          * property getter/setter/deleter (all reported as ``Cls.prop``);
-          * synthetic names — ``<listcomp>``, ``<genexpr>``, ``<lambda>``,
-            ``<dictcomp>``, ``<setcomp>``;
-          * any user-defined overload that genuinely has the same qualname
-            at multiple source locations.
-
-        The disambiguator: collect the *set* of observed lines per
-        ``(file_name, func_name)`` from each side. A line from ``obs2``
-        only triggers a conflict if it is **not present** in ``obs1``'s
-        set for that name *and* ``obs1``'s set is non-empty — i.e. each
-        side independently saw a different line for what they think is
-        the same function. When both sides agree that a name has both
-        lines (typical of getter/setter), that's fine.
+        Different bodies at different lines (e.g. property
+        getter/setter, or two named closures in adjacent branches of one
+        enclosing function) hash to different ``bytecode_hash`` values
+        and don't collide here.
         """
         if not self.func_info or not obs2.func_info:
             return
 
-        def is_synthetic(name: "FunctionName") -> bool:
-            # Synthetic functions (<lambda>, <listcomp>, <genexpr>,
-            # <dictcomp>, <setcomp>) legitimately recur at different
-            # lines in the same file with the same parameter shape.
-            # CPython qualnames them either as the bare synthetic
-            # (top-level) or as ``Outer.<locals>.<synthetic>`` (nested).
-            return name.startswith("<") or name.rsplit(".", 1)[-1].startswith("<")
-
-        # The key disambiguates entries that legitimately share
-        # (file_name, func_name) at distinct lines — property
-        # getter/setter, methods with different arities, etc. — by their
-        # parameter shape. A line shift caused by source-revision drift
-        # would preserve the signature but change the line; that case
-        # produces a single ``key`` that maps to different lines in obs1
-        # vs obs2 and triggers the raise.
-        def sig_key(
-            fi: "FuncInfo",
-        ) -> tuple["Filename", "FunctionName", tuple["ArgumentName", ...],
-                  "ArgumentName | None", "ArgumentName | None"]:
-            return (
-                fi.code_id.file_name,
-                fi.code_id.func_name,
-                tuple(a.arg_name for a in fi.args),
-                fi.varargs,
-                fi.kwargs,
-            )
-
-        def line_by_sig(obs: "Observations") -> dict[tuple, int]:
-            out: dict[tuple, int] = {}
+        def lines_by_content(
+            obs: "Observations",
+        ) -> dict[tuple["Filename", int], tuple[int, "FunctionName"]]:
+            out: dict[tuple["Filename", int], tuple[int, "FunctionName"]] = {}
             for fi in obs.func_info.values():
-                if is_synthetic(fi.code_id.func_name):
-                    continue
-                out[sig_key(fi)] = fi.code_id.first_code_line
+                key = (fi.code_id.file_name, fi.code_id.bytecode_hash)
+                out[key] = (fi.code_id.first_code_line, fi.code_id.func_name)
             return out
 
-        lines1 = line_by_sig(self)
-        lines2 = line_by_sig(obs2)
-
-        for key, l2 in lines2.items():
-            l1 = lines1.get(key)
-            if l1 is None or l1 == l2:
+        lines1 = lines_by_content(self)
+        for key, (l2, _name2) in lines_by_content(obs2).items():
+            entry = lines1.get(key)
+            if entry is None or entry[0] == l2:
                 continue
+            l1, name1 = entry
             file_name = key[0]
-            func_name = key[1]
             raise ValueError(
-                f"Refusing to merge: {func_name!r} in {file_name} has "
+                f"Refusing to merge: {name1!r} in {file_name} has "
                 f"first_code_line {l1} in one observation set and {l2} "
-                f"in the other (same parameter shape). The .rt files "
-                f"were recorded against different source revisions "
-                f"(often because ``process --output-files`` rewrote "
-                f"annotations between collections). Remedy: delete "
-                f"righttyper-*.rt and re-collect against a consistent "
-                f"source state."
+                f"in the other (identical bytecode). The .rt files were "
+                f"recorded against different source revisions (often "
+                f"because ``process --output-files`` rewrote annotations "
+                f"between collections). Remedy: delete righttyper-*.rt "
+                f"and re-collect against a consistent source state."
             )
 
     def merge_observations(self, obs2: "Observations") -> None:
@@ -1058,7 +1015,7 @@ class Observations:
         return result
 
 
-    def collect_annotations(self) -> tuple[dict[CodeId, FuncAnnotation], dict[Filename, ModuleVars], dict[CodeId, list[TraceDistribution]]]:
+    def collect_annotations(self) -> tuple[dict[FuncLoc, FuncAnnotation], dict[Filename, ModuleVars], dict[FuncLoc, list[TraceDistribution]]]:
         """Collects function type annotations from the observed types."""
 
         accessed_attrs = self.accessed_attributes
@@ -1195,7 +1152,11 @@ class Observations:
 
         transform_types(MakePickleableT())
 
-        return annotations, module_vars, type_distributions
+        return (
+            {c.to_loc(): a for c, a in annotations.items()},
+            module_vars,
+            {c.to_loc(): d for c, d in type_distributions.items()},
+        )
 
 
 class LoadAndCheckTypesT(LoadTypeObjT):

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -554,9 +554,22 @@ class Observations:
         Detect this and raise so the caller can re-collect against a
         consistent source state.
 
-        Skips synthetic names (``<listcomp>``, ``<genexpr>``, ``<lambda>``,
-        ``<dictcomp>``, ``<setcomp>``) since those legitimately recur at
-        different lines in the same file.
+        Some legitimate cases share a ``(file_name, func_name)`` across
+        distinct ``first_code_line`` values without being a conflict:
+
+          * property getter/setter/deleter (all reported as ``Cls.prop``);
+          * synthetic names — ``<listcomp>``, ``<genexpr>``, ``<lambda>``,
+            ``<dictcomp>``, ``<setcomp>``;
+          * any user-defined overload that genuinely has the same qualname
+            at multiple source locations.
+
+        The disambiguator: collect the *set* of observed lines per
+        ``(file_name, func_name)`` from each side. A line from ``obs2``
+        only triggers a conflict if it is **not present** in ``obs1``'s
+        set for that name *and* ``obs1``'s set is non-empty — i.e. each
+        side independently saw a different line for what they think is
+        the same function. When both sides agree that a name has both
+        lines (typical of getter/setter), that's fine.
         """
         if not self.func_info or not obs2.func_info:
             return
@@ -564,28 +577,51 @@ class Observations:
         def is_synthetic(name: "FunctionName") -> bool:
             return name.startswith("<")
 
-        existing: dict[tuple["Filename", "FunctionName"], int] = {}
-        for fid in self.func_info:
-            if is_synthetic(fid.func_name):
-                continue
-            existing.setdefault(
-                (fid.file_name, fid.func_name), fid.first_code_line,
+        # The key disambiguates entries that legitimately share
+        # (file_name, func_name) at distinct lines — property
+        # getter/setter, methods with different arities, etc. — by their
+        # parameter shape. A line shift caused by source-revision drift
+        # would preserve the signature but change the line; that case
+        # produces a single ``key`` that maps to different lines in obs1
+        # vs obs2 and triggers the raise.
+        def sig_key(
+            fi: "FuncInfo",
+        ) -> tuple["Filename", "FunctionName", tuple["ArgumentName", ...],
+                  "ArgumentName | None", "ArgumentName | None"]:
+            return (
+                fi.code_id.file_name,
+                fi.code_id.func_name,
+                tuple(a.arg_name for a in fi.args),
+                fi.varargs,
+                fi.kwargs,
             )
 
-        for fid in obs2.func_info:
-            if is_synthetic(fid.func_name):
+        def line_by_sig(obs: "Observations") -> dict[tuple, int]:
+            out: dict[tuple, int] = {}
+            for fi in obs.func_info.values():
+                if is_synthetic(fi.code_id.func_name):
+                    continue
+                out[sig_key(fi)] = fi.code_id.first_code_line
+            return out
+
+        lines1 = line_by_sig(self)
+        lines2 = line_by_sig(obs2)
+
+        for key, l2 in lines2.items():
+            l1 = lines1.get(key)
+            if l1 is None or l1 == l2:
                 continue
-            other_line = existing.get((fid.file_name, fid.func_name))
-            if other_line is None or other_line == fid.first_code_line:
-                continue
+            file_name = key[0]
+            func_name = key[1]
             raise ValueError(
-                f"Refusing to merge: {fid.func_name!r} in {fid.file_name} "
-                f"has first_code_line {other_line} in one observation set "
-                f"and {fid.first_code_line} in the other. The .rt files "
-                f"were recorded against different source revisions (often "
-                f"because ``process --output-files`` rewrote annotations "
-                f"between collections). Remedy: delete righttyper-*.rt "
-                f"and re-collect against a consistent source state."
+                f"Refusing to merge: {func_name!r} in {file_name} has "
+                f"first_code_line {l1} in one observation set and {l2} "
+                f"in the other (same parameter shape). The .rt files "
+                f"were recorded against different source revisions "
+                f"(often because ``process --output-files`` rewrote "
+                f"annotations between collections). Remedy: delete "
+                f"righttyper-*.rt and re-collect against a consistent "
+                f"source state."
             )
 
     def merge_observations(self, obs2: "Observations") -> None:

--- a/righttyper/observations.py
+++ b/righttyper/observations.py
@@ -680,10 +680,14 @@ class Observations:
                                          f"    {a2.arg_name}"
                         )
                 if args1 != args2:
+                    # Empty default set → no-default arg; preserve Python None.
                     func_info.args = tuple(
                         ArgInfo(
                             a1.arg_name,
-                            TypeInfo.from_set({d for d in (a1.default, a2.default) if d is not None}, empty_is_none=True)
+                            TypeInfo.from_set(
+                                {d for d in (a1.default, a2.default) if d is not None},
+                                on_empty=None,
+                            )
                         )
                         for a1, a2 in zip(args1, args2)
                     )

--- a/righttyper/options.py
+++ b/righttyper/options.py
@@ -90,6 +90,7 @@ class RunOptions:
     infer_wrapped_return_type: bool = True
     max_union_size: int = 32  # Unions exceeding this collapse to Any
     container_caching: bool = True  # Cache container scans; --no-container-caching forces rescan every visit
+    with_coverage: bool = False  # When True, compose slipcover branch instrumentation alongside RT and persist line coverage
 
 
     def process_args(self, kwargs: dict[str, Any]) -> None:

--- a/righttyper/options.py
+++ b/righttyper/options.py
@@ -30,6 +30,7 @@ class OutputOptions:
     type_distribution_comments: bool = False
     use_attribute_simplification: bool = False
     use_constructor_types: bool = False
+    with_coverage: bool = False  # At run: enable SlipCover instrumentation; at process: emit diagnostics artifact
 
 
     def process_args(self, kwargs: dict[str, Any]) -> None:
@@ -90,7 +91,6 @@ class RunOptions:
     infer_wrapped_return_type: bool = True
     max_union_size: int = 32  # Unions exceeding this collapse to Any
     container_caching: bool = True  # Cache container scans; --no-container-caching forces rescan every visit
-    with_coverage: bool = False  # When True, compose slipcover branch instrumentation alongside RT and persist line coverage
 
 
     def process_args(self, kwargs: dict[str, Any]) -> None:

--- a/righttyper/recorder.py
+++ b/righttyper/recorder.py
@@ -232,7 +232,9 @@ class _ResolveContainerSnapshotT(TypeInfo.Transformer):
                 # cache's current resolved per-counter view.  Tagged
                 # nodes are never ``UnionTypeInfo``s (handlers only tag
                 # container outers), so this can't collapse a union.
-                node = node.replace(args=cache_entry.resolved_samples())
+                resolved = cache_entry.resolved_samples()
+                if resolved != node.args:
+                    node = node.replace(args=resolved)
         # Recurse to find tagged descendants — inner container_ids in
         # the rewritten args, or members of an untagged Union.
         node = super().visit(node)

--- a/righttyper/recorder.py
+++ b/righttyper/recorder.py
@@ -118,7 +118,14 @@ class PendingCallTrace:
         self_type: TypeInfo|None,
     ) -> None:
         self.arg_info = arg_info
-        self.args_start = self._get_arg_types(arg_info)
+        # PY_START's arg_info.locals always contains every arg name (Python
+        # binds parameters before the body runs), so no element here is
+        # ever None — the per-entry None case in _get_arg_types only
+        # applies to later samples where a name may have been del'd.
+        self.args_start = typing.cast(
+            "tuple[TypeInfo, ...]",
+            self._get_arg_types(arg_info, arg_info.locals),
+        )
         self.yields: set[TypeInfo] = set()
         self.sends: set[TypeInfo] = set()
         self.is_async = bool(co_flags & (inspect.CO_ASYNC_GENERATOR | inspect.CO_COROUTINE))
@@ -127,36 +134,45 @@ class PendingCallTrace:
 
 
     @staticmethod
-    def _get_arg_types(arg_info: inspect.ArgInfo) -> tuple[TypeInfo, ...]:
-        """Computes the types of the given arguments."""
+    def _get_arg_types(
+        arg_info: inspect.ArgInfo,
+        locals_map: abc.Mapping[str, Any],
+    ) -> tuple[TypeInfo | None, ...]:
+        """Computes the types of the given arguments by looking up each name
+        in ``locals_map``. Yields ``None`` for any name absent from it
+        (callers fall back to the entry-time observation)."""
         return (
             *(
-                get_value_type(arg_info.locals[arg_name]) if arg_name in arg_info.locals else None
+                get_value_type(locals_map[arg_name]) if arg_name in locals_map else None
                 for arg_name in arg_info.args
             ),
             *(
                 (
                     # Empty *args/**kwargs → Never, absorbed by the union.
                     TypeInfo.from_set({
-                        get_value_type(val) for val in arg_info.locals[arg_info.varargs]
+                        get_value_type(val) for val in locals_map[arg_info.varargs]
                     })
-                    if arg_info.varargs in arg_info.locals else None,
+                    if arg_info.varargs in locals_map else None,
                 )
                 if arg_info.varargs else ()
             ),
             *(
                 (
                     TypeInfo.from_set({
-                        get_value_type(val) for val in arg_info.locals[arg_info.keywords].values()
+                        get_value_type(val) for val in locals_map[arg_info.keywords].values()
                     })
-                    if arg_info.keywords in arg_info.locals else None,
+                    if arg_info.keywords in locals_map else None,
                 )
                 if arg_info.keywords else ()
             )
         )
 
 
-    def finish(self, retval: TypeInfo) -> CallTrace:
+    def finish(
+        self,
+        retval: TypeInfo,
+        locals_map: abc.Mapping[str, Any],
+    ) -> CallTrace:
         if self.is_generator:
             # A generator that never yielded/sent really has type None.
             y = TypeInfo.from_set(self.yields, on_empty=NoneTypeInfo)
@@ -167,12 +183,18 @@ class PendingCallTrace:
             else:
                 retval = TypeInfo.from_type(abc.Generator, args=(y, s, retval))
 
-        # Arguments may change value (and, in particular, empty containers may be added to)
-        # during the function execution, so we sample a 2nd time at the end.
-        args_now = self._get_arg_types(self.arg_info)
+        # Arguments may change value during execution — either a mutable
+        # container is filled in, or the parameter name is rebound to a
+        # different value (possibly of a different type). Callers with a
+        # live returning frame pass its ``f_locals`` to capture both kinds
+        # of change; callers without one (wrapped traces whose function
+        # never ran, leftover generators at shutdown) pass the PY_START
+        # snapshot, which still reflects in-place container mutations.
+        args_now = self._get_arg_types(self.arg_info, locals_map)
         type_data: tuple[TypeInfo, ...] = (
-            *tuple(
-                at_start if now is None else TypeInfo.from_set({at_start, now})
+            *(
+                at_start if now is None
+                else cast_not_None(TypeInfo.from_set({at_start, now}))
                 for at_start, now in zip(self.args_start, args_now)
             ),
             retval
@@ -567,8 +589,17 @@ class ObservationsRecorder:
                     class_attrs[VariableName(attr)].add(TypeInfo.from_type(const_type))
 
 
-    def _record_return_type(self, tr: PendingCallTrace, code: CodeType, ret_type: Any) -> None:
-        """Records a pending call trace's return type, finishing the trace."""
+    def _record_return_type(
+        self,
+        tr: PendingCallTrace,
+        code: CodeType,
+        ret_type: Any,
+        locals_map: abc.Mapping[str, Any],
+    ) -> None:
+        """Records a pending call trace's return type, finishing the trace.
+        ``locals_map`` is the live ``frame.f_locals`` from the returning
+        frame, or the PY_START snapshot when no live frame is available
+        (wrapped traces whose function never ran; leftover generators)."""
         assert tr is not None
 
         retval_type = (
@@ -581,7 +612,7 @@ class ObservationsRecorder:
         )
 
         func_info = self._code2func_info[code]
-        func_info.traces.update((tr.finish(retval_type),))
+        func_info.traces.update((tr.finish(retval_type, locals_map),))
 
 
     def _complete_wrapped_trace(self, code: CodeType, frame_id: FrameId, return_value: Any) -> None:
@@ -600,7 +631,10 @@ class ObservationsRecorder:
                     if run_options.infer_wrapped_return_type
                     else UnknownTypeInfo
                 )
-                self._record_return_type(tr, wrapped_code, retval_type)
+                # No live frame for the wrapped function (it never ran);
+                # re-sample from the PY_START snapshot to preserve any
+                # in-place container mutations.
+                self._record_return_type(tr, wrapped_code, retval_type, tr.arg_info.locals)
 
 
     def record_return(self, code: CodeType, frame: FrameType, return_value: Any) -> bool:
@@ -609,7 +643,7 @@ class ObservationsRecorder:
         # print(f"record_return {code.co_qualname}")
         frame_id = id(frame)
         if (per_frame := self._pending_traces.get(code)) and (tr := per_frame.get(frame_id)):
-            self._record_return_type(tr, code, get_value_type(return_value))
+            self._record_return_type(tr, code, get_value_type(return_value), frame.f_locals)
             self._record_variables(code, frame)
             del per_frame[frame_id]
             self._complete_wrapped_trace(code, frame_id, return_value)
@@ -626,7 +660,7 @@ class ObservationsRecorder:
         # print(f"record_no_return {code.co_qualname}")
         frame_id = id(frame)
         if (per_frame := self._pending_traces.get(code)) and (tr := per_frame.get(frame_id)):
-            self._record_return_type(tr, code, None)
+            self._record_return_type(tr, code, None, frame.f_locals)
             self._record_variables(code, frame)
             del per_frame[frame_id]
             # Discard wrapped trace on exception
@@ -773,7 +807,9 @@ class ObservationsRecorder:
         for code, per_frame in self._pending_traces.items():
             for tr in per_frame.values():
                 if tr.is_generator:
-                    self._record_return_type(tr, code, None)
+                    # Their frames are no longer reachable here; re-sample
+                    # from the PY_START snapshot.
+                    self._record_return_type(tr, code, None, tr.arg_info.locals)
 
         self._assign_attributes_to_scopes()
 

--- a/righttyper/recorder.py
+++ b/righttyper/recorder.py
@@ -2,7 +2,7 @@ import inspect
 import builtins
 from dataclasses import dataclass, field
 from types import CodeType, FrameType, FunctionType, GeneratorType
-from collections import Counter, defaultdict
+from collections import defaultdict
 import collections.abc as abc
 from pathlib import Path
 import logging
@@ -204,46 +204,38 @@ class PendingCallTrace:
 
 
 class _ResolveContainerSnapshotT(TypeInfo.Transformer):
-    """Rewrites every TypeInfo node carrying a ``container_id`` whose
-    corresponding ``ContainerSamples`` entry is in the by-cid map (built
-    once from the live cache at recording end) with a fresh outer
-    TypeInfo built from that entry's ``resolved_samples()`` view.
+    """For any node carrying ``container_id`` whose cache entry is live,
+    refresh its element-args from the cache's current per-counter
+    state (``cache_entry.resolved_samples()``) — outer type stays as
+    whatever the handler chose at recording time (e.g.,
+    ``_handle_randomdict`` chose ``dict``, ``_handle_tuple_iter`` chose
+    ``Iterator``).  Then ``super().visit`` recurses into the rewritten
+    args to chase any inner ``container_id``s.
 
-    Walks bottom-up via ``super().visit(node)``; the standard union-
-    dedup-after-modification pattern (see ``ResolvingT`` in
-    ``observations.py:443-448``) collapses unions of progressive
-    snapshots into one canonical entry once their members rewrite to
-    the same TypeInfo.
+    Standard union-dedup-after-modification (``ResolvingT`` pattern,
+    ``observations.py:443-448``) collapses members that rewrote to
+    equal forms.
 
-    Evicted cache entries (cid not in the map) are silent no-ops — the
-    original TypeInfo passes through unchanged.  Monotonic cids ensure
-    no id-reuse-after-GC can ever cause a wrong cache hit."""
+    Evicted cache entries are silent no-ops.  Monotonic cids
+    eliminate id-reuse-after-GC risk."""
 
     def __init__(self, cid_to_entry: "dict[int, Any]") -> None:
         self._cid_to_entry = cid_to_entry
 
     def visit(vself, node: TypeInfo) -> TypeInfo:
         pre = node
-        node = super().visit(node)
         if (cid := node.container_id) is not None:
             cache_entry = vself._cid_to_entry.get(cid)
             if cache_entry is not None:
-                resolved = cache_entry.resolved_samples()
-                inner_args = tuple(
-                    TypeInfo.from_set(set(c)) for c in resolved
-                )
-                if inner_args:
-                    # Source of truth for the outer shape: the cache's
-                    # own held container (``cache_entry.o``).  Avoids
-                    # the ``ti.replace(args=...)`` pitfall when ``ti``
-                    # itself is a Union (whose ``args`` are members,
-                    # not outer-element args).
-                    node = TypeInfo.from_type(
-                        type(cache_entry.o), args=inner_args
-                    )
-        # After modifying inside a union (members rewriting to equal
-        # forms), re-form via ``to_set()`` to dedup — the
-        # ``ResolvingT`` pattern.
+                # ``node.args`` for a tagged container TypeInfo is the
+                # element-args tuple — safe to overwrite with the
+                # cache's current resolved per-counter view.  Tagged
+                # nodes are never ``UnionTypeInfo``s (handlers only tag
+                # container outers), so this can't collapse a union.
+                node = node.replace(args=cache_entry.resolved_samples())
+        # Recurse to find tagged descendants — inner container_ids in
+        # the rewritten args, or members of an untagged Union.
+        node = super().visit(node)
         if pre is not node and isinstance(node, UnionTypeInfo):
             node = TypeInfo.from_set(
                 node.to_set(), typevar_index=node.typevar_index
@@ -851,10 +843,11 @@ class ObservationsRecorder:
 
 
     def _resolve_container_snapshots(self) -> None:
-        """At recording end, walk every trace and variable TypeInfo with
-        ``_ResolveContainerSnapshotT``, which rewrites nodes carrying
-        ``container_id`` to the resolved-latest snapshot from the live
-        ``ContainerTypeCache``.
+        """At recording end, walk every TypeInfo (in traces, variables,
+        module-level vars, arg defaults, etc.) with
+        ``_ResolveContainerSnapshotT``, which refreshes any node
+        carrying ``container_id`` to the live ``ContainerTypeCache``'s
+        current per-counter view.
 
         Built from the cache so id-reuse is impossible (cids are
         monotonic, assigned at ``ContainerSamples`` creation).  Cache-
@@ -865,28 +858,7 @@ class ObservationsRecorder:
         cid_to_entry = {e.cid: e for e in _cache._cache.values()}
         if not cid_to_entry:
             return
-        tr = _ResolveContainerSnapshotT(cid_to_entry)
-
-        for func_info in self._obs.func_info.values():
-            # Traces: rewrite each position; Counter rebuild collapses
-            # CallTraces that became equal after the rewrite.
-            if func_info.traces:
-                new_traces: Counter[CallTrace] = Counter()
-                for trace, count in func_info.traces.items():
-                    rewritten = tuple(tr.visit(ti) for ti in trace)
-                    if rewritten == tuple(trace):
-                        new_traces[trace] += count
-                    else:
-                        new_traces[CallTrace(
-                            rewritten, first_arg_class=trace.first_arg_class
-                        )] += count
-                func_info.traces = new_traces
-
-            # Variables: set of TypeInfos; rebuild from rewrites.
-            for var_name in list(func_info.variables):
-                func_info.variables[var_name] = {
-                    tr.visit(t) for t in func_info.variables[var_name]
-                }
+        self._obs.transform_types(_ResolveContainerSnapshotT(cid_to_entry))
 
 
     def finish_recording(self, main_globals: dict[str, Any]) -> Observations:

--- a/righttyper/recorder.py
+++ b/righttyper/recorder.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from types import CodeType, FrameType, FunctionType, GeneratorType
 from collections import defaultdict
 import collections.abc as abc
+from functools import cache
 from pathlib import Path
 import logging
 from righttyper.logger import logger
@@ -220,21 +221,23 @@ class _ResolveContainerSnapshotT(TypeInfo.Transformer):
     eliminate id-reuse-after-GC risk."""
 
     def __init__(self, cid_to_entry: "dict[int, Any]") -> None:
-        self._cid_to_entry = cid_to_entry
+        @cache
+        def resolve(cid: int) -> tuple[TypeInfo, ...] | None:
+            entry = cid_to_entry.get(cid)
+            return entry.resolved_samples() if entry is not None else None
+        self._resolve = resolve
 
     def visit(vself, node: TypeInfo) -> TypeInfo:
         pre = node
         if (cid := node.container_id) is not None:
-            cache_entry = vself._cid_to_entry.get(cid)
-            if cache_entry is not None:
-                # ``node.args`` for a tagged container TypeInfo is the
-                # element-args tuple — safe to overwrite with the
-                # cache's current resolved per-counter view.  Tagged
-                # nodes are never ``UnionTypeInfo``s (handlers only tag
-                # container outers), so this can't collapse a union.
-                resolved = cache_entry.resolved_samples()
-                if resolved != node.args:
-                    node = node.replace(args=resolved)
+            # ``node.args`` for a tagged container TypeInfo is the
+            # element-args tuple — safe to overwrite with the
+            # cache's current resolved per-counter view.  Tagged
+            # nodes are never ``UnionTypeInfo``s (handlers only tag
+            # container outers), so this can't collapse a union.
+            resolved = vself._resolve(cid)
+            if resolved is not None and resolved != node.args:
+                node = node.replace(args=resolved)
         # Recurse to find tagged descendants — inner container_ids in
         # the rewritten args, or members of an untagged Union.
         node = super().visit(node)

--- a/righttyper/recorder.py
+++ b/righttyper/recorder.py
@@ -2,13 +2,13 @@ import inspect
 import builtins
 from dataclasses import dataclass, field
 from types import CodeType, FrameType, FunctionType, GeneratorType
-from collections import defaultdict
+from collections import Counter, defaultdict
 import collections.abc as abc
 from pathlib import Path
 import logging
 from righttyper.logger import logger
 from righttyper.righttyper_types import ArgumentName, VariableName, Filename, CodeId, CallableWithCode, cast_not_None
-from righttyper.typeinfo import TypeInfo, NoneTypeInfo, UnknownTypeInfo, CallTrace
+from righttyper.typeinfo import TypeInfo, NoneTypeInfo, UnknownTypeInfo, CallTrace, UnionTypeInfo
 from typing import Final, Any, NewType, overload
 import typing
 from righttyper.observations import Observations, FuncInfo, OverriddenFunction, ArgInfo
@@ -201,6 +201,54 @@ class PendingCallTrace:
         )
 
         return CallTrace(type_data, first_arg_class=self.self_type)
+
+
+class _ResolveContainerSnapshotT(TypeInfo.Transformer):
+    """Rewrites every TypeInfo node carrying a ``container_id`` whose
+    corresponding ``ContainerSamples`` entry is in the by-cid map (built
+    once from the live cache at recording end) with a fresh outer
+    TypeInfo built from that entry's ``resolved_samples()`` view.
+
+    Walks bottom-up via ``super().visit(node)``; the standard union-
+    dedup-after-modification pattern (see ``ResolvingT`` in
+    ``observations.py:443-448``) collapses unions of progressive
+    snapshots into one canonical entry once their members rewrite to
+    the same TypeInfo.
+
+    Evicted cache entries (cid not in the map) are silent no-ops — the
+    original TypeInfo passes through unchanged.  Monotonic cids ensure
+    no id-reuse-after-GC can ever cause a wrong cache hit."""
+
+    def __init__(self, cid_to_entry: "dict[int, Any]") -> None:
+        self._cid_to_entry = cid_to_entry
+
+    def visit(vself, node: TypeInfo) -> TypeInfo:
+        pre = node
+        node = super().visit(node)
+        if (cid := node.container_id) is not None:
+            cache_entry = vself._cid_to_entry.get(cid)
+            if cache_entry is not None:
+                resolved = cache_entry.resolved_samples()
+                inner_args = tuple(
+                    TypeInfo.from_set(set(c)) for c in resolved
+                )
+                if inner_args:
+                    # Source of truth for the outer shape: the cache's
+                    # own held container (``cache_entry.o``).  Avoids
+                    # the ``ti.replace(args=...)`` pitfall when ``ti``
+                    # itself is a Union (whose ``args`` are members,
+                    # not outer-element args).
+                    node = TypeInfo.from_type(
+                        type(cache_entry.o), args=inner_args
+                    )
+        # After modifying inside a union (members rewriting to equal
+        # forms), re-form via ``to_set()`` to dedup — the
+        # ``ResolvingT`` pattern.
+        if pre is not node and isinstance(node, UnionTypeInfo):
+            node = TypeInfo.from_set(
+                node.to_set(), typevar_index=node.typevar_index
+            )
+        return node
 
 
 class ObservationsRecorder:
@@ -802,6 +850,45 @@ class ObservationsRecorder:
                 out[var_name].add(get_type_name(last_class))
 
 
+    def _resolve_container_snapshots(self) -> None:
+        """At recording end, walk every trace and variable TypeInfo with
+        ``_ResolveContainerSnapshotT``, which rewrites nodes carrying
+        ``container_id`` to the resolved-latest snapshot from the live
+        ``ContainerTypeCache``.
+
+        Built from the cache so id-reuse is impossible (cids are
+        monotonic, assigned at ``ContainerSamples`` creation).  Cache-
+        evicted entries (cid no longer in the by-cid map) fall back to
+        the original TypeInfo — sound, just no fix benefit."""
+        from righttyper.type_id import _cache
+
+        cid_to_entry = {e.cid: e for e in _cache._cache.values()}
+        if not cid_to_entry:
+            return
+        tr = _ResolveContainerSnapshotT(cid_to_entry)
+
+        for func_info in self._obs.func_info.values():
+            # Traces: rewrite each position; Counter rebuild collapses
+            # CallTraces that became equal after the rewrite.
+            if func_info.traces:
+                new_traces: Counter[CallTrace] = Counter()
+                for trace, count in func_info.traces.items():
+                    rewritten = tuple(tr.visit(ti) for ti in trace)
+                    if rewritten == tuple(trace):
+                        new_traces[trace] += count
+                    else:
+                        new_traces[CallTrace(
+                            rewritten, first_arg_class=trace.first_arg_class
+                        )] += count
+                func_info.traces = new_traces
+
+            # Variables: set of TypeInfos; rebuild from rewrites.
+            for var_name in list(func_info.variables):
+                func_info.variables[var_name] = {
+                    tr.visit(t) for t in func_info.variables[var_name]
+                }
+
+
     def finish_recording(self, main_globals: dict[str, Any]) -> Observations:
         # Any generators left?
         for code, per_frame in self._pending_traces.items():
@@ -810,6 +897,17 @@ class ObservationsRecorder:
                     # Their frames are no longer reachable here; re-sample
                     # from the PY_START snapshot.
                     self._record_return_type(tr, code, None, tr.arg_info.locals)
+
+        # Rewrite trace positions whose ``arg_ids`` point to a still-live
+        # ``ContainerTypeCache`` entry.  Each call's trace snapshot was
+        # captured at call time, reflecting only the container's
+        # then-cumulative state; the cache has continued to accumulate
+        # samples (across this call's body and subsequent calls).
+        # Rewriting with the cache's resolved-latest collapses progressive
+        # refinement-fragment snapshots of one physical id across traces
+        # to one canonical shape.  Must run while ``_cache`` is still
+        # live, before ``finish_recording`` clears recorder state.
+        self._resolve_container_snapshots()
 
         self._assign_attributes_to_scopes()
 

--- a/righttyper/recorder.py
+++ b/righttyper/recorder.py
@@ -226,10 +226,18 @@ class _ResolveContainerSnapshotT(TypeInfo.Transformer):
             entry = cid_to_entry.get(cid)
             return entry.resolved_samples() if entry is not None else None
         self._resolve = resolve
+        # Cids currently being resolved up the recursion stack. A
+        # self-aliasing container (e.g., httpx cookie jar entries that
+        # reference the jar itself) puts a TypeInfo with the outer's
+        # container_id into the resolved args; without this guard, the
+        # descent into that arg re-resolves the same cid to the same
+        # args, recursing forever.
+        self._active_cids: set[int] = set()
 
     def visit(vself, node: TypeInfo) -> TypeInfo:
         pre = node
-        if (cid := node.container_id) is not None:
+        cid = node.container_id
+        if cid is not None and cid not in vself._active_cids:
             # ``node.args`` for a tagged container TypeInfo is the
             # element-args tuple — safe to overwrite with the
             # cache's current resolved per-counter view.  Tagged
@@ -239,8 +247,18 @@ class _ResolveContainerSnapshotT(TypeInfo.Transformer):
             if resolved is not None and resolved != node.args:
                 node = node.replace(args=resolved)
         # Recurse to find tagged descendants — inner container_ids in
-        # the rewritten args, or members of an untagged Union.
-        node = super().visit(node)
+        # the rewritten args, or members of an untagged Union. Mark
+        # cid active so any self-reference inside ``node.args`` is
+        # walked without re-resolving (terminates the recursion at
+        # the snapshot we already substituted above).
+        if cid is not None:
+            vself._active_cids.add(cid)
+            try:
+                node = super().visit(node)
+            finally:
+                vself._active_cids.discard(cid)
+        else:
+            node = super().visit(node)
         if pre is not node and isinstance(node, UnionTypeInfo):
             node = TypeInfo.from_set(
                 node.to_set(), typevar_index=node.typevar_index

--- a/righttyper/recorder.py
+++ b/righttyper/recorder.py
@@ -136,9 +136,10 @@ class PendingCallTrace:
             ),
             *(
                 (
+                    # Empty *args/**kwargs → Never, absorbed by the union.
                     TypeInfo.from_set({
                         get_value_type(val) for val in arg_info.locals[arg_info.varargs]
-                    }, empty_is_none=True)
+                    })
                     if arg_info.varargs in arg_info.locals else None,
                 )
                 if arg_info.varargs else ()
@@ -147,7 +148,7 @@ class PendingCallTrace:
                 (
                     TypeInfo.from_set({
                         get_value_type(val) for val in arg_info.locals[arg_info.keywords].values()
-                    }, empty_is_none=True)
+                    })
                     if arg_info.keywords in arg_info.locals else None,
                 )
                 if arg_info.keywords else ()
@@ -157,8 +158,9 @@ class PendingCallTrace:
 
     def finish(self, retval: TypeInfo) -> CallTrace:
         if self.is_generator:
-            y = TypeInfo.from_set(self.yields, empty_is_none=True)
-            s = TypeInfo.from_set(self.sends, empty_is_none=True)
+            # A generator that never yielded/sent really has type None.
+            y = TypeInfo.from_set(self.yields, on_empty=NoneTypeInfo)
+            s = TypeInfo.from_set(self.sends, on_empty=NoneTypeInfo)
 
             if self.is_async:
                 retval = TypeInfo.from_type(abc.AsyncGenerator, args=(y, s))

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -48,7 +48,7 @@ from righttyper.atomic import AtomicCounter
 
 
 PKL_FILE_NAME = TOOL_NAME+"-{N}.rt"
-PKL_FILE_VERSION = 7
+PKL_FILE_VERSION = 8
 
 
 rec = ObservationsRecorder()

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -705,6 +705,13 @@ def add_output_options(group=None):
                 default=output_options.use_constructor_types,
                 help="""Whether to use a variable's source-level constructor or factory call (e.g., `p = Path("/tmp")` or `p = Path.cwd()`) as its annotation, when the observed runtime type is consistent with the call's declared return.""",
             ),
+            base.option(
+                "--with-coverage/--no-with-coverage",
+                is_flag=True,
+                default=output_options.with_coverage,
+                help="Capture branch and line coverage (using SlipCover) to identify "
+                     "exercise-driver gaps behind degenerate annotations.",
+            ),
         ]):
             func = opt(func)
         return func
@@ -872,13 +879,6 @@ def add_output_options(group=None):
           " You can later process using RightTyper's \"process\" command."
 )
 @click.option(
-    "--with-coverage/--no-with-coverage",
-    default=run_options.with_coverage,
-    is_flag=True,
-    help="Capture branch and line coverage (using SlipCover) to identify "
-         "exercise-driver gaps behind degenerate annotations."
-)
-@click.option(
     "--allow-runtime-exceptions/--no-allow-runtime-exceptions",
     is_flag=True,
     default=run_options.allow_runtime_exceptions,
@@ -961,7 +961,7 @@ def run(
     run_options.process_args(kwargs)
     output_options.process_args(kwargs)
 
-    if run_options.with_coverage:
+    if output_options.with_coverage:
         from righttyper import coverage as rt_coverage
         try:
             rt_coverage.enable(source=run_options.script_dir)
@@ -1030,7 +1030,7 @@ def run(
                     'script': Path(script).resolve(),
                     'observations': obs,
                 }
-                if run_options.with_coverage:
+                if output_options.with_coverage:
                     from righttyper import coverage as rt_coverage
                     snap = rt_coverage.snapshot()
                     if snap is not None:
@@ -1100,6 +1100,7 @@ def process(**kwargs):
     output_options.process_args(kwargs)
 
     obs_list = []
+    coverage_total: dict | None = None
     script = None
     for filename in Path('.').glob(PKL_FILE_NAME.format(N='*')):
         with filename.open("rb") as f:
@@ -1116,6 +1117,13 @@ def process(**kwargs):
 
             # TODO check for compatible options?
             obs_list.append(pkl['observations'])
+
+            if output_options.with_coverage and 'coverage' in pkl:
+                if coverage_total is None:
+                    coverage_total = pkl['coverage']
+                else:
+                    from slipcover import merge_coverage
+                    coverage_total = merge_coverage(coverage_total, pkl['coverage'])
 
     if not obs_list:
         print("Error: No files found")
@@ -1144,6 +1152,10 @@ def process(**kwargs):
     from righttyper.type_transformers import LoadTypeObjT
     obs.transform_types(LoadTypeObjT())
     process_obs(obs)
+
+    if output_options.with_coverage:
+        from righttyper import diagnostics
+        diagnostics.emit(obs, coverage_total, Path(diagnostics.ARTIFACT_NAME))
 
 
 @cli.command()

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -872,6 +872,13 @@ def add_output_options(group=None):
           " You can later process using RightTyper's \"process\" command."
 )
 @click.option(
+    "--with-coverage/--no-with-coverage",
+    default=run_options.with_coverage,
+    is_flag=True,
+    help="Capture branch and line coverage (using SlipCover) to identify "
+         "exercise-driver gaps behind degenerate annotations."
+)
+@click.option(
     "--allow-runtime-exceptions/--no-allow-runtime-exceptions",
     is_flag=True,
     default=run_options.allow_runtime_exceptions,
@@ -954,6 +961,13 @@ def run(
     run_options.process_args(kwargs)
     output_options.process_args(kwargs)
 
+    if run_options.with_coverage:
+        from righttyper import coverage as rt_coverage
+        try:
+            rt_coverage.enable(source=run_options.script_dir)
+        except rt_coverage.CoverageSetupError as e:
+            raise click.UsageError(str(e))
+
     if run_options.log_sampling:
         from righttyper.logger import init_sampling_log
         init_sampling_log()
@@ -1016,6 +1030,11 @@ def run(
                     'script': Path(script).resolve(),
                     'observations': obs,
                 }
+                if run_options.with_coverage:
+                    from righttyper import coverage as rt_coverage
+                    snap = rt_coverage.snapshot()
+                    if snap is not None:
+                        collected['coverage'] = snap
 
                 index = 1
                 while True:

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -1111,6 +1111,7 @@ def process(**kwargs):
     obs_list = []
     coverage_total: dict | None = None
     script = None
+    pkl: dict = {}
     for filename in Path('.').glob(PKL_FILE_NAME.format(N='*')):
         with filename.open("rb") as f:
             pkl = pickle.load(f)

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -38,7 +38,7 @@ from righttyper.righttyper_tool import (
 import righttyper.loader as loader
 from righttyper.righttyper_utils import detected_test_modules
 from righttyper.typeinfo import TypeInfo
-from righttyper.righttyper_types import CodeId, Filename, FunctionName
+from righttyper.righttyper_types import Filename, FuncLoc, FunctionName
 from righttyper.annotation import FuncAnnotation, ModuleVars, TraceDistribution
 from righttyper.observations import Observations
 from righttyper.recorder import ObservationsRecorder
@@ -48,7 +48,7 @@ from righttyper.atomic import AtomicCounter
 
 
 PKL_FILE_NAME = TOOL_NAME+"-{N}.rt"
-PKL_FILE_VERSION = 8
+PKL_FILE_VERSION = 9
 
 
 rec = ObservationsRecorder()
@@ -311,10 +311,10 @@ def output_changes(
 
 def emit_json(
     files: list[tuple[Filename, str]],
-    type_annotations: dict[CodeId, FuncAnnotation],
+    type_annotations: dict[FuncLoc, FuncAnnotation],
     module_vars: dict[Filename, ModuleVars],
     code_changes: list[CodeChanges],
-    type_distributions: dict[CodeId, list[TraceDistribution]] | None = None
+    type_distributions: dict[FuncLoc, list[TraceDistribution]] | None = None
 ) -> dict[str, Any]:
 
     file2module = {file: module for file, module in files}
@@ -424,9 +424,9 @@ def process_file_wrapper(args) -> CodeChanges:
 
 def process_files(
     files: list[tuple[Filename, str]],
-    type_annotations: dict[CodeId, FuncAnnotation],
+    type_annotations: dict[FuncLoc, FuncAnnotation],
     module_vars: dict[Filename, ModuleVars],
-    type_distributions: dict[CodeId, list[TraceDistribution]] | None = None
+    type_distributions: dict[FuncLoc, list[TraceDistribution]] | None = None
 ) -> list[CodeChanges]:
     if not files:
         return []

--- a/righttyper/righttyper.py
+++ b/righttyper/righttyper.py
@@ -774,6 +774,15 @@ def add_output_options(group=None):
     help="Expected sample captures per second (Poisson process rate).",
 )
 @click.option(
+    "--poisson-warmup-samples",
+    type=click.IntRange(0, None),
+    default=run_options.poisson_warmup_samples,
+    help="Capture this many initial calls per function before Poisson "
+         "sampling kicks in. Higher values catch rare per-call variants "
+         "(e.g. exception paths through __exit__) that the sampler may "
+         "otherwise miss; lower is faster.",
+)
+@click.option(
     "--call-sampling/--no-call-sampling",
     default=run_options.call_sampling,
     help=f"Whether to sample calls or to use every one.",

--- a/righttyper/righttyper_process.py
+++ b/righttyper/righttyper_process.py
@@ -4,7 +4,7 @@ from typing import TypeAlias
 import libcst as cst
 
 from righttyper.generate_stubs import PyiTransformer
-from righttyper.righttyper_types import Filename, CodeId, FunctionName
+from righttyper.righttyper_types import Filename, FuncLoc, FunctionName
 from righttyper.annotation import FuncAnnotation, ModuleVars, TraceDistribution
 from righttyper.righttyper_utils import (
     source_to_module_fqn
@@ -74,10 +74,10 @@ def correct_indentation_issues(file_contents: str) -> str:
 def process_file(
     filename: Filename,
     module_name: str,
-    type_annotations: dict[CodeId, FuncAnnotation],
+    type_annotations: dict[FuncLoc, FuncAnnotation],
     module_vars: ModuleVars,
     options: OutputOptions,
-    type_distributions: dict[CodeId, list[TraceDistribution]] | None = None
+    type_distributions: dict[FuncLoc, list[TraceDistribution]] | None = None
 ) -> CodeChanges:
     logger.debug(f"process_file: {filename}")
     try:

--- a/righttyper/righttyper_types.py
+++ b/righttyper/righttyper_types.py
@@ -1,5 +1,7 @@
+import hashlib
+import marshal
 from dataclasses import dataclass
-from typing import Any, NewType, Protocol, TypeGuard
+from typing import Any, NamedTuple, NewType, Protocol, TypeGuard
 from types import CodeType
 
 
@@ -20,14 +22,61 @@ ArgumentName = NewType("ArgumentName", str)
 VariableName = NewType("VariableName", str)
 FunctionName = NewType("FunctionName", str)
 
-@dataclass(eq=True, order=True, frozen=True)
-class CodeId:
+
+def _content_hash(code: CodeType) -> int:
+    """Hash code-object content, excluding source-line metadata.
+
+    Catches actual bytecode/closure-body changes; ignores ``co_firstlineno``,
+    the line table, and ``co_filename`` so source-revision drift (same
+    content, different line) and installation-path differences both produce
+    the same hash. ``marshal`` deterministically encodes tuples of
+    primitive types across processes (Python's built-in ``hash`` does not).
+    Nested code objects in ``co_consts`` are recursively reduced to their
+    own hashes.
+    """
+    def _fields(c: CodeType) -> tuple:
+        return (
+            c.co_name, c.co_qualname, c.co_code,
+            tuple(_content_hash(k) if isinstance(k, CodeType) else k
+                  for k in c.co_consts),
+            c.co_names, c.co_varnames, c.co_freevars, c.co_cellvars,
+            c.co_argcount, c.co_posonlyargcount, c.co_kwonlyargcount,
+            c.co_flags,
+        )
+    digest = hashlib.sha256(marshal.dumps(_fields(code))).digest()
+    return int.from_bytes(digest[:8], 'little', signed=True)
+
+
+class FuncLoc(NamedTuple):
+    """Identifies a function by its source location (file + qualname + line).
+
+    Constructible without a runtime code object — used wherever a function
+    needs to be named but its bytecode isn't available (e.g., the AST
+    transformer mapping a ``def`` back to its recorded annotations).
+    """
     file_name: Filename
     func_name: FunctionName
     first_code_line: int
 
-    # if a <genexpr> or such, hash(code) to be able to differentiate same-line objects
-    code_hash: int
+
+@dataclass(eq=True, order=True, frozen=True)
+class CodeId:
+    """Identifies a function by source location *and* bytecode content.
+
+    Stricter than ``FuncLoc``: two functions sharing a location but
+    differing in body (e.g., two lambdas on one line, property
+    getter/setter at adjacent lines) remain distinct CodeIds. Used as the
+    record-time identity in ``Observations.func_info`` and as
+    ``TypeInfo.code_id`` so distinct Callable types stay distinct.
+    """
+    file_name: Filename
+    func_name: FunctionName
+    first_code_line: int
+    # Line-number-independent content hash. Same content at different
+    # lines (drift) ⇒ same bytecode_hash but different CodeIds; detected
+    # at merge time. Different content at any lines ⇒ different
+    # bytecode_hash ⇒ different CodeIds.
+    bytecode_hash: int
 
 
     @staticmethod
@@ -36,8 +85,11 @@ class CodeId:
             Filename(code.co_filename),
             FunctionName(code.co_qualname),
             code.co_firstlineno,
-            hash(code) if code.co_qualname.endswith('>') else 0
+            _content_hash(code),
         )
+
+    def to_loc(self) -> FuncLoc:
+        return FuncLoc(self.file_name, self.func_name, self.first_code_line)
 
 
 def cast_not_None[T](x: T | None) -> T:

--- a/righttyper/type_id.py
+++ b/righttyper/type_id.py
@@ -465,72 +465,45 @@ class ContainerSamples:
         """Check if sample contains a type not seen before."""
         return any(v not in counter for v, counter in zip(sample, self.all_samples))
 
-    def resolved_samples(
-        self,
-        _resolving: set[int] | None = None,
-        _resolved: dict[int, "tuple[Counter[TypeInfo], ...]"] | None = None,
-    ) -> tuple[Counter[TypeInfo], ...]:
-        """Per-counter Counter view that collapses progressive snapshots
-        of the same inner-container id to one resolved-latest snapshot
-        derived from the inner's own cumulative state in ``_cache``.
+    def resolved_samples(self) -> tuple[TypeInfo, ...]:
+        """One merged TypeInfo per counter — this container's current
+        per-counter element types.
 
-        Bottom-up + memoized: an inner is resolved before being used by
-        its outer.  Falls back to the stored snapshots when the inner's
-        cache entry has been LRU-evicted or its id has been reused for a
-        different object (``e.o`` mismatch).  A cycle in container
-        references (very rare; would have to be created via ``__dict__``
-        or similar) falls back to ``all_samples`` unchanged."""
-        # Short-circuit: no parameterized inners observed at any counter
-        # → nothing to resolve, ``all_samples`` is already canonical.
-        # This is the common case (containers of scalars) and keeps
-        # post-fix overhead at ~zero on the hot path.
+        - Inner-container snapshots are pulled from ``inner_ids``
+          (latest snapshot per id, each carrying its own
+          ``container_id`` for the resolver to chase via its own
+          visit recursion).
+        - Scalar / non-tracked entries from ``all_samples`` pass
+          through.
+        - Lub-reduced via ``merged_types`` (default sound
+          ``assume_covariant=False``) so numeric-tower (``int <:
+          float``) and MRO-subtype (``bool <: int``) redundancies
+          collapse before the outer wrap.
+
+        Used at sample time (called from ``_handle_*`` via
+        ``_sample_container``) for the just-built TypeInfo's args, and
+        at finish-time by the resolver to refresh each tagged trace
+        position's args.  Cheap — no recursive cache walk; the
+        resolver's transformer-recursion handles deeper container_ids
+        in the returned args."""
+        from righttyper.generalize import merged_types
+
+        # Fast path: no parameterized inners → cumulative scalars only.
         if not any(self.inner_ids):
-            return self.all_samples
-        if _resolved is None:
-            _resolved = {}
-        if _resolving is None:
-            _resolving = set()
-        my_id = id(self)
-        if my_id in _resolved:
-            return _resolved[my_id]
-        if my_id in _resolving:
-            return self.all_samples
-        _resolving.add(my_id)
-        try:
-            result: tuple[Counter[TypeInfo], ...] = tuple(
-                Counter() for _ in range(self.n_counters)
+            return tuple(merged_types(set(c)) for c in self.all_samples)
+
+        result: list[set[TypeInfo]] = [set() for _ in range(self.n_counters)]
+        for i in range(self.n_counters):
+            contributed: set[TypeInfo] = set()
+            for inner_id, (back_ref, id_counter) in self.inner_ids[i].items():
+                contributed.update(id_counter)
+                # Any past snapshot works — its ``container_id`` is the
+                # inner's cid, which the finish-time resolver chases.
+                result[i].add(next(iter(id_counter)))
+            result[i].update(
+                t for t in self.all_samples[i] if t not in contributed
             )
-            for i in range(self.n_counters):
-                contributed: Counter[TypeInfo] = Counter()
-                for inner_id, (back_ref, id_counter) in self.inner_ids[i].items():
-                    contributed.update(id_counter)
-                    cache_entry = _cache._cache.get(inner_id)
-                    if cache_entry is not None and cache_entry.o is back_ref:
-                        # Recurse: get the inner's resolved per-counter Counters,
-                        # build the inner's TypeInfo by re-wrapping with the
-                        # outer-shape template (any past snapshot has the right
-                        # module/name/type_obj — the args are what we recompute).
-                        inner_resolved = cache_entry.resolved_samples(_resolving, _resolved)
-                        template = next(iter(id_counter))
-                        inner_args = tuple(
-                            TypeInfo.from_set(set(c)) for c in inner_resolved
-                        )
-                        resolved_snapshot = template.replace(args=inner_args)
-                        result[i][resolved_snapshot] += 1
-                    else:
-                        # Evicted or id-reuse: keep the stored snapshots.
-                        result[i].update(id_counter)
-                # Preserve scalar / non-tracked entries: anything in
-                # all_samples[i] that wasn't contributed by a tracked id.
-                remaining = self.all_samples[i].copy()
-                remaining.subtract(contributed)
-                for ti, cnt in remaining.items():
-                    if cnt > 0:
-                        result[i][ti] += cnt
-            _resolved[my_id] = result
-            return result
-        finally:
-            _resolving.discard(my_id)
+        return tuple(merged_types(c) for c in result)
 
     def sample_until_stable(self, sampler: abc.Callable[[], tuple[Any, ...]], depth: int) -> str:
         """Sample until Good-Turing indicates stability or the per-container
@@ -628,12 +601,16 @@ class ContainerTypeCache:
 
 _cache = ContainerTypeCache(1024)
 
-def _get_container_args(
+def _sample_container(
     container: Any,
     n_counters: typing.Literal[1,2],
     sampler: abc.Callable[[], tuple[TypeInfo, ...]],
-    depth: int
+    depth: int,
 ) -> tuple[TypeInfo, ...]:
+    """Sample ``container``'s contents into its ``ContainerSamples`` cache
+    entry; return the per-counter merged element TypeInfos (one per
+    counter — the caller wraps with its desired outer container
+    type)."""
 
     entry = _cache.get(container, n_counters)
     action = "skip"
@@ -684,13 +661,6 @@ def _get_container_args(
                     sample_trigger = "spot_check"
                 else:
                     action = "spot_check_miss"
-
-    # ``resolved_samples()`` replaces progressive snapshots of the same
-    # inner-container id with one resolved-latest snapshot built from the
-    # inner's own cumulative cache state (bottom-up).  When the artifact
-    # doesn't apply (no parameterized inners, no growing ids), it returns
-    # the same Counters as ``all_samples``.
-    result = tuple(TypeInfo.from_set(set(c)) for c in entry.resolved_samples())
 
     if run_options.log_sampling and container:
         n_samples_after = entry.all_samples[0].total()
@@ -757,7 +727,13 @@ def _get_container_args(
         sampling_logger.info(json.dumps(record, default=str))
         update_sampling_summary(record)
 
-    return result
+    # Cheap recording-time view: just dedup ``all_samples`` per
+    # counter.  The resolver at ``finish_recording`` refreshes each
+    # tagged trace position via ``cache_entry.resolved_samples()``
+    # (which deduplicates inner-id snapshots and lub-reduces).  For
+    # cache-evicted entries (rare), this stored form survives — sound
+    # but possibly bloated.
+    return tuple(TypeInfo.from_set(set(c)) for c in entry.all_samples)
 
 
 def _handle_tuple(value: Any, depth: int) -> TypeInfo:
@@ -778,39 +754,34 @@ def _handle_tuple(value: Any, depth: int) -> TypeInfo:
 
 def _cid_for(container: Any) -> int | None:
     """``ContainerSamples.cid`` for an observed container, or ``None`` if
-    no cache entry is currently mapped to its id (shouldn't happen for
-    a value just sampled by ``_get_container_args``, but defensive)."""
+    no cache entry is currently mapped to its id."""
     e = _cache._cache.get(id(container))
     return e.cid if e is not None and e.o is container else None
 
 
 def _handle_dict(value: Any, depth: int) -> TypeInfo:
     sampler = lambda: ((el := _random_item(value)), value[el])
-    args = _get_container_args(value, 2, sampler, depth)
-
+    args = _sample_container(value, 2, sampler, depth)
     t: type = type(value)
     if (ti := _BUILTINS.get(t)):
         return ti.replace(args=args, container_id=_cid_for(value))
-
     return TypeInfo.from_type(t, args=args, container_id=_cid_for(value))
 
 
 def _handle_randomdict(value: Any, depth: int) -> TypeInfo:
     sampler = lambda: ((el := value.random_item())[0], el[1])
-
     try:
-        args = _get_container_args(value, 2, sampler, depth)
-    except Exception as e:
+        args = _sample_container(value, 2, sampler, depth)
+    except Exception:
         return TypeInfo.from_type(dict)
-    else:
-        return TypeInfo.from_type(dict, args=args, container_id=_cid_for(value))
+    return TypeInfo.from_type(dict, args=args, container_id=_cid_for(value))
 
 
 def _handle_list(value: Any, depth: int) -> TypeInfo:
     sampler = lambda: (value[random.randint(0, len(value)-1)],) # this is O(1), much faster than islice()
     return TypeInfo.from_type(
         list,
-        args=_get_container_args(value, 1, sampler, depth),
+        args=_sample_container(value, 1, sampler, depth),
         container_id=_cid_for(value),
     )
 
@@ -819,7 +790,7 @@ def _handle_set(value: Any, depth: int) -> TypeInfo:
     sampler = lambda: (_random_item(value),)
     return TypeInfo.from_type(
         type(value),
-        args=_get_container_args(value, 1, sampler, depth),
+        args=_sample_container(value, 1, sampler, depth),
         container_id=_cid_for(value),
     )
 
@@ -859,7 +830,11 @@ def _handle_set_iter(value: Any, depth: int) -> TypeInfo|None:
 def _handle_tuple_iter(value: Any, depth: int) -> TypeInfo|None:
     if type(t := _first_referent(value)) is tuple:
         sampler = lambda: (t[random.randint(0, len(t)-1)],) # this is O(1), much faster than islice()
-        return TypeInfo.from_type(abc.Iterator, args=_get_container_args(t, 1, sampler, depth))
+        return TypeInfo.from_type(
+            abc.Iterator,
+            args=_sample_container(t, 1, sampler, depth),
+            container_id=_cid_for(t),
+        )
     return None
 
 

--- a/righttyper/type_id.py
+++ b/righttyper/type_id.py
@@ -415,11 +415,26 @@ class ContainerSamples:
         self.last_sampled_size = 0
         # Set by sample_until_stable on Good-Turing convergence
         self.last_singleton_ratios: list[float] = []
+        # Cached recording-time view; ``None`` means stale.  Invalidated
+        # on every mutation of ``all_samples``.  ``sample_view()`` is read
+        # once per ``_sample_container`` call after all mutations of that
+        # call, so over-invalidating within a call costs nothing — the
+        # win is the cross-call cache (spot_check_miss / empty-container
+        # paths, where ``all_samples`` is untouched).
+        self._sample_view: tuple[TypeInfo, ...] | None = None
 
     def add_sample(self, sample: tuple[TypeInfo, ...]) -> None:
         """Add a sample to cumulative history."""
+        self._sample_view = None
         for c, v in zip(self.all_samples, sample):
             c[v] += 1
+
+    def sample_view(self) -> tuple[TypeInfo, ...]:
+        """Cheap recording-time view: per-counter union over ``all_samples``.
+        Cached; rebuilt only when a sample introduced a new TypeInfo."""
+        if self._sample_view is None:
+            self._sample_view = tuple(TypeInfo.from_set(set(c)) for c in self.all_samples)
+        return self._sample_view
 
     def has_new_type(self, sample: tuple[TypeInfo, ...]) -> bool:
         """Check if sample contains a type not seen before."""
@@ -491,6 +506,7 @@ class ContainerSamples:
             raw_sample = sampler()
             sample = tuple(get_value_type(v, depth+1) for v in raw_sample)
             # Add to cumulative history
+            self._sample_view = None
             for c, v in zip(self.all_samples, sample):
                 c[v] += 1
             # Add to cycle-local counter
@@ -682,13 +698,7 @@ def _sample_container(
         sampling_logger.info(json.dumps(record, default=str))
         update_sampling_summary(record)
 
-    # Cheap recording-time view: just dedup ``all_samples`` per
-    # counter.  The resolver at ``finish_recording`` refreshes each
-    # tagged trace position via ``cache_entry.resolved_samples()``
-    # (which deduplicates inner-id snapshots and lub-reduces).  For
-    # cache-evicted entries (rare), this stored form survives — sound
-    # but possibly bloated.
-    return tuple(TypeInfo.from_set(set(c)) for c in entry.all_samples)
+    return entry.sample_view()
 
 
 def _handle_tuple(value: Any, depth: int) -> TypeInfo:

--- a/righttyper/type_id.py
+++ b/righttyper/type_id.py
@@ -415,51 +415,11 @@ class ContainerSamples:
         self.last_sampled_size = 0
         # Set by sample_until_stable on Good-Turing convergence
         self.last_singleton_ratios: list[float] = []
-        # Per-counter map ``id(inner) -> (back_ref, Counter of all progressive
-        # snapshots ever stored for this id at this counter)``.  When the
-        # same physical inner container is revisited and its cumulative
-        # contents have grown, ``all_samples`` accumulates progressive
-        # snapshots that look like distinct keys; this map lets
-        # ``resolved_samples()`` collapse them to one resolved-latest
-        # snapshot per id at recording time.  The Counter alongside the
-        # back-ref records exactly which snapshot keys an id contributed,
-        # so ``resolved_samples()`` can subtract them cleanly from
-        # ``all_samples`` and keep scalar entries intact.  ``all_samples``
-        # itself stays untouched during sampling — Good-Turing
-        # (``sample_until_stable``) reads it and needs the per-visit
-        # snapshot keys to estimate when content discovery has converged.
-        self.inner_ids: tuple[dict[int, tuple[object, Counter[TypeInfo]]], ...] = tuple(
-            {} for _ in range(n_counters)
-        )
 
-    def _track_inner_ids(self, raw: tuple[Any, ...], sample: tuple[TypeInfo, ...]) -> None:
-        """Record id-keyed snapshot info for any sample element whose
-        TypeInfo carries type arguments — i.e., a parameterized inner
-        whose content could refine over time.  Bare-type elements (no
-        ``args``) have nothing to dedup.  Mirrors
-        ``ContainerTypeCache.get``'s ``e.o is not o`` reuse check: an id
-        whose stored back-ref no longer matches the live object resets
-        the entry."""
-        for i, (raw_v, ti) in enumerate(zip(raw, sample)):
-            if not ti.args:
-                continue
-            v_id = id(raw_v)
-            existing = self.inner_ids[i].get(v_id)
-            if existing is None or existing[0] is not raw_v:
-                existing = (raw_v, Counter())
-                self.inner_ids[i][v_id] = existing
-            existing[1][ti] += 1
-
-    def add_sample(self, sample: tuple[TypeInfo, ...], raw: tuple[Any, ...] | None = None) -> None:
-        """Add a sample to cumulative history.
-
-        When ``raw`` is provided (the original Python values that produced
-        ``sample``), also update ``inner_ids`` so container elements can be
-        deduped by id at resolution time."""
+    def add_sample(self, sample: tuple[TypeInfo, ...]) -> None:
+        """Add a sample to cumulative history."""
         for c, v in zip(self.all_samples, sample):
             c[v] += 1
-        if raw is not None:
-            self._track_inner_ids(raw, sample)
 
     def has_new_type(self, sample: tuple[TypeInfo, ...]) -> bool:
         """Check if sample contains a type not seen before."""
@@ -467,43 +427,40 @@ class ContainerSamples:
 
     def resolved_samples(self) -> tuple[TypeInfo, ...]:
         """One merged TypeInfo per counter — this container's current
-        per-counter element types.
+        per-counter element types, with progressive snapshots of any
+        inner container collapsed to a single representative.
 
-        - Inner-container snapshots are pulled from ``inner_ids``
-          (latest snapshot per id, each carrying its own
-          ``container_id`` for the resolver to chase via its own
-          visit recursion).
-        - Scalar / non-tracked entries from ``all_samples`` pass
-          through.
-        - Lub-reduced via ``merged_types`` (default sound
-          ``assume_covariant=False``) so numeric-tower (``int <:
-          float``) and MRO-subtype (``bool <: int``) redundancies
-          collapse before the outer wrap.
+        For each parametric element in ``all_samples``, the element's
+        ``container_id`` uniquely identifies its physical inner container.
+        Progressive snapshots of the same inner share the same cid (and
+        outer shape) and differ only in args — so picking one tagged
+        representative per cid is enough.  The finish-time resolver
+        visits each representative and overwrites its args via the
+        inner's own ``resolved_samples()``, so the args we keep are
+        scratch.
 
-        Used at sample time (called from ``_handle_*`` via
-        ``_sample_container``) for the just-built TypeInfo's args, and
-        at finish-time by the resolver to refresh each tagged trace
-        position's args.  Cheap — no recursive cache walk; the
-        resolver's transformer-recursion handles deeper container_ids
-        in the returned args."""
+        Scalars (``container_id is None``) pass through unchanged.
+
+        Lub-reduced via ``merged_types`` so numeric-tower (``int <:
+        float``) and MRO-subtype (``bool <: int``) redundancies collapse
+        before the outer wrap."""
         from righttyper.generalize import merged_types
 
-        # Fast path: no parameterized inners → cumulative scalars only.
-        if not any(self.inner_ids):
-            return tuple(merged_types(set(c)) for c in self.all_samples)
+        def _reduce(s: set[TypeInfo]) -> TypeInfo:
+            return next(iter(s)) if len(s) == 1 else merged_types(s)
 
-        result: list[set[TypeInfo]] = [set() for _ in range(self.n_counters)]
-        for i in range(self.n_counters):
-            contributed: set[TypeInfo] = set()
-            for inner_id, (back_ref, id_counter) in self.inner_ids[i].items():
-                contributed.update(id_counter)
-                # Any past snapshot works — its ``container_id`` is the
-                # inner's cid, which the finish-time resolver chases.
-                result[i].add(next(iter(id_counter)))
-            result[i].update(
-                t for t in self.all_samples[i] if t not in contributed
-            )
-        return tuple(merged_types(c) for c in result)
+        out: list[TypeInfo] = []
+        for samples in self.all_samples:
+            seen_cids: set[int] = set()
+            deduped: set[TypeInfo] = set()
+            for ti in samples:
+                if (cid := ti.container_id) is None:
+                    deduped.add(ti)
+                elif cid not in seen_cids:
+                    seen_cids.add(cid)
+                    deduped.add(ti)
+            out.append(_reduce(deduped))
+        return tuple(out)
 
     def sample_until_stable(self, sampler: abc.Callable[[], tuple[Any, ...]], depth: int) -> str:
         """Sample until Good-Turing indicates stability or the per-container
@@ -533,10 +490,9 @@ class ContainerSamples:
 
             raw_sample = sampler()
             sample = tuple(get_value_type(v, depth+1) for v in raw_sample)
-            # Add to cumulative history (and track ids for parameterized inners)
+            # Add to cumulative history
             for c, v in zip(self.all_samples, sample):
                 c[v] += 1
-            self._track_inner_ids(raw_sample, sample)
             # Add to cycle-local counter
             for c, v in zip(cycle_counter, sample):
                 c[v] += 1
@@ -558,12 +514,11 @@ class ContainerSamples:
         """Fully scan a small container."""
         if self.n_counters == 1:
             for v in container:
-                self.add_sample((get_value_type(v, depth+1),), (v,))
+                self.add_sample((get_value_type(v, depth+1),))
         else:
             for k, v in container.items():
                 self.add_sample(
                     (get_value_type(k, depth+1), get_value_type(v, depth+1)),
-                    (k, v),
                 )
         self.last_sampled_size = len(container)
 
@@ -654,7 +609,7 @@ def _sample_container(
                 raw_sample = sampler()
                 sample = tuple(get_value_type(v, depth+1) for v in raw_sample)
                 if entry.has_new_type(sample):
-                    entry.add_sample(sample, raw_sample)
+                    entry.add_sample(sample)
                     stopping_reason = entry.sample_until_stable(sampler, depth)
                     entry.last_sampled_size = current_size
                     action = "spot_check_hit"

--- a/righttyper/type_id.py
+++ b/righttyper/type_id.py
@@ -518,6 +518,8 @@ def _get_container_args(
     stopping_reason: str | None = None
     sample_trigger: str | None = None
     n_samples_before = 0
+    current_size = 0
+    is_small = False
 
     if run_options.log_sampling:
         n_samples_before = entry.all_samples[0].total()

--- a/righttyper/type_id.py
+++ b/righttyper/type_id.py
@@ -30,6 +30,7 @@ import types
 from typing import Any, cast, get_type_hints, get_origin, get_args, TypeGuard
 import typing
 
+from righttyper.atomic import AtomicCounter
 from righttyper.random_dict import RandomDict
 from righttyper.typeinfo import TypeInfo, TypeInfoArg, NoneTypeInfo, AnyTypeInfo, UnknownTypeInfo
 from righttyper.righttyper_types import Filename, FunctionName, CodeId, CallableWithCode, has_code
@@ -389,6 +390,14 @@ def _first_referent(value: Any) -> object|None:
     return ref[0] if len(ref) else None
 
 
+# Monotonic counter for ``ContainerSamples.cid``: stable identifiers that,
+# unlike Python's ``id()``, never reuse values for distinct objects.
+# TypeInfos store this cid (as ``container_id``) so the resolve at
+# recording end can't be tricked by id-reuse-after-GC into pulling a
+# different (later-allocated) container's resolved snapshot.
+_cid_counter = AtomicCounter()
+
+
 class ContainerSamples:
     """Tracks type samples from a container for type inference.
 
@@ -398,6 +407,7 @@ class ContainerSamples:
     """
 
     def __init__(self, o: object, n_counters: int):
+        self.cid = _cid_counter.inc()
         self.o = o
         self.n_counters = n_counters
         # Cumulative counters: all types ever seen (for final annotation)
@@ -405,15 +415,122 @@ class ContainerSamples:
         self.last_sampled_size = 0
         # Set by sample_until_stable on Good-Turing convergence
         self.last_singleton_ratios: list[float] = []
+        # Per-counter map ``id(inner) -> (back_ref, Counter of all progressive
+        # snapshots ever stored for this id at this counter)``.  When the
+        # same physical inner container is revisited and its cumulative
+        # contents have grown, ``all_samples`` accumulates progressive
+        # snapshots that look like distinct keys; this map lets
+        # ``resolved_samples()`` collapse them to one resolved-latest
+        # snapshot per id at recording time.  The Counter alongside the
+        # back-ref records exactly which snapshot keys an id contributed,
+        # so ``resolved_samples()`` can subtract them cleanly from
+        # ``all_samples`` and keep scalar entries intact.  ``all_samples``
+        # itself stays untouched during sampling — Good-Turing
+        # (``sample_until_stable``) reads it and needs the per-visit
+        # snapshot keys to estimate when content discovery has converged.
+        self.inner_ids: tuple[dict[int, tuple[object, Counter[TypeInfo]]], ...] = tuple(
+            {} for _ in range(n_counters)
+        )
 
-    def add_sample(self, sample: tuple[TypeInfo, ...]) -> None:
-        """Add a sample to cumulative history."""
+    def _track_inner_ids(self, raw: tuple[Any, ...], sample: tuple[TypeInfo, ...]) -> None:
+        """Record id-keyed snapshot info for any sample element whose
+        TypeInfo carries type arguments — i.e., a parameterized inner
+        whose content could refine over time.  Bare-type elements (no
+        ``args``) have nothing to dedup.  Mirrors
+        ``ContainerTypeCache.get``'s ``e.o is not o`` reuse check: an id
+        whose stored back-ref no longer matches the live object resets
+        the entry."""
+        for i, (raw_v, ti) in enumerate(zip(raw, sample)):
+            if not ti.args:
+                continue
+            v_id = id(raw_v)
+            existing = self.inner_ids[i].get(v_id)
+            if existing is None or existing[0] is not raw_v:
+                existing = (raw_v, Counter())
+                self.inner_ids[i][v_id] = existing
+            existing[1][ti] += 1
+
+    def add_sample(self, sample: tuple[TypeInfo, ...], raw: tuple[Any, ...] | None = None) -> None:
+        """Add a sample to cumulative history.
+
+        When ``raw`` is provided (the original Python values that produced
+        ``sample``), also update ``inner_ids`` so container elements can be
+        deduped by id at resolution time."""
         for c, v in zip(self.all_samples, sample):
             c[v] += 1
+        if raw is not None:
+            self._track_inner_ids(raw, sample)
 
     def has_new_type(self, sample: tuple[TypeInfo, ...]) -> bool:
         """Check if sample contains a type not seen before."""
         return any(v not in counter for v, counter in zip(sample, self.all_samples))
+
+    def resolved_samples(
+        self,
+        _resolving: set[int] | None = None,
+        _resolved: dict[int, "tuple[Counter[TypeInfo], ...]"] | None = None,
+    ) -> tuple[Counter[TypeInfo], ...]:
+        """Per-counter Counter view that collapses progressive snapshots
+        of the same inner-container id to one resolved-latest snapshot
+        derived from the inner's own cumulative state in ``_cache``.
+
+        Bottom-up + memoized: an inner is resolved before being used by
+        its outer.  Falls back to the stored snapshots when the inner's
+        cache entry has been LRU-evicted or its id has been reused for a
+        different object (``e.o`` mismatch).  A cycle in container
+        references (very rare; would have to be created via ``__dict__``
+        or similar) falls back to ``all_samples`` unchanged."""
+        # Short-circuit: no parameterized inners observed at any counter
+        # → nothing to resolve, ``all_samples`` is already canonical.
+        # This is the common case (containers of scalars) and keeps
+        # post-fix overhead at ~zero on the hot path.
+        if not any(self.inner_ids):
+            return self.all_samples
+        if _resolved is None:
+            _resolved = {}
+        if _resolving is None:
+            _resolving = set()
+        my_id = id(self)
+        if my_id in _resolved:
+            return _resolved[my_id]
+        if my_id in _resolving:
+            return self.all_samples
+        _resolving.add(my_id)
+        try:
+            result: tuple[Counter[TypeInfo], ...] = tuple(
+                Counter() for _ in range(self.n_counters)
+            )
+            for i in range(self.n_counters):
+                contributed: Counter[TypeInfo] = Counter()
+                for inner_id, (back_ref, id_counter) in self.inner_ids[i].items():
+                    contributed.update(id_counter)
+                    cache_entry = _cache._cache.get(inner_id)
+                    if cache_entry is not None and cache_entry.o is back_ref:
+                        # Recurse: get the inner's resolved per-counter Counters,
+                        # build the inner's TypeInfo by re-wrapping with the
+                        # outer-shape template (any past snapshot has the right
+                        # module/name/type_obj — the args are what we recompute).
+                        inner_resolved = cache_entry.resolved_samples(_resolving, _resolved)
+                        template = next(iter(id_counter))
+                        inner_args = tuple(
+                            TypeInfo.from_set(set(c)) for c in inner_resolved
+                        )
+                        resolved_snapshot = template.replace(args=inner_args)
+                        result[i][resolved_snapshot] += 1
+                    else:
+                        # Evicted or id-reuse: keep the stored snapshots.
+                        result[i].update(id_counter)
+                # Preserve scalar / non-tracked entries: anything in
+                # all_samples[i] that wasn't contributed by a tracked id.
+                remaining = self.all_samples[i].copy()
+                remaining.subtract(contributed)
+                for ti, cnt in remaining.items():
+                    if cnt > 0:
+                        result[i][ti] += cnt
+            _resolved[my_id] = result
+            return result
+        finally:
+            _resolving.discard(my_id)
 
     def sample_until_stable(self, sampler: abc.Callable[[], tuple[Any, ...]], depth: int) -> str:
         """Sample until Good-Turing indicates stability or the per-container
@@ -441,10 +558,12 @@ class ContainerSamples:
                 )
                 return 'max_limit'
 
-            sample = tuple(get_value_type(v, depth+1) for v in sampler())
-            # Add to cumulative history
+            raw_sample = sampler()
+            sample = tuple(get_value_type(v, depth+1) for v in raw_sample)
+            # Add to cumulative history (and track ids for parameterized inners)
             for c, v in zip(self.all_samples, sample):
                 c[v] += 1
+            self._track_inner_ids(raw_sample, sample)
             # Add to cycle-local counter
             for c, v in zip(cycle_counter, sample):
                 c[v] += 1
@@ -466,10 +585,13 @@ class ContainerSamples:
         """Fully scan a small container."""
         if self.n_counters == 1:
             for v in container:
-                self.add_sample((get_value_type(v, depth+1),))
+                self.add_sample((get_value_type(v, depth+1),), (v,))
         else:
             for k, v in container.items():
-                self.add_sample((get_value_type(k, depth+1), get_value_type(v, depth+1)))
+                self.add_sample(
+                    (get_value_type(k, depth+1), get_value_type(v, depth+1)),
+                    (k, v),
+                )
         self.last_sampled_size = len(container)
 
     def compute_ground_truth(self, container: Any, depth: int) -> tuple[Counter[TypeInfo], ...]:
@@ -536,7 +658,8 @@ def _get_container_args(
                 action = "full_scan"
             elif random.random() < run_options.container_check_probability:
                 # Spot-check: take one sample, rescan if new type found
-                sample = tuple(get_value_type(v, depth+1) for v in sampler())
+                raw_sample = sampler()
+                sample = tuple(get_value_type(v, depth+1) for v in raw_sample)
                 if entry.has_new_type(sample):
                     entry.full_scan(container, depth)
                     action = "spot_check_hit"
@@ -551,9 +674,10 @@ def _get_container_args(
                 action = "sample"
             elif random.random() < run_options.container_check_probability:
                 # Spot-check: resample only if new type found
-                sample = tuple(get_value_type(v, depth+1) for v in sampler())
+                raw_sample = sampler()
+                sample = tuple(get_value_type(v, depth+1) for v in raw_sample)
                 if entry.has_new_type(sample):
-                    entry.add_sample(sample)
+                    entry.add_sample(sample, raw_sample)
                     stopping_reason = entry.sample_until_stable(sampler, depth)
                     entry.last_sampled_size = current_size
                     action = "spot_check_hit"
@@ -561,7 +685,12 @@ def _get_container_args(
                 else:
                     action = "spot_check_miss"
 
-    result = tuple(TypeInfo.from_set(set(c)) for c in entry.all_samples)
+    # ``resolved_samples()`` replaces progressive snapshots of the same
+    # inner-container id with one resolved-latest snapshot built from the
+    # inner's own cumulative cache state (bottom-up).  When the artifact
+    # doesn't apply (no parameterized inners, no growing ids), it returns
+    # the same Counters as ``all_samples``.
+    result = tuple(TypeInfo.from_set(set(c)) for c in entry.resolved_samples())
 
     if run_options.log_sampling and container:
         n_samples_after = entry.all_samples[0].total()
@@ -647,15 +776,23 @@ def _handle_tuple(value: Any, depth: int) -> TypeInfo:
     return TypeInfo.from_type(tuple, args=args)
 
 
+def _cid_for(container: Any) -> int | None:
+    """``ContainerSamples.cid`` for an observed container, or ``None`` if
+    no cache entry is currently mapped to its id (shouldn't happen for
+    a value just sampled by ``_get_container_args``, but defensive)."""
+    e = _cache._cache.get(id(container))
+    return e.cid if e is not None and e.o is container else None
+
+
 def _handle_dict(value: Any, depth: int) -> TypeInfo:
     sampler = lambda: ((el := _random_item(value)), value[el])
     args = _get_container_args(value, 2, sampler, depth)
 
     t: type = type(value)
     if (ti := _BUILTINS.get(t)):
-        return ti.replace(args=args)
+        return ti.replace(args=args, container_id=_cid_for(value))
 
-    return TypeInfo.from_type(t, args=args)
+    return TypeInfo.from_type(t, args=args, container_id=_cid_for(value))
 
 
 def _handle_randomdict(value: Any, depth: int) -> TypeInfo:
@@ -666,17 +803,25 @@ def _handle_randomdict(value: Any, depth: int) -> TypeInfo:
     except Exception as e:
         return TypeInfo.from_type(dict)
     else:
-        return TypeInfo.from_type(dict, args=args)
+        return TypeInfo.from_type(dict, args=args, container_id=_cid_for(value))
 
 
 def _handle_list(value: Any, depth: int) -> TypeInfo:
     sampler = lambda: (value[random.randint(0, len(value)-1)],) # this is O(1), much faster than islice()
-    return TypeInfo.from_type(list, args=_get_container_args(value, 1, sampler, depth))
+    return TypeInfo.from_type(
+        list,
+        args=_get_container_args(value, 1, sampler, depth),
+        container_id=_cid_for(value),
+    )
 
 
 def _handle_set(value: Any, depth: int) -> TypeInfo:
     sampler = lambda: (_random_item(value),)
-    return TypeInfo.from_type(type(value), args=_get_container_args(value, 1, sampler, depth))
+    return TypeInfo.from_type(
+        type(value),
+        args=_get_container_args(value, 1, sampler, depth),
+        container_id=_cid_for(value),
+    )
 
 
 def _handle_dict_keyiter(value: Any, depth: int) -> TypeInfo|None:

--- a/righttyper/typeinfo.py
+++ b/righttyper/typeinfo.py
@@ -1,5 +1,5 @@
 import typing
-from typing import Iterator, Iterable, Final, Callable, Any, cast
+from typing import Iterator, Iterable, Final, Callable, Any, cast, overload
 import types
 from dataclasses import dataclass, fields, replace, field
 from righttyper.righttyper_types import CodeId
@@ -100,6 +100,16 @@ class TypeInfo:
             **kwargs
         )
 
+
+    @overload
+    @staticmethod
+    def from_set(s: "set[TypeInfo]", **kwargs: Any) -> "TypeInfo": ...
+    @overload
+    @staticmethod
+    def from_set(s: "set[TypeInfo]", on_empty: "TypeInfo", **kwargs: Any) -> "TypeInfo": ...
+    @overload
+    @staticmethod
+    def from_set(s: "set[TypeInfo]", on_empty: None, **kwargs: Any) -> "TypeInfo | None": ...
 
     @staticmethod
     def from_set(s: "set[TypeInfo]", on_empty: Any = _UNSET,

--- a/righttyper/typeinfo.py
+++ b/righttyper/typeinfo.py
@@ -13,6 +13,14 @@ type SpecialForms = typing.Any|typing.Never
 type TypeInfoArg = TypeInfo|str|types.EllipsisType|tuple[()]
 
 
+# Sentinel for ``TypeInfo.from_set``'s ``on_empty`` parameter to
+# distinguish "caller didn't specify what to return on empty input"
+# from "caller wants Python ``None`` returned." Defaulting directly to
+# ``TypeInfo.from_type(typing.Never)`` isn't possible because ``TypeInfo``
+# isn't yet bound at class-body evaluation time.
+_UNSET: Any = object()
+
+
 @dataclass(eq=True, frozen=True)
 class TypeInfo:
     """Holds information about a type."""
@@ -94,15 +102,29 @@ class TypeInfo:
 
 
     @staticmethod
-    def from_set(s: "set[TypeInfo]", empty_is_none=False, **kwargs: Any) -> "TypeInfo":
+    def from_set(s: "set[TypeInfo]", on_empty: Any = _UNSET,
+                 **kwargs: Any) -> "TypeInfo | None":
         """Form a union from a set, with simplification.
 
         Expands nested unions, subsumes Any, removes Never/NoReturn,
         cleans up Never-generics, caps oversized unions, and sorts
         for deterministic output.
+
+        ``on_empty`` controls what to return when ``s`` is empty:
+
+        - default (unset): ``typing.Never`` TypeInfo — appropriate for
+          "no observations contribute here, leave as the union identity."
+        - ``NoneTypeInfo``: appropriate for slots where empty really means
+          the type is ``None`` (e.g. a generator that never yielded).
+        - Python ``None``: signals "no information" — return the
+          sentinel rather than a type. Callers that hold a
+          ``TypeInfo | None`` field (e.g. ``ArgInfo.default``) use this.
+        - Any other ``TypeInfo``: returned as-is.
         """
         if not s:
-            return NoneTypeInfo if empty_is_none else TypeInfo.from_type(typing.Never)
+            if on_empty is _UNSET:
+                return TypeInfo.from_type(typing.Never)
+            return on_empty
 
         def expand_unions(t: "TypeInfo") -> Iterator["TypeInfo"]:
             # Don't merge unions designated as typevars, or the typevar gets lost.

--- a/righttyper/typeinfo.py
+++ b/righttyper/typeinfo.py
@@ -7,7 +7,12 @@ from righttyper.righttyper_utils import normalize_module_name
 
 
 # The typing module does not define a type for such "typing special forms".
-type SpecialForms = typing.Any|typing.Never
+# from_type accepts both regular types and special forms like typing.Any,
+# typing.Never, typing.NoReturn, typing.Self, typing.Callable, typing.Union,
+# and typing.Optional. There isn't a good way to narrow to just these:
+# mypy and pyright disagree on how to model them, and any union containing
+# typing.Any collapses to Any anyway. The alias is kept for documentation.
+type SpecialForms = typing.Any
 
 # What is allowed in TypeInfo.args
 type TypeInfoArg = TypeInfo|str|types.EllipsisType|tuple[()]

--- a/righttyper/typeinfo.py
+++ b/righttyper/typeinfo.py
@@ -46,6 +46,16 @@ class TypeInfo:
     # Multiple can occur in a function call, in different order, so include in comparisons.
     typevar_index: int = field(default=0, compare=True)
 
+    # ``id()`` of the Python container that produced this TypeInfo, when
+    # one was sampled (set in the relevant ``_handle_*`` handlers in
+    # ``type_id``).  Excluded from comparison so two TypeInfos with the
+    # same shape but different container ids still hash/eq equal in
+    # ``Counter[CallTrace]`` dedup.  Consumed at recording end by the
+    # transformer that rewrites trace TypeInfos to each container's
+    # resolved-latest snapshot from ``ContainerTypeCache``; cleared post-
+    # rewrite (so it never reaches the ``.rt`` pickle).
+    container_id: int | None = field(default=None, compare=False)
+
 
     @staticmethod
     def _arg2str(a: TypeInfoArg, modifier: Callable[["TypeInfo"], str|None]|None) -> str:
@@ -235,15 +245,25 @@ class TypeInfo:
 
     @staticmethod
     def _strip_type_obj_for_pickle(t: "TypeInfo") -> tuple[Any, ...]:
-        """Pickle reducer that drops `type_obj`.  Registered on the
-        `Pickler.dispatch_table` used to write `.rt` files: without it,
-        the live class reference (often a __main__-defined class) leaks
-        through the round-trip and overrides the canonical (module, name)
-        chosen by `AdjustTypeNamesT`, producing names like
-        `__main__.Foo` at process time.  Walks `fields()` so it stays
-        correct as TypeInfo evolves."""
+        """Pickle reducer that drops ``type_obj`` and ``container_id``.
+        Registered on the ``Pickler.dispatch_table`` used to write
+        ``.rt`` files.
+
+        ``type_obj``: without stripping, the live class reference (often
+        a ``__main__``-defined class) leaks through the round-trip and
+        overrides the canonical ``(module, name)`` chosen by
+        ``AdjustTypeNamesT``, producing names like ``__main__.Foo`` at
+        process time.
+
+        ``container_id``: a transient cid (from
+        ``ContainerSamples.cid``) only meaningful within one recording
+        process — the resolver consumes it before pickle; any leftover
+        values reference an in-memory cache that the process step won't
+        have.  Cleared here for cleanliness.
+
+        Walks ``fields()`` so it stays correct as TypeInfo evolves."""
         return type(t), tuple(
-            None if f.name == 'type_obj' else getattr(t, f.name)
+            None if f.name in ('type_obj', 'container_id') else getattr(t, f.name)
             for f in fields(type(t))
         )
 

--- a/righttyper/unified_transformer.py
+++ b/righttyper/unified_transformer.py
@@ -9,7 +9,7 @@ from righttyper.variable_binding import VariableBindingProvider
 import re
 
 from righttyper.typeinfo import TypeInfo
-from righttyper.righttyper_types import Filename, CodeId, FunctionName, VariableName, ArgumentName
+from righttyper.righttyper_types import Filename, FuncLoc, FunctionName, VariableName, ArgumentName
 from righttyper.annotation import FuncAnnotation, ModuleVars, TraceDistribution
 
 
@@ -186,7 +186,7 @@ class UnifiedTransformer(cst.CSTTransformer):
     def __init__(
         self,
         filename: str,
-        type_annotations: dict[CodeId, FuncAnnotation],
+        type_annotations: dict[FuncLoc, FuncAnnotation],
         module_variables: ModuleVars | None,
         module_name: str,
         *,
@@ -194,7 +194,7 @@ class UnifiedTransformer(cst.CSTTransformer):
         only_update_annotations: bool = False,
         inline_generics: bool = True,
         always_quote_annotations: bool = False,
-        type_distributions: dict[CodeId, list[TraceDistribution]] | None = None,
+        type_distributions: dict[FuncLoc, list[TraceDistribution]] | None = None,
     ) -> None:
         self.filename = filename
         self.type_annotations = type_annotations
@@ -486,8 +486,8 @@ class UnifiedTransformer(cst.CSTTransformer):
         # The annotation for the current function, if any
         self.func_ann_stack: list[FuncAnnotation|None] = [None]
 
-        # The CodeId for the current function, if any
-        self.func_code_id_stack: list[CodeId|None] = [None]
+        # The FuncLoc for the current function, if any
+        self.func_loc_stack: list[FuncLoc|None] = [None]
 
         # Whether to annotate variables in this scope
         self.annotate_vars_stack: list[bool] = [True]
@@ -901,10 +901,10 @@ class UnifiedTransformer(cst.CSTTransformer):
             self.get_metadata(PositionProvider, node).start.line
             for node in (node, *node.decorators)
         )
-        key = CodeId(Filename(self.filename), FunctionName(name), first_line, 0)
+        key = FuncLoc(Filename(self.filename), FunctionName(name), first_line)
         ann = self.type_annotations.get(key)
         self.func_ann_stack.append(ann)
-        self.func_code_id_stack.append(key)
+        self.func_loc_stack.append(key)
         self.annotate_vars_stack.append(True)
 
         # Reserve inline type-param names for this function so that outer
@@ -990,7 +990,7 @@ class UnifiedTransformer(cst.CSTTransformer):
         | cst.FlattenSentinel[cst.FunctionDef|cst.SimpleStatementLine|cst.BaseCompoundStatement] \
         | cst.RemovalSentinel:
         func_name = ".".join(self.name_stack[:-1])
-        func_code_id = self.func_code_id_stack.pop()
+        func_loc = self.func_loc_stack.pop()
         self.annotate_vars_stack.pop()
         self.name_stack.pop()
         self.name_stack.pop()
@@ -1194,8 +1194,8 @@ class UnifiedTransformer(cst.CSTTransformer):
 
             # Add type distribution comment if available
             if (
-                func_code_id
-                and (dist := self.type_distributions.get(func_code_id))
+                func_loc
+                and (dist := self.type_distributions.get(func_loc))
                 and (comment_text := self._format_distribution_comment(dist))
             ):
                 # Strip any existing # righttyper: comments to avoid duplication on re-runs

--- a/tests/test_coverage_loader.py
+++ b/tests/test_coverage_loader.py
@@ -1,0 +1,148 @@
+"""Tests for the --with-coverage loader integration.
+
+These verify (a) that --with-coverage causes slipcover to instrument the user
+code and persist per-file line coverage in the .rt pickle, and (b) the
+off-by-default contract: without the flag, slipcover is never imported and
+no coverage data appears in the pickle. The latter is a hard priority — RT's
+near-zero-overhead promise depends on it.
+"""
+
+from __future__ import annotations
+
+import pickle
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from test_integration import rt_run
+
+
+@pytest.fixture(scope="function")
+def tmp_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    yield tmp_path
+
+
+def _write_target(tmp_cwd: Path) -> Path:
+    """A target with a branch we exercise (truthy) and one we don't (falsy)."""
+    src = textwrap.dedent(
+        """\
+        import sys
+
+        def f(x: int) -> str:
+            if x:
+                return "yes"
+            return "no"
+
+        f(1)
+
+        with open("slipcover_imported.txt", "w") as _fh:
+            _fh.write("yes" if "slipcover" in sys.modules else "no")
+        """
+    )
+    target = tmp_cwd / "t.py"
+    target.write_text(src)
+    return target
+
+
+def _load_only_pickle(tmp_cwd: Path) -> dict:
+    pickles = sorted(tmp_cwd.glob("righttyper-*.rt"))
+    assert len(pickles) == 1, f"expected exactly one .rt pickle, got {pickles}"
+    with pickles[0].open("rb") as f:
+        return pickle.load(f)
+
+
+def test_with_coverage_populates_pickle(tmp_cwd):
+    target = _write_target(tmp_cwd)
+
+    rt_run("--only-collect", "--with-coverage", str(target))
+
+    pkl = _load_only_pickle(tmp_cwd)
+
+    assert "coverage" in pkl, "expected 'coverage' key in pickle"
+    cov = pkl["coverage"]
+    assert isinstance(cov, dict)
+    assert "files" in cov, f"slipcover coverage dict shape changed: {cov.keys()}"
+
+    target_resolved = str(target.resolve())
+    file_entries = {Path(k).resolve(): v for k, v in cov["files"].items()}
+    assert target.resolve() in file_entries, (
+        f"target file {target_resolved} not found in coverage files: "
+        f"{list(file_entries.keys())}"
+    )
+
+    entry = file_entries[target.resolve()]
+    executed = set(entry.get("executed_lines", ()))
+    # `if x:` was taken (truthy), `return "yes"` ran, `return "no"` did not.
+    src_lines = target.read_text().splitlines()
+    yes_line = next(i for i, l in enumerate(src_lines, 1) if 'return "yes"' in l)
+    no_line = next(i for i, l in enumerate(src_lines, 1) if 'return "no"' in l)
+    assert yes_line in executed, (
+        f"expected line {yes_line} (return \"yes\") in executed_lines {executed}"
+    )
+    assert no_line not in executed, (
+        f"expected line {no_line} (return \"no\") NOT in executed_lines {executed}"
+    )
+
+
+def test_default_run_does_not_import_slipcover(tmp_cwd):
+    target = _write_target(tmp_cwd)
+
+    rt_run("--only-collect", str(target))
+
+    pkl = _load_only_pickle(tmp_cwd)
+    assert "coverage" not in pkl, (
+        f"unexpected 'coverage' key in pickle for default run: pkl keys={list(pkl)}"
+    )
+
+    flag = (tmp_cwd / "slipcover_imported.txt").read_text().strip()
+    assert flag == "no", (
+        "slipcover was imported during a default run; that breaks the "
+        "off-by-default zero-overhead contract"
+    )
+
+
+def test_with_coverage_fails_clearly_when_coverage_id_taken(tmp_cwd):
+    """If another tool already holds sys.monitoring's COVERAGE_ID, slipcover
+    can't claim it. RT should fail with a clear, actionable message rather
+    than a raw ValueError from CPython.
+    """
+    target = _write_target(tmp_cwd)
+
+    wrapper = tmp_cwd / "wrapper.py"
+    wrapper.write_text(
+        textwrap.dedent(
+            f"""\
+            import sys
+            sys.monitoring.use_tool_id(sys.monitoring.COVERAGE_ID, "PreclaimedByTest")
+            sys.argv = [
+                "righttyper", "run", "--no-use-multiprocessing",
+                "--allow-runtime-exceptions",
+                "--with-coverage", "--only-collect", {str(target)!r},
+            ]
+            from righttyper.righttyper import cli
+            try:
+                cli()
+            except SystemExit as e:
+                sys.exit(e.code if isinstance(e.code, int) else 1)
+            """
+        )
+    )
+
+    proc = subprocess.run(
+        [sys.executable, str(wrapper)],
+        capture_output=True,
+        text=True,
+    )
+
+    assert proc.returncode != 0, (
+        f"expected non-zero exit; stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    )
+    combined = (proc.stdout or "") + (proc.stderr or "")
+    assert "COVERAGE_ID" in combined and "PreclaimedByTest" in combined, (
+        f"expected clear error mentioning COVERAGE_ID and the holder; got: "
+        f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    )

--- a/tests/test_diagnostics_emit.py
+++ b/tests/test_diagnostics_emit.py
@@ -1,0 +1,63 @@
+"""End-to-end test for the diagnostics emitter.
+
+Target models an input-shape gap: a comprehension whose body is
+line-covered but the filter excludes every element.
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+
+import pytest
+
+from test_integration import rt_run
+
+
+@pytest.fixture(scope="function")
+def tmp_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    yield tmp_path
+
+
+def test_emit_records_input_shape_gap_on_return(tmp_cwd):
+    target = tmp_cwd / "t.py"
+    target.write_text(
+        textwrap.dedent(
+            """\
+            def f(items, threshold):
+                return [x for x in items if x > threshold]
+
+            f([1, 2, 3], 100)
+            f([1, 2, 3], 100)
+            """
+        )
+    )
+
+    rt_run("--only-collect", "--with-coverage", str(target))
+    rt_run("process", "--with-coverage", "--no-output-files")
+
+    artifact_path = tmp_cwd / "righttyper-diagnostics.json"
+    assert artifact_path.exists(), "expected righttyper-diagnostics.json to be written"
+
+    artifact = json.loads(artifact_path.read_text())
+    assert isinstance(artifact, list), f"expected JSON list, got {type(artifact).__name__}"
+
+    records = [r for r in artifact if r.get("qpath") == "f"]
+    assert len(records) == 1, f"expected exactly one record for f, got {records}"
+    rec = records[0]
+
+    assert rec["slot"] == "return"
+    assert rec["kind"] == "return"
+    assert rec["degeneracy"]["shape"] == "empty-container"
+    assert rec["degeneracy"]["always_empty"] is True
+    assert rec["degeneracy"]["n_observations"] >= 1
+
+    cov = rec["coverage"]
+    assert cov is not None, "expected coverage block to be populated when --with-coverage was set at run time"
+    assert isinstance(cov["function_executed"], list)
+    src_lines = target.read_text().splitlines()
+    comp_line = next(i for i, l in enumerate(src_lines, 1) if "return [x for x" in l)
+    assert comp_line in cov["function_executed"], (
+        f"expected comprehension line {comp_line} in function_executed {cov['function_executed']}"
+    )

--- a/tests/test_diagnostics_emit.py
+++ b/tests/test_diagnostics_emit.py
@@ -61,3 +61,45 @@ def test_emit_records_input_shape_gap_on_return(tmp_cwd):
     assert comp_line in cov["function_executed"], (
         f"expected comprehension line {comp_line} in function_executed {cov['function_executed']}"
     )
+
+
+def test_always_none_returns_are_not_reported(tmp_cwd):
+    """Functions that always return None on every call (``__init__``,
+    descriptor setters, void action methods, etc.) are common and
+    intentional in Python.  Without comparing observations to the
+    developer's declared annotation, we can't separate "intentionally
+    void" from "Optional[T] whose T-branch wasn't exercised" -- so the
+    emitter drops always-none-optional on returns. (Args remain reported.)
+    """
+    target = tmp_cwd / "t.py"
+    target.write_text(
+        textwrap.dedent(
+            """\
+            class C:
+                def __init__(self, x):
+                    self.x = x
+                def update(self, x):
+                    self.x = x
+
+            def void_fn():
+                pass
+
+            c = C(1)
+            c.update(2)
+            void_fn()
+            void_fn()
+            """
+        )
+    )
+
+    rt_run("--only-collect", "--with-coverage", str(target))
+    rt_run("process", "--with-coverage", "--no-output-files")
+
+    artifact = json.loads((tmp_cwd / "righttyper-diagnostics.json").read_text())
+    always_none_returns = [
+        r for r in artifact
+        if r["kind"] == "return" and r["degeneracy"]["shape"] == "always-none-optional"
+    ]
+    assert not always_none_returns, (
+        f"expected no always-none-optional return records; got {always_none_returns}"
+    )

--- a/tests/test_diagnostics_predicate.py
+++ b/tests/test_diagnostics_predicate.py
@@ -1,0 +1,67 @@
+"""Tests for the degeneracy predicate used by the diagnostics emitter.
+
+A slot is *degenerate* when, across all observations, its types collapse to
+one of:
+  - an empty container shape (list[Never], dict[Never, Never], tuple[()], ...);
+  - a generator/iterator/coroutine that never advanced past first yield;
+  - an Optional value observed only as None.
+
+The predicate operates on the multiset of TypeInfo observations for one
+slot and returns the shape name (or None when the slot is *not*
+degenerate). The shape name flows directly into the diagnostics JSON.
+"""
+
+from __future__ import annotations
+
+import typing
+from collections import abc
+
+import pytest
+
+from righttyper.generalize import degenerate_shape
+from righttyper.typeinfo import NoneTypeInfo, TypeInfo
+
+
+NEVER = TypeInfo.from_type(typing.Never)
+INT = TypeInfo.from_type(int)
+STR = TypeInfo.from_type(str)
+
+
+def c(t: type, *args: TypeInfo) -> TypeInfo:
+    return TypeInfo.from_type(t, args=args)
+
+
+EMPTY_TUPLE = TypeInfo.from_type(tuple, args=((),))
+
+
+CASES = [
+    # (description, observation set, expected shape-or-None)
+    ("list[Never]",                {c(list, NEVER)},                              "empty-container"),
+    ("dict[Never, Never]",         {c(dict, NEVER, NEVER)},                       "empty-container"),
+    ("set[Never]",                 {c(set, NEVER)},                               "empty-container"),
+    ("tuple[()]",                  {EMPTY_TUPLE},                                 "empty-container"),
+    ("Generator[None,None,None]",  {c(abc.Generator, NoneTypeInfo, NoneTypeInfo, NoneTypeInfo)}, "never-advanced-generator"),
+    ("Iterator[None]",             {c(abc.Iterator, NoneTypeInfo)},               "never-advanced-generator"),
+    ("AsyncIterator[None]",        {c(abc.AsyncIterator, NoneTypeInfo)},          "never-advanced-generator"),
+    ("AsyncGenerator[None,None]",  {c(abc.AsyncGenerator, NoneTypeInfo, NoneTypeInfo)},          "never-advanced-generator"),
+    ("Coroutine[_,_,None]",        {c(abc.Coroutine, NoneTypeInfo, NoneTypeInfo, NoneTypeInfo)}, "never-advanced-generator"),
+    ("always None",                {NoneTypeInfo},                                "always-none-optional"),
+
+    # Negative cases.
+    ("list[int]",                  {c(list, INT)},                                None),
+    ("Generator[int,None,None]",   {c(abc.Generator, INT, NoneTypeInfo, NoneTypeInfo)},          None),
+    ("Iterator[int]",              {c(abc.Iterator, INT)},                        None),
+    ("Coroutine[_,_,int]",         {c(abc.Coroutine, NoneTypeInfo, NoneTypeInfo, INT)},          None),
+    ("list[Never] + list[int]",    {c(list, NEVER), c(list, INT)},                None),
+    ("list[Never] + list[str]",    {c(list, NEVER), c(list, STR)},                None),
+    ("Iterator[None] + Iterator[int]", {c(abc.Iterator, NoneTypeInfo), c(abc.Iterator, INT)},     None),
+    ("tuple[()] + tuple[int]",     {EMPTY_TUPLE, c(tuple, INT)},                  None),
+    ("list[Never] + Iterator[None]", {c(list, NEVER), c(abc.Iterator, NoneTypeInfo)},            None),  # mixed degenerate shapes — abstain
+    ("None + int",                 {NoneTypeInfo, INT},                           None),
+    ("empty observations",         set(),                                         None),
+]
+
+
+@pytest.mark.parametrize("desc,obs,expected", CASES, ids=[row[0] for row in CASES])
+def test_degenerate_shape(desc, obs, expected):
+    assert degenerate_shape(obs) == expected

--- a/tests/test_generalize.py
+++ b/tests/test_generalize.py
@@ -1662,6 +1662,41 @@ def test_is_private_type():
     assert _is_private_type(private_name)
 
 
+def test_is_private_type_survives_concurrent_sys_modules_mutation(monkeypatch):
+    """``_is_private_type`` walks ``sys.modules`` to check for public
+    re-exports.  ``getattr(m, name, None)`` can trigger a module-level
+    ``__getattr__`` that performs a lazy import (httpx, jaxtyping, etc. do
+    this), mutating sys.modules mid-iteration.  Without snapshotting,
+    CPython raises ``RuntimeError: dictionary changed size during iteration``.
+
+    Regression: httpx-righttyper -fullscan / -nocache lost the exercise
+    step (~635 traces, 21 unique functions) because finish_recording's
+    container-snapshot resolver hit this in ``lub`` → ``_is_private_type``.
+    """
+    import sys, types as _types
+    from righttyper.generalize import _is_private_type
+
+    # A type from a private module that gets re-exported nowhere.
+    target = type('HiddenType', (object,), {'__module__': '_secret_impl'})
+
+    # Install a module whose __getattr__ adds a new entry to sys.modules
+    # every time it's probed — simulates lazy-import side effects.
+    class LazyModule(_types.ModuleType):
+        _counter = 0
+        def __getattr__(self, name):
+            cls = type(self)
+            cls._counter += 1
+            new_name = f"_lazy_inject_{cls._counter}"
+            sys.modules[new_name] = _types.ModuleType(new_name)
+            raise AttributeError(name)
+
+    lazy = LazyModule("lazy_pkg")
+    monkeypatch.setitem(sys.modules, "lazy_pkg", lazy)
+
+    # Must not raise RuntimeError; should still classify as private.
+    assert _is_private_type(target)
+
+
 def test_lub_skips_private_mro_ancestors():
     """lub should not merge to a common ancestor defined in a private module."""
     from righttyper.generalize import lub

--- a/tests/test_generalize.py
+++ b/tests/test_generalize.py
@@ -365,7 +365,7 @@ def test_merge_container_supersets_list():
     list_int = TypeInfo.from_type(list).replace(args=(int_t,))
     list_int_str = TypeInfo.from_type(list).replace(args=(TypeInfo.from_set({int_t, str_t}),))
 
-    result = merged_types({list_int, list_int_str}, for_variable=True)
+    result = merged_types({list_int, list_int_str}, assume_covariant=True)
     assert result == list_int_str
 
 
@@ -378,7 +378,7 @@ def test_merge_container_supersets_no_subset():
     list_int = TypeInfo.from_type(list).replace(args=(int_t,))
     list_str = TypeInfo.from_type(list).replace(args=(str_t,))
 
-    result = merged_types({list_int, list_str}, for_variable=True)
+    result = merged_types({list_int, list_str}, assume_covariant=True)
     assert result == TypeInfo.from_type(list).replace(args=(TypeInfo.from_set({int_t, str_t}),))
 
 
@@ -394,7 +394,7 @@ def test_merge_container_supersets_chain():
     list_int_str = TypeInfo.from_type(list).replace(args=(TypeInfo.from_set({int_t, str_t}),))
     list_all = TypeInfo.from_type(list).replace(args=(TypeInfo.from_set({int_t, str_t, float_t}),))
 
-    result = merged_types({list_int, list_int_str, list_all}, for_variable=True)
+    result = merged_types({list_int, list_int_str, list_all}, assume_covariant=True)
     assert result == list_all
 
 
@@ -409,7 +409,7 @@ def test_merge_container_supersets_nested():
     list_set_int = TypeInfo.from_type(list).replace(args=(set_int,))
     list_set_int_str = TypeInfo.from_type(list).replace(args=(set_int_str,))
 
-    result = merged_types({list_set_int, list_set_int_str}, for_variable=True)
+    result = merged_types({list_set_int, list_set_int_str}, assume_covariant=True)
     assert result == list_set_int_str
 
 
@@ -424,7 +424,7 @@ def test_merge_container_supersets_dict():
     dict_str_int = TypeInfo.from_type(dict).replace(args=(str_t, int_t))
     dict_str_int_float = TypeInfo.from_type(dict).replace(args=(str_t, TypeInfo.from_set({int_t, float_t})))
 
-    result = merged_types({dict_str_int, dict_str_int_float}, for_variable=True)
+    result = merged_types({dict_str_int, dict_str_int_float}, assume_covariant=True)
     assert result == dict_str_int_float
 
 
@@ -438,7 +438,7 @@ def test_merge_container_supersets_dict_no_subset():
     dict_str_int = TypeInfo.from_type(dict).replace(args=(str_t, int_t))
     dict_int_int = TypeInfo.from_type(dict).replace(args=(int_t, int_t))
 
-    result = merged_types({dict_str_int, dict_int_int}, for_variable=True)
+    result = merged_types({dict_str_int, dict_int_int}, assume_covariant=True)
     assert result == TypeInfo.from_type(dict).replace(args=(TypeInfo.from_set({str_t, int_t}), int_t))
 
 
@@ -452,7 +452,7 @@ def test_merge_container_supersets_dict_key_subset():
     dict_str_int = TypeInfo.from_type(dict).replace(args=(str_t, int_t))
     dict_str_or_int_int = TypeInfo.from_type(dict).replace(args=(TypeInfo.from_set({str_t, int_t}), int_t))
 
-    result = merged_types({dict_str_int, dict_str_or_int_int}, for_variable=True)
+    result = merged_types({dict_str_int, dict_str_or_int_int}, assume_covariant=True)
     assert result == dict_str_or_int_int
 
 
@@ -466,7 +466,7 @@ def test_merge_container_supersets_mixed_containers():
     list_int_str = TypeInfo.from_type(list).replace(args=(TypeInfo.from_set({int_t, str_t}),))
     set_int = TypeInfo.from_type(set).replace(args=(int_t,))
 
-    result = merged_types({list_int, set_int, list_int_str}, for_variable=True)
+    result = merged_types({list_int, set_int, list_int_str}, assume_covariant=True)
     assert result == TypeInfo.from_set({set_int, list_int_str})
 
 
@@ -481,7 +481,7 @@ def test_merge_covariant_tuple():
     tuple_int = TypeInfo.from_type(tuple).replace(args=(int_t,))
     tuple_bool = TypeInfo.from_type(tuple).replace(args=(bool_t,))
 
-    result = merged_types({tuple_int, tuple_bool}, for_variable=False)
+    result = merged_types({tuple_int, tuple_bool}, assume_covariant=False)
     assert result == TypeInfo.from_type(tuple).replace(args=(int_t,))
 
 
@@ -496,7 +496,7 @@ def test_merge_covariant_tuple_multi_arg():
     tuple_is = TypeInfo.from_type(tuple).replace(args=(int_t, str_t))
     tuple_fs = TypeInfo.from_type(tuple).replace(args=(float_t, str_t))
 
-    result = merged_types({tuple_is, tuple_fs}, for_variable=False)
+    result = merged_types({tuple_is, tuple_fs}, assume_covariant=False)
     # int|float simplifies to float via PEP 3141 numeric tower
     expected = TypeInfo.from_type(tuple).replace(args=(float_t, str_t))
     assert result == expected
@@ -511,7 +511,7 @@ def test_merge_covariant_tuple_varlen():
     tuple_int_var = TypeInfo.from_type(tuple).replace(args=(int_t, Ellipsis))
     tuple_str_var = TypeInfo.from_type(tuple).replace(args=(str_t, Ellipsis))
 
-    result = merged_types({tuple_int_var, tuple_str_var}, for_variable=False)
+    result = merged_types({tuple_int_var, tuple_str_var}, assume_covariant=False)
     expected = TypeInfo.from_type(tuple).replace(
         args=(TypeInfo.from_set({int_t, str_t}), Ellipsis)
     )
@@ -527,7 +527,7 @@ def test_merge_covariant_frozenset():
     fs_int = TypeInfo.from_type(frozenset).replace(args=(int_t,))
     fs_str = TypeInfo.from_type(frozenset).replace(args=(str_t,))
 
-    result = merged_types({fs_int, fs_str}, for_variable=False)
+    result = merged_types({fs_int, fs_str}, assume_covariant=False)
     expected = TypeInfo.from_type(frozenset).replace(
         args=(TypeInfo.from_set({int_t, str_t}),)
     )
@@ -548,7 +548,7 @@ def test_merge_covariant_tuple_different_lengths():
     tuple_1 = TypeInfo.from_type(tuple).replace(args=(int_t,))
     tuple_2 = TypeInfo.from_type(tuple).replace(args=(int_t, str_t))
 
-    result = merged_types({tuple_1, tuple_2}, for_variable=False)
+    result = merged_types({tuple_1, tuple_2}, assume_covariant=False)
     assert result == TypeInfo.from_type(tuple).replace(
         args=(TypeInfo.from_set({int_t, str_t}), Ellipsis)
     )
@@ -563,7 +563,7 @@ def test_merge_covariant_tuple_fixed_vs_varlen():
     tuple_fixed = TypeInfo.from_type(tuple).replace(args=(int_t, str_t))
     tuple_var = TypeInfo.from_type(tuple).replace(args=(int_t, Ellipsis))
 
-    result = merged_types({tuple_fixed, tuple_var}, for_variable=False)
+    result = merged_types({tuple_fixed, tuple_var}, assume_covariant=False)
     assert result == TypeInfo.from_set({tuple_fixed, tuple_var})
 
 
@@ -576,7 +576,7 @@ def test_merge_invariant_list_unchanged():
     list_int = TypeInfo.from_type(list).replace(args=(int_t,))
     list_str = TypeInfo.from_type(list).replace(args=(str_t,))
 
-    result = merged_types({list_int, list_str}, for_variable=False)
+    result = merged_types({list_int, list_str}, assume_covariant=False)
     assert result == TypeInfo.from_set({list_int, list_str})
 
 
@@ -590,7 +590,7 @@ def test_subsume_fixed_by_varlen_tuple():
     tuple_fixed = TypeInfo.from_type(tuple).replace(args=(int_t, int_t))
     tuple_var = TypeInfo.from_type(tuple).replace(args=(int_t, Ellipsis))
 
-    result = merged_types({tuple_fixed, tuple_var}, for_variable=False)
+    result = merged_types({tuple_fixed, tuple_var}, assume_covariant=False)
     assert result == tuple_var
 
 
@@ -603,7 +603,7 @@ def test_no_subsume_fixed_by_varlen_tuple():
     tuple_fixed = TypeInfo.from_type(tuple).replace(args=(int_t, str_t))
     tuple_var = TypeInfo.from_type(tuple).replace(args=(int_t, Ellipsis))
 
-    result = merged_types({tuple_fixed, tuple_var}, for_variable=False)
+    result = merged_types({tuple_fixed, tuple_var}, assume_covariant=False)
     assert result == TypeInfo.from_set({tuple_fixed, tuple_var})
 
 
@@ -617,7 +617,7 @@ def test_subsume_fixed_by_varlen_tuple_union_elem():
     tuple_fixed = TypeInfo.from_type(tuple).replace(args=(int_t, str_t))
     tuple_var = TypeInfo.from_type(tuple).replace(args=(int_or_str, Ellipsis))
 
-    result = merged_types({tuple_fixed, tuple_var}, for_variable=False)
+    result = merged_types({tuple_fixed, tuple_var}, assume_covariant=False)
     assert result == tuple_var
 
 
@@ -630,7 +630,7 @@ def test_subsume_multiple_fixed_by_varlen():
     tuple_2 = TypeInfo.from_type(tuple).replace(args=(int_t, int_t))
     tuple_var = TypeInfo.from_type(tuple).replace(args=(int_t, Ellipsis))
 
-    result = merged_types({tuple_1, tuple_2, tuple_var}, for_variable=False)
+    result = merged_types({tuple_1, tuple_2, tuple_var}, assume_covariant=False)
     assert result == tuple_var
 
 
@@ -642,7 +642,7 @@ def test_subsume_empty_tuple_by_varlen():
     tuple_empty = TypeInfo.from_type(tuple).replace(args=((),))
     tuple_var = TypeInfo.from_type(tuple).replace(args=(int_t, Ellipsis))
 
-    result = merged_types({tuple_empty, tuple_var}, for_variable=False)
+    result = merged_types({tuple_empty, tuple_var}, assume_covariant=False)
     assert result == tuple_var
 
 
@@ -934,49 +934,49 @@ def test_lub_no_common_base():
     assert types == {int, str}
 
 
-def test_lub_same_container_merge_for_variable():
-    """lub(list[int], list[str]) = list[int|str] when for_variable=True."""
+def test_lub_same_container_merge_assume_covariant():
+    """lub(list[int], list[str]) = list[int|str] when assume_covariant=True."""
     from righttyper.generalize import lub
     int_t = TypeInfo.from_type(int)
     str_t = TypeInfo.from_type(str)
     a = TypeInfo.from_type(list).replace(args=(int_t,))
     b = TypeInfo.from_type(list).replace(args=(str_t,))
-    result = lub(a, b, for_variable=True)
+    result = lub(a, b, assume_covariant=True)
     assert result.type_obj is list
     assert result.args and isinstance(result.args[0], TypeInfo)
     assert _ti(result.args[0]).is_union()
 
 
 def test_lub_same_container_no_merge_invariant():
-    """lub(list[int], list[str]) = list[int]|list[str] when for_variable=False (invariant)."""
+    """lub(list[int], list[str]) = list[int]|list[str] when assume_covariant=False (invariant)."""
     from righttyper.generalize import lub
     int_t = TypeInfo.from_type(int)
     str_t = TypeInfo.from_type(str)
     a = TypeInfo.from_type(list).replace(args=(int_t,))
     b = TypeInfo.from_type(list).replace(args=(str_t,))
-    result = lub(a, b, for_variable=False)
+    result = lub(a, b, assume_covariant=False)
     assert result.is_union()
     assert result.to_set() == {a, b}
 
 
 def test_lub_same_container_subtype_args():
-    """lub(list[bool], list[int]) = list[int] when for_variable=True (bool <: int)."""
+    """lub(list[bool], list[int]) = list[int] when assume_covariant=True (bool <: int)."""
     from righttyper.generalize import lub
     a = TypeInfo.from_type(list).replace(args=(TypeInfo.from_type(bool),))
     b = TypeInfo.from_type(list).replace(args=(TypeInfo.from_type(int),))
-    result = lub(a, b, for_variable=True)
+    result = lub(a, b, assume_covariant=True)
     assert result.type_obj is list
     assert _ti(result.args[0]).type_obj is int
 
 
 def test_lub_covariant_tuple_always_merges():
-    """lub(tuple[int,...], tuple[str,...]) = tuple[int|str,...] even for_variable=False."""
+    """lub(tuple[int,...], tuple[str,...]) = tuple[int|str,...] even assume_covariant=False."""
     from righttyper.generalize import lub
     int_t = TypeInfo.from_type(int)
     str_t = TypeInfo.from_type(str)
     a = TypeInfo.from_type(tuple).replace(args=(int_t, Ellipsis))
     b = TypeInfo.from_type(tuple).replace(args=(str_t, Ellipsis))
-    result = lub(a, b, for_variable=False)
+    result = lub(a, b, assume_covariant=False)
     assert result.type_obj is tuple
     assert _ti(result.args[0]).is_union()
 
@@ -1289,11 +1289,11 @@ def test_lub_fixed_tuple_same_length_merge():
 
 
 def test_lub_multiple_lists_merge_args():
-    """list[int] | list[str] → list[int|str] when for_variable=True."""
+    """list[int] | list[str] → list[int|str] when assume_covariant=True."""
     from righttyper.generalize import lub
     a = TypeInfo.from_type(list).replace(args=(TypeInfo.from_type(int),))
     b = TypeInfo.from_type(list).replace(args=(TypeInfo.from_type(str),))
-    result = lub(a, b, for_variable=True)
+    result = lub(a, b, assume_covariant=True)
     assert result.type_obj is list
     assert _ti(result.args[0]).is_union()
     assert _ti(result.args[0]).to_set() == {TypeInfo.from_type(int), TypeInfo.from_type(str)}
@@ -1346,26 +1346,26 @@ def test_lub_abc_cross_container_same_args():
 
 
 def test_lub_abc_cross_container_different_args_invariant():
-    """lub(list[int], set[str]) stays as union when for_variable=False (invariant)."""
+    """lub(list[int], set[str]) stays as union when assume_covariant=False (invariant)."""
     from righttyper.generalize import lub
 
     a = TypeInfo.from_type(list).replace(args=(TypeInfo.from_type(int),))
     b = TypeInfo.from_type(set).replace(args=(TypeInfo.from_type(str),))
 
-    result = lub(a, b, for_variable=False, accessed_attributes={"__iter__"})
+    result = lub(a, b, assume_covariant=False, accessed_attributes={"__iter__"})
     assert result.is_union()
     assert result.to_set() == {a, b}
 
 
-def test_lub_abc_cross_container_different_args_for_variable():
-    """lub(list[int], set[str]) merges args when for_variable=True."""
+def test_lub_abc_cross_container_different_args_assume_covariant():
+    """lub(list[int], set[str]) merges args when assume_covariant=True."""
     import collections.abc
     from righttyper.generalize import lub
 
     a = TypeInfo.from_type(list).replace(args=(TypeInfo.from_type(int),))
     b = TypeInfo.from_type(set).replace(args=(TypeInfo.from_type(str),))
 
-    result = lub(a, b, for_variable=True, accessed_attributes={"__iter__"})
+    result = lub(a, b, assume_covariant=True, accessed_attributes={"__iter__"})
     assert not result.is_union()
     assert isinstance(result.type_obj, type)
     assert issubclass(result.type_obj, collections.abc.Iterable)
@@ -1466,7 +1466,7 @@ def test_lub_callable_different_return():
         args=(TypeInfo.list([int_t]), int_t))
     b = TypeInfo.from_type(collections.abc.Callable).replace(
         args=(TypeInfo.list([int_t]), str_t))
-    result = lub(a, b, for_variable=True)
+    result = lub(a, b, assume_covariant=True)
     # Same params, different return → merge return to int|str
     assert result.type_obj is collections.abc.Callable
     assert not result.is_union()
@@ -1495,8 +1495,8 @@ def test_lub_callable_different_params():
     assert result.to_set() == {a, b}
 
 
-def test_lub_callable_different_arities_for_variable():
-    """lub(Callable[[int], int], Callable[[int, int], int], for_variable=True)
+def test_lub_callable_different_arities_assume_covariant():
+    """lub(Callable[[int], int], Callable[[int, int], int], assume_covariant=True)
     must stay a union of two Callables. Element-wise merging would push the
     union INSIDE the parameter list (``Callable[[int, int]|[int], int]``),
     which is not a valid type expression."""
@@ -1507,7 +1507,7 @@ def test_lub_callable_different_arities_for_variable():
         args=(TypeInfo.list([int_t]), int_t))
     b = TypeInfo.from_type(collections.abc.Callable).replace(
         args=(TypeInfo.list([int_t, int_t]), int_t))
-    result = lub(a, b, for_variable=True)
+    result = lub(a, b, assume_covariant=True)
     assert result.is_union()
     assert result.to_set() == {a, b}
 
@@ -1520,7 +1520,7 @@ def test_lub_callable_ellipsis_params():
     str_t = TypeInfo.from_type(str)
     a = TypeInfo.from_type(collections.abc.Callable).replace(args=(..., int_t))
     b = TypeInfo.from_type(collections.abc.Callable).replace(args=(..., str_t))
-    result = lub(a, b, for_variable=True)
+    result = lub(a, b, assume_covariant=True)
     assert result.type_obj is collections.abc.Callable
     assert not result.is_union()
     assert result.args[0] is ...

--- a/tests/test_generalize.py
+++ b/tests/test_generalize.py
@@ -1495,6 +1495,23 @@ def test_lub_callable_different_params():
     assert result.to_set() == {a, b}
 
 
+def test_lub_callable_different_arities_for_variable():
+    """lub(Callable[[int], int], Callable[[int, int], int], for_variable=True)
+    must stay a union of two Callables. Element-wise merging would push the
+    union INSIDE the parameter list (``Callable[[int, int]|[int], int]``),
+    which is not a valid type expression."""
+    import collections.abc
+    from righttyper.generalize import lub
+    int_t = TypeInfo.from_type(int)
+    a = TypeInfo.from_type(collections.abc.Callable).replace(
+        args=(TypeInfo.list([int_t]), int_t))
+    b = TypeInfo.from_type(collections.abc.Callable).replace(
+        args=(TypeInfo.list([int_t, int_t]), int_t))
+    result = lub(a, b, for_variable=True)
+    assert result.is_union()
+    assert result.to_set() == {a, b}
+
+
 def test_lub_callable_ellipsis_params():
     """lub(Callable[..., int], Callable[..., str]) merges return types."""
     import collections.abc

--- a/tests/test_generalize.py
+++ b/tests/test_generalize.py
@@ -1603,6 +1603,43 @@ def test_lub_bare_reversible_subsumes_parametrized():
     assert lub(parametrized, bare) == bare
 
 
+def test_lub_parametrized_mro_subtype_collapses_to_common_ancestor():
+    """``lub(list[X], Iterable[X])`` should return ``Iterable[X]``: ``list``
+    is a subclass of ``Iterable`` and Iterable is covariant in its arg,
+    so the union collapses to the common supertype.
+
+    Currently the existing rules don't fire: Rule 4 requires bare types,
+    Rule 5c requires same outer type, Rule 6 requires one side empty,
+    Rule 7 requires non-generic types. Different-outer parametrized
+    types fall through to a union — even when one is an MRO subclass
+    of the other and the args agree at the common ancestor."""
+    from righttyper.generalize import lub
+    import collections.abc as abc
+
+    INT = TypeInfo.from_type(int)
+    list_int = TypeInfo.from_type(list, args=(INT,))
+    iterable_int = TypeInfo.from_type(abc.Iterable, args=(INT,))
+
+    assert lub(list_int, iterable_int) == iterable_int
+    assert lub(iterable_int, list_int) == iterable_int
+
+
+def test_lub_parametrized_mro_subtype_with_arg_merging():
+    """When the args differ, ``lub(list[bool], Iterable[int])`` should
+    return ``Iterable[lub(bool, int)] == Iterable[int]`` — the common
+    ancestor with covariantly-merged args."""
+    from righttyper.generalize import lub
+    import collections.abc as abc
+
+    BOOL = TypeInfo.from_type(bool)
+    INT = TypeInfo.from_type(int)
+    list_bool = TypeInfo.from_type(list, args=(BOOL,))
+    iterable_int = TypeInfo.from_type(abc.Iterable, args=(INT,))
+    iterable_int_again = TypeInfo.from_type(abc.Iterable, args=(INT,))
+
+    assert lub(list_bool, iterable_int) == iterable_int_again
+
+
 def test_is_private_type():
     """Types in private modules without public re-export should be detected."""
     from righttyper.generalize import _is_private_type

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3951,6 +3951,51 @@ def test_custom_collection_typing(superclass):
     """)
 
 
+def test_nested_growing_inner_collapses_to_cumulative_shape():
+    """An outer list holds one inner list that grows between successive
+    calls. Container sampling reuses one ``ContainerSamples`` entry per
+    physical container id; the outer's per-element-counter therefore
+    accumulates a progressive chain of inner snapshots — ``list[int]``,
+    then ``list[int]`` plus ``list[int|str]``, then plus
+    ``list[int|str|float]`` — across the three calls. Each call's
+    outer snapshot reflects the cumulative state at that point and
+    becomes a distinct ``CallTrace``. ``generalize``'s homogeneous
+    path collapses the outer (all three are ``list``) but the inner
+    position mixes a bare ``TypeInfo`` with two ``UnionTypeInfo``s and
+    falls into the non-homogeneous fallback, which uses
+    ``merged_types`` without ``assume_covariant``; under ``list``
+    invariance the inner union members stay distinct.
+
+    The annotation should describe the single observed inner — one
+    physical container with a final cumulative element set — as
+
+        def f(x: list[list[float|int|str]]) -> None: ...
+
+    not as a refinement-fragment union of progressive outer
+    snapshots."""
+    Path("t.py").write_text(textwrap.dedent("""\
+        def f(x):
+            pass
+
+        inner = [1]
+        outer = [inner]
+        f(outer)
+        inner.append("s")
+        f(outer)
+        inner.append(1.5)
+        f(outer)
+    """))
+
+    # ``--no-call-sampling`` so every call is recorded — keeps the test
+    # deterministic regardless of Poisson sampling timing.
+    rt_run('--no-call-sampling', 't.py')
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+    assert get_function(code, 'f') == textwrap.dedent("""\
+        def f(x: list[list[float|int|str]]) -> None: ...
+    """)
+
+
 @pytest.mark.parametrize('init, expected', [
     ['[1,2,3]', 'list[int]'],
     ['{"a", "b"}', 'set[str]'],

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3293,50 +3293,6 @@ def test_kwargs_mixed_empty_and_non_empty_calls():
     """)
 
 
-def test_return_position_collapses_same_outer_inner_unions_via_lub():
-    """When a function's return spans multiple outer container types
-    *and* same-outer entries with subset-related inner-arg unions, the
-    same-outer entries should collapse into one via lub's covariant-arg-
-    merging rule (``assume_covariant=True``).
-
-    The wide-inner-union shapes typically arise from container sampling:
-    sequential samples of the same returned-list observe slightly
-    different element-type subsets. ``generalize`` keeps the outer
-    container types as separate union members when not all outer types
-    agree (here a ``tuple`` is mixed in alongside the ``list`` returns),
-    so the same-outer ``list[X] | list[X|Y]`` group never gets the
-    covariant-arg-merging treatment.
-
-    The fix routes the return position through ``merged_types`` with
-    ``assume_covariant=True`` in ``mk_annotation`` — the same path
-    ``variables`` already uses. Lub then collapses the inner-arg unions
-    on covariant or assume_covariant-true positions while leaving unrelated
-    outer types (``tuple`` here) intact.
-    """
-    Path("t.py").write_text(textwrap.dedent("""\
-        def make(kind):
-            if kind == 'tuple':
-                return ('a', 'b')
-            elif kind == 'narrow':
-                return [1, 2, 3]
-            else:
-                return [1, 'a', 2, 'b']
-
-        make('tuple')
-        make('narrow')
-        make('wide')
-        """
-    ))
-
-    rt_run('t.py')
-    output = Path("t.py").read_text()
-    code = cst.parse_module(output)
-    # After the fix: list[int] | list[int|str] collapses to list[int|str];
-    # tuple[str, str] stays as a separate union member.
-    assert get_function(code, 'make') == textwrap.dedent("""\
-        def make(kind: str) -> list[int|str]|tuple[str, str]: ...
-    """)
-
 
 def test_varargs_json():
     Path("t.py").write_text(textwrap.dedent("""\

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3293,6 +3293,51 @@ def test_kwargs_mixed_empty_and_non_empty_calls():
     """)
 
 
+def test_return_position_collapses_same_outer_inner_unions_via_lub():
+    """When a function's return spans multiple outer container types
+    *and* same-outer entries with subset-related inner-arg unions, the
+    same-outer entries should collapse into one via lub's covariant-arg-
+    merging rule (``assume_covariant=True``).
+
+    The wide-inner-union shapes typically arise from container sampling:
+    sequential samples of the same returned-list observe slightly
+    different element-type subsets. ``generalize`` keeps the outer
+    container types as separate union members when not all outer types
+    agree (here a ``tuple`` is mixed in alongside the ``list`` returns),
+    so the same-outer ``list[X] | list[X|Y]`` group never gets the
+    covariant-arg-merging treatment.
+
+    The fix routes the return position through ``merged_types`` with
+    ``assume_covariant=True`` in ``mk_annotation`` — the same path
+    ``variables`` already uses. Lub then collapses the inner-arg unions
+    on covariant or assume_covariant-true positions while leaving unrelated
+    outer types (``tuple`` here) intact.
+    """
+    Path("t.py").write_text(textwrap.dedent("""\
+        def make(kind):
+            if kind == 'tuple':
+                return ('a', 'b')
+            elif kind == 'narrow':
+                return [1, 2, 3]
+            else:
+                return [1, 'a', 2, 'b']
+
+        make('tuple')
+        make('narrow')
+        make('wide')
+        """
+    ))
+
+    rt_run('t.py')
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+    # After the fix: list[int] | list[int|str] collapses to list[int|str];
+    # tuple[str, str] stays as a separate union member.
+    assert get_function(code, 'make') == textwrap.dedent("""\
+        def make(kind: str) -> list[int|str]|tuple[str, str]: ...
+    """)
+
+
 def test_varargs_json():
     Path("t.py").write_text(textwrap.dedent("""\
         def foo(x, *rest):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3198,6 +3198,11 @@ def test_varargs():
 
 
 def test_varargs_empty():
+    """If a function is only ever observed with empty ``*args``, RT has
+    no element-type observations to emit — leave ``*args`` unannotated.
+    (Previously RT emitted ``*args: None``, which read as "the element
+    type is None" — meaningless, since ``None`` can't be an element of
+    a positional-extras tuple.)"""
     Path("t.py").write_text(textwrap.dedent("""\
         def foo(x, *args):
             pass
@@ -3210,7 +3215,57 @@ def test_varargs_empty():
     output = Path("t.py").read_text()
     code = cst.parse_module(output)
     assert get_function(code, 'foo') == textwrap.dedent("""\
-        def foo(x: bool, *args: None) -> None: ...
+        def foo(x: bool, *args) -> None: ...
+    """)
+
+
+def test_varargs_mixed_empty_and_non_empty_calls():
+    """Regression: when the same function is called with non-empty
+    ``*args`` at one site and empty ``*args`` at another, the emitted
+    annotation must be just the element-type union (here ``int``) — not
+    ``int | None``.
+
+    The bug: the recorder used ``TypeInfo.from_set(elem_types,
+    empty_is_none=True)`` to compute the per-call varargs element type,
+    so a call with zero extras contributed ``NoneTypeInfo`` to the union.
+    When merged with non-empty calls' real-type observations, the
+    emitted annotation came out as ``int | None``, with the ``None``
+    being a sampling artifact rather than a real caller-supplied type."""
+    Path("t.py").write_text(textwrap.dedent("""\
+        def foo(x, *args):
+            pass
+
+        foo(True, 1)
+        foo(True)
+        """
+    ))
+
+    rt_run('t.py')
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+    assert get_function(code, 'foo') == textwrap.dedent("""\
+        def foo(x: bool, *args: int) -> None: ...
+    """)
+
+
+def test_kwargs_mixed_empty_and_non_empty_calls():
+    """Same shape as test_varargs_mixed_empty_and_non_empty_calls but
+    for ``**kwargs``: a call with empty kwargs must not contribute
+    ``None`` to the kwargs value-type union."""
+    Path("t.py").write_text(textwrap.dedent("""\
+        def foo(x, **kwargs):
+            pass
+
+        foo(True, a=1)
+        foo(True)
+        """
+    ))
+
+    rt_run('t.py')
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+    assert get_function(code, 'foo') == textwrap.dedent("""\
+        def foo(x: bool, **kwargs: int) -> None: ...
     """)
 
 
@@ -3251,6 +3306,9 @@ def test_kwargs():
 
 
 def test_kwargs_empty():
+    """Analog of test_varargs_empty for ``**kwargs``: no kwargs ever
+    observed → leave the slot unannotated rather than emit the
+    meaningless ``**kwargs: None``."""
     Path("t.py").write_text(textwrap.dedent("""\
         def foo(x, **kwargs):
             pass
@@ -3263,7 +3321,7 @@ def test_kwargs_empty():
     output = Path("t.py").read_text()
     code = cst.parse_module(output)
     assert get_function(code, 'foo') == textwrap.dedent("""\
-        def foo(x: bool, **kwargs: None) -> None: ...
+        def foo(x: bool, **kwargs) -> None: ...
     """)
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -704,6 +704,30 @@ def test_default_in_private_method():
     """)
 
 
+def test_parameter_reassigned_to_different_type():
+    """A parameter rebound inside the body to a different type must be
+    annotated with the union of both types — otherwise the rebinding
+    statement itself fails to type-check (mypy: 'Incompatible types in
+    assignment')."""
+    t = textwrap.dedent("""\
+        def f(x):
+            x = str(x)
+            return x
+
+        f(42)
+        """)
+
+    Path("t.py").write_text(t)
+
+    rt_run('t.py')
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+
+    assert get_function(code, 'f') == textwrap.dedent("""\
+        def f(x: int|str) -> str: ...
+    """)
+
+
 @pytest.mark.skipif(importlib.util.find_spec('numpy') is None, reason='missing module')
 def test_default_is_numpy_array_more_than_one_element():
     t = textwrap.dedent("""\

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -55,9 +55,17 @@ def runmypy(tmp_cwd, request):
     if pv == "3.9":
         return
     python_version = ('--python-version', pv) if pv else ()
+    # Point mypy at the project's pyproject.toml so ``[tool.mypy]``
+    # config (e.g. ``ignore_missing_imports``, ``check_untyped_defs``)
+    # applies even though mypy runs from ``tmp_cwd``.  Without this,
+    # tests that import ``righttyper.*`` from the generated source
+    # produce spurious ``Cannot find implementation`` errors locally.
+    from pathlib import Path as _Path
+    _project_root = _Path(__file__).resolve().parent.parent
     from mypy import api
     stdout, stderr, exit_status = api.run([
         '--cache-dir', str(MYPY_CACHE_DIR), # speeds up mypy
+        '--config-file', str(_project_root / 'pyproject.toml'),
         *python_version,
         *(mypy_args.args if mypy_args else ()),
         '.'
@@ -3951,6 +3959,33 @@ def test_custom_collection_typing(superclass):
     """)
 
 
+def test_container_inner_union_reduces_via_numeric_tower():
+    """A list whose sampled element types form a numeric-tower set
+    (``int``, ``float``, plus maybe ``bool`` and unrelated types like
+    ``str``) should be annotated with the numeric tower reduced:
+    ``int`` is absorbed by ``float`` (PEP 3141), ``bool`` by ``int``.
+
+    The element-type set comes out of ``_get_container_args`` as the
+    per-counter Counter; building the wrapping TypeInfo via
+    ``TypeInfo.from_set`` only dedups, leaving ``int|float|str`` etc.
+    intact. Building via ``merged_types`` (default ``assume_covariant=
+    False``, sound) lets lub rule 4 apply the numeric-tower subsumption.
+    """
+    Path("t.py").write_text(textwrap.dedent("""\
+        def f(x):
+            pass
+
+        f([1, 1.5, "s", True, 2, 2.5, "t", False])
+    """))
+
+    rt_run('t.py')
+    output = Path("t.py").read_text()
+    code = cst.parse_module(output)
+    assert get_function(code, 'f') == textwrap.dedent("""\
+        def f(x: list[float|str]) -> None: ...
+    """)
+
+
 def test_nested_growing_inner_collapses_to_cumulative_shape():
     """An outer list holds one inner list that grows between successive
     calls. Container sampling reuses one ``ContainerSamples`` entry per
@@ -3991,8 +4026,10 @@ def test_nested_growing_inner_collapses_to_cumulative_shape():
     rt_run('--no-call-sampling', 't.py')
     output = Path("t.py").read_text()
     code = cst.parse_module(output)
+    # ``int`` absorbed by ``float`` via numeric tower (lub rule 4 applied
+    # by ``merged_types`` inside ``resolved_samples``).
     assert get_function(code, 'f') == textwrap.dedent("""\
-        def f(x: list[list[float|int|str]]) -> None: ...
+        def f(x: list[list[float|str]]) -> None: ...
     """)
 
 
@@ -7666,7 +7703,7 @@ def test_max_union_size():
     """Unions exceeding --max-union-size collapse to Any in container elements."""
     t = textwrap.dedent("""\
         def f():
-            return [1, 'a', 2.0, b'x']
+            return ['a', 2.0, b'x', frozenset()]
 
         f()
         """)
@@ -7676,7 +7713,9 @@ def test_max_union_size():
     output = Path("t.py").read_text()
     code = cst.parse_module(output)
 
-    # 4 distinct element types (int, str, float, bytes) > limit 3 → Any
+    # 4 distinct element types (str, float, bytes, frozenset) > limit 3 → Any.
+    # No numeric-tower reduction available, so the 4-type union survives
+    # ``merged_types`` and trips ``UnionSizeT``.
     assert get_function(code, 'f') == textwrap.dedent("""\
         def f() -> list[Any]: ...
     """)

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -4,7 +4,7 @@ from libcst.metadata import MetadataWrapper, PositionProvider
 import textwrap
 from righttyper.unified_transformer import UnifiedTransformer, types_in_annotation
 from righttyper.typeinfo import TypeInfo, NoneTypeInfo, AnyTypeInfo
-from righttyper.righttyper_types import CodeId, Filename, FunctionName, ArgumentName, VariableName
+from righttyper.righttyper_types import FuncLoc, Filename, FunctionName, ArgumentName, VariableName
 from righttyper.annotation import FuncAnnotation, ModuleVars
 from righttyper.type_id import get_type_name
 import typing
@@ -118,14 +118,13 @@ def get_function_all(m: cst.Module, funcname: str, body=True) -> list[str]:
     return strings
 
 
-def get_code_id(filename: str, m: cst.Module, funcname: str) -> CodeId:
-    """Returns a CodeId for the given function, if found in 'm'"""
+def get_func_loc(filename: str, m: cst.Module, funcname: str) -> FuncLoc:
+    """Returns a FuncLoc for the given function, if found in 'm'"""
     if (f := find_function(m, funcname)):
-        return CodeId(
+        return FuncLoc(
             Filename(filename),
             FunctionName(funcname),
             f[1],
-            0
         )
 
     raise RuntimeError(f"Unable to find {funcname}")
@@ -163,8 +162,8 @@ def test_transform_function():
             return z/2
     """))
 
-    foo = get_code_id('foo.py', code, 'foo')
-    baz = get_code_id('foo.py', code, 'baz')
+    foo = get_func_loc('foo.py', code, 'foo')
+    baz = get_func_loc('foo.py', code, 'baz')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -237,9 +236,9 @@ def test_transform_method():
                 return z/2
     """))
 
-    foo = get_code_id('foo.py', code, 'C.foo')
-    bar = get_code_id('foo.py', code, 'C.bar')
-    baz = get_code_id('foo.py', code, 'C.baz')
+    foo = get_func_loc('foo.py', code, 'C.foo')
+    bar = get_func_loc('foo.py', code, 'C.bar')
+    baz = get_func_loc('foo.py', code, 'C.baz')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -317,8 +316,8 @@ def test_transform_local_function():
             return bar(x+y)
     """))
 
-    foo = get_code_id('foo.py', code, 'foo')
-    bar = get_code_id('foo.py', code, 'foo.<locals>.bar')
+    foo = get_func_loc('foo.py', code, 'foo')
+    bar = get_func_loc('foo.py', code, 'foo.<locals>.bar')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -364,8 +363,8 @@ def test_override_annotations():
                 return x/2
     """))
 
-    foo = get_code_id('foo.py', code, 'foo')
-    bar = get_code_id('foo.py', code, 'C.bar')
+    foo = get_func_loc('foo.py', code, 'foo')
+    bar = get_func_loc('foo.py', code, 'C.bar')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -407,7 +406,7 @@ def test_transform_adds_typing_import_for_typing_names():
         def foo(x): ...
     """))
 
-    foo = get_code_id('foo.py', code, 'foo')
+    foo = get_func_loc('foo.py', code, 'foo')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -445,7 +444,7 @@ def test_transform_unknown_type_as_string():
             return x/2
     """))
 
-    foo = get_code_id('foo.py', code, 'foo')
+    foo = get_func_loc('foo.py', code, 'foo')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -488,7 +487,7 @@ def test_transform_unknown_type_with_import_annotations():
             return x/2
     """))
 
-    foo = get_code_id('foo.py', code, 'foo')
+    foo = get_func_loc('foo.py', code, 'foo')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -557,7 +556,7 @@ def test_transform_deletes_type_hint_comments_in_header():
             pass
     """))
 
-    foo = get_code_id('foo.py', code, 'foo')
+    foo = get_func_loc('foo.py', code, 'foo')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -606,7 +605,7 @@ def test_transform_deletes_type_hint_comments_in_parameters():
             pass
     """))
 
-    foo = get_code_id('foo.py', code, 'foo')
+    foo = get_func_loc('foo.py', code, 'foo')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -661,7 +660,7 @@ def test_transform_deletes_type_hint_comments_for_retval():
             pass
     """))
 
-    foo = get_code_id('foo.py', code, 'foo')
+    foo = get_func_loc('foo.py', code, 'foo')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -714,9 +713,9 @@ def test_transform_locally_defined_types():
             return F((x+y)/2)
     """))
 
-    foo = get_code_id('foo.py', code, 'foo')
-    f_foo = get_code_id('foo.py', code, 'F.foo')
-    bar = get_code_id('foo.py', code, 'bar')
+    foo = get_func_loc('foo.py', code, 'foo')
+    f_foo = get_func_loc('foo.py', code, 'F.foo')
+    bar = get_func_loc('foo.py', code, 'bar')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -780,7 +779,7 @@ def test_uses_imported_aliases():
         import r    # imported after 'def foo', so can't be used in annotation
     """))
 
-    foo = get_code_id('foo.py', code, 'foo')
+    foo = get_func_loc('foo.py', code, 'foo')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -823,7 +822,7 @@ def test_uses_imported_domains():
         def foo(x, y): ...
     """))
 
-    foo = get_code_id('foo.py', code, 'foo')
+    foo = get_func_loc('foo.py', code, 'foo')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -861,7 +860,7 @@ def test_imports_subdomain_if_needed():
         def foo(x): ...
     """))
 
-    foo = get_code_id('foo.py', code, 'foo')
+    foo = get_func_loc('foo.py', code, 'foo')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -904,7 +903,7 @@ def test_existing_typing_imports():
 
     import ast
 
-    foo = get_code_id('foo.py', code, 'foo')
+    foo = get_func_loc('foo.py', code, 'foo')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -956,7 +955,7 @@ def test_inserts_imports_after_docstring_and_space():
 
     import ast
 
-    foo = get_code_id('foo.py', code, 'foo')
+    foo = get_func_loc('foo.py', code, 'foo')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -1009,7 +1008,7 @@ def test_relative_import():
         def foo(x, y, z): ...
     """))
 
-    foo = get_code_id('foo.py', code, 'foo')
+    foo = get_func_loc('foo.py', code, 'foo')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -1054,10 +1053,10 @@ def test_uses_local_imports():
         def f(a, b): ...
     """))
 
-    foobar = get_code_id('foo.py', code, 'foo.<locals>.bar')
-    Cfoo = get_code_id('foo.py', code, 'C.foo')
-    Dfoo = get_code_id('foo.py', code, 'C.D.foo')
-    f = get_code_id('foo.py', code, 'f')
+    foobar = get_func_loc('foo.py', code, 'foo.<locals>.bar')
+    Cfoo = get_func_loc('foo.py', code, 'C.foo')
+    Dfoo = get_func_loc('foo.py', code, 'C.D.foo')
+    f = get_func_loc('foo.py', code, 'f')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -1128,8 +1127,8 @@ def test_nonglobal_imported_modules_are_ignored():
             pass
     """))
 
-    foo = get_code_id('foo.py', code, 'foo')
-    bar = get_code_id('foo.py', code, 'bar')
+    foo = get_func_loc('foo.py', code, 'foo')
+    bar = get_func_loc('foo.py', code, 'bar')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -1188,8 +1187,8 @@ def test_nonglobal_assignments_are_ignored():
             pass
     """))
 
-    foo = get_code_id('foo.py', code, 'foo')
-    bar = get_code_id('foo.py', code, 'bar')
+    foo = get_func_loc('foo.py', code, 'foo')
+    bar = get_func_loc('foo.py', code, 'bar')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -1239,7 +1238,7 @@ def test_if_type_checking_insertion():
         def foo(x): ...
     """))
 
-    foo = get_code_id('foo.py', code, 'foo')
+    foo = get_func_loc('foo.py', code, 'foo')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -1274,7 +1273,7 @@ def test_import_conflicts_with_import():
         def foo(x, y): ...
     """))
 
-    foo = get_code_id('foo.py', code, 'foo')
+    foo = get_func_loc('foo.py', code, 'foo')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -1324,7 +1323,7 @@ def test_import_conflicts_with_definitions():
         def foo(x, y): ...
     """))
 
-    foo = get_code_id('foo.py', code, 'foo')
+    foo = get_func_loc('foo.py', code, 'foo')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -1375,7 +1374,7 @@ def test_import_conflicts_with_assignments():
         c: int = 10
     """))
 
-    foo = get_code_id('foo.py', code, 'foo')
+    foo = get_func_loc('foo.py', code, 'foo')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -1425,7 +1424,7 @@ def test_import_conflicts_with_with():
         def foo(x): ...
     """))
 
-    foo = get_code_id('foo.py', code, 'foo')
+    foo = get_func_loc('foo.py', code, 'foo')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -1473,7 +1472,7 @@ def test_builtin_name_conflicts():
             pass
     """))
 
-    f = get_code_id('foo.py', code, 'C.f')
+    f = get_func_loc('foo.py', code, 'C.f')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -1516,7 +1515,7 @@ def test_arg_name_conflicts():
             pass
     """))
 
-    f = get_code_id('foo.py', code, 'C.f')
+    f = get_func_loc('foo.py', code, 'C.f')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -1551,7 +1550,7 @@ def test_class_names_dont_affect_body_of_methods():
                 pass
     """))
 
-    g = get_code_id('foo.py', code, 'C.f.<locals>.g')
+    g = get_func_loc('foo.py', code, 'C.f.<locals>.g')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -1601,10 +1600,10 @@ def test_inner_function():
                         pass
     """))
 
-    g = get_code_id('foo.py', code, 'C.f.<locals>.g')
-    h = get_code_id('foo.py', code, 'C.f.<locals>.g.<locals>.h')
-    i = get_code_id('foo.py', code, 'C.f.<locals>.D.i')
-    j = get_code_id('foo.py', code, 'C.f.<locals>.D.i.<locals>.j')
+    g = get_func_loc('foo.py', code, 'C.f.<locals>.g')
+    h = get_func_loc('foo.py', code, 'C.f.<locals>.g.<locals>.h')
+    i = get_func_loc('foo.py', code, 'C.f.<locals>.D.i')
+    j = get_func_loc('foo.py', code, 'C.f.<locals>.D.i.<locals>.j')
     tuple_int_float = TypeInfo.from_type(tuple, args=(
         TypeInfo.from_type(int, module=''),
         TypeInfo.from_type(float, module='')
@@ -1660,7 +1659,7 @@ def test_builtin_name_conflicts_even_module_name():
             pass
     """))
 
-    f = get_code_id('foo.py', code, 'C.f')
+    f = get_func_loc('foo.py', code, 'C.f')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -1724,7 +1723,7 @@ def test_generics_inline_simple():
     """))
 
     T1 = make_typevar([str, int], 1)
-    f = get_code_id('foo.py', code, 'add')
+    f = get_func_loc('foo.py', code, 'add')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -1759,7 +1758,7 @@ def test_generics_arg_already_annotated(override):
     """))
 
     T1 = make_typevar([str, int], 1)
-    f = get_code_id('foo.py', code, 'add')
+    f = get_func_loc('foo.py', code, 'add')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -1800,7 +1799,7 @@ def test_generics_ret_already_annotated(override):
     """))
 
     T1 = make_typevar([str, int], 1)
-    f = get_code_id('foo.py', code, 'add')
+    f = get_func_loc('foo.py', code, 'add')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -1841,7 +1840,7 @@ def test_generics_existing_generics(override):
     """))
 
     T1 = make_typevar([str, int], 1)
-    f = get_code_id('foo.py', code, 'add')
+    f = get_func_loc('foo.py', code, 'add')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -1879,7 +1878,7 @@ def test_generics_existing_unused_generics():
             return a + b
     """))
 
-    f = get_code_id('foo.py', code, 'add')
+    f = get_func_loc('foo.py', code, 'add')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -1913,7 +1912,7 @@ def test_generics_existing_generics_nested(override):
     """))
 
     T1 = make_typevar([str, int], 1)
-    f = get_code_id('foo.py', code, 'add')
+    f = get_func_loc('foo.py', code, 'add')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -1954,7 +1953,7 @@ def test_generics_existing_generics_overlaps_name():
 
     T1 = make_typevar([str, int], 1)
     T2 = make_typevar([str, bool], 2)
-    f = get_code_id('foo.py', code, 'add')
+    f = get_func_loc('foo.py', code, 'add')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -1988,7 +1987,7 @@ def test_generics_inline_multiple():
 
     T1 = make_typevar([int, str], 1)
     T2 = make_typevar([int, str], 2)
-    f = get_code_id('foo.py', code, 'foo')
+    f = get_func_loc('foo.py', code, 'foo')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -2024,7 +2023,7 @@ def test_generics_inline_nested():
     """))
 
     T1 = make_typevar([int, str], 1)
-    f = get_code_id('foo.py', code, 'add')
+    f = get_func_loc('foo.py', code, 'add')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -2059,7 +2058,7 @@ def test_generics_existing_identical(override):
     """))
 
     T1 = make_typevar([int, str], 1)
-    f = get_code_id('foo.py', code, 'add')
+    f = get_func_loc('foo.py', code, 'add')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -2093,7 +2092,7 @@ def test_generics_defined_simple():
     """))
 
     T1 = make_typevar([int, str], 1)
-    f = get_code_id('foo.py', code, 'add')
+    f = get_func_loc('foo.py', code, 'add')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -2140,7 +2139,7 @@ def test_overload_preserve():
             elif isinstance(bar, bool):
                 return not bar
     """))
-    foo = get_code_id('foo.py', input_code, 'foo')
+    foo = get_func_loc('foo.py', input_code, 'foo')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -2182,7 +2181,7 @@ def test_overload_remove():
     """))
     
     
-    foo = get_code_id('foo.py', code, 'foo')
+    foo = get_func_loc('foo.py', code, 'foo')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -2230,7 +2229,7 @@ def test_overload_aliased():
             elif isinstance(bar, str):
                 return 2
     """))
-    foo = get_code_id('foo.py', code, 'foo')
+    foo = get_func_loc('foo.py', code, 'foo')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -2265,7 +2264,7 @@ def test_dont_annotate_with_any():
         def foo(bar: int) -> float:
             ...
     """))
-    foo = get_code_id('foo.py', code, 'foo')
+    foo = get_func_loc('foo.py', code, 'foo')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -2301,7 +2300,7 @@ def test_local_aliases_known():
         def f(x):
             ...
     """))
-    f = get_code_id('foo.py', code, 'f')
+    f = get_func_loc('foo.py', code, 'f')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -2337,7 +2336,7 @@ def test_local_aliases_known_multiple():
         def f(x):
             ...
     """))
-    f = get_code_id('foo.py', code, 'f')
+    f = get_func_loc('foo.py', code, 'f')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -2375,7 +2374,7 @@ def test_local_aliases_known_annotated():
         def f(x):
             ...
     """))
-    f = get_code_id('foo.py', code, 'f')
+    f = get_func_loc('foo.py', code, 'f')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -2412,7 +2411,7 @@ def test_local_aliases_known_namedexpr():
         def f(x):
             ...
     """))
-    f = get_code_id('foo.py', code, 'f')
+    f = get_func_loc('foo.py', code, 'f')
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -2440,7 +2439,7 @@ def test_local_aliases_known_namedexpr():
 
 def mk_var_transformer(filename, code, *, override_annotations=True, only_update_annotations=False):
     try:
-        C_init = get_code_id(filename, code, 'C.__init__')
+        C_init = get_func_loc(filename, code, 'C.__init__')
     except:
         C_init = None
 
@@ -2793,7 +2792,7 @@ def test_attribute_of_subscript():
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
-                get_code_id('foo.py', code, 'C.__init__'): FuncAnnotation(
+                get_func_loc('foo.py', code, 'C.__init__'): FuncAnnotation(
                     {},
                     TypeInfo("", "None"),
                     varargs=None, kwargs=None,
@@ -2862,7 +2861,7 @@ def test_type_keyword_is_known():
     t = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
-                get_code_id('foo.py', code, 'foo'): FuncAnnotation(
+                get_func_loc('foo.py', code, 'foo'): FuncAnnotation(
                     {ArgumentName('x'): TypeInfo("foo", "MyStr")},
                     TypeInfo("", "None"),
                     varargs=None, kwargs=None,
@@ -2925,7 +2924,7 @@ def test_type_checking_import_quoted_without_future_annotations():
             return x
     """))
 
-    foo = get_code_id('foo.py', code, 'foo')
+    foo = get_func_loc('foo.py', code, 'foo')
     tr = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -2966,7 +2965,7 @@ def test_attribute_type_checking_guard():
             return x
     """))
 
-    foo = get_code_id('foo.py', code, 'foo')
+    foo = get_func_loc('foo.py', code, 'foo')
     tr = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {
@@ -3005,7 +3004,7 @@ def test_attribute_type_checking_guard_merges_imports():
             return x
     """))
 
-    foo = get_code_id('foo.py', code, 'foo')
+    foo = get_func_loc('foo.py', code, 'foo')
     tr = UnifiedTransformer(
             filename='foo.py',
             type_annotations = {

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1436,6 +1436,47 @@ def test_merge_observations_aborts_on_line_shifted_twin():
     assert "57" in msg
 
 
+def test_merge_observations_accepts_property_getter_setter_pair():
+    """A property getter and setter share ``func_name`` but live at
+    distinct lines with different parameter shapes (``(self,)`` vs
+    ``(self, value)``). The line-shift detector must not flag this as
+    a source-revision conflict.
+
+    Concretely: tqdm's ``Bar.colour`` has a getter at one line and a
+    setter at another. Pytest may exercise the getter while a separate
+    exercise script exercises the setter — both .rt files are valid and
+    must merge cleanly.
+    """
+    from righttyper.observations import (
+        Observations, FuncInfo, ArgInfo,
+    )
+    from righttyper.righttyper_types import (
+        ArgumentName, CodeId, Filename, FunctionName,
+    )
+
+    getter_id = CodeId(Filename("m.py"), FunctionName("Cls.prop"), 100, 0)
+    setter_id = CodeId(Filename("m.py"), FunctionName("Cls.prop"), 104, 0)
+
+    obs1 = Observations()
+    obs1.func_info[getter_id] = FuncInfo(
+        code_id=getter_id,
+        args=(ArgInfo(ArgumentName("self"), None),),
+        varargs=None, kwargs=None,
+    )
+    obs2 = Observations()
+    obs2.func_info[setter_id] = FuncInfo(
+        code_id=setter_id,
+        args=(ArgInfo(ArgumentName("self"), None),
+              ArgInfo(ArgumentName("value"), None)),
+        varargs=None, kwargs=None,
+    )
+
+    # Must not raise — different arities disambiguate them.
+    obs1.merge_observations(obs2)
+    assert getter_id in obs1.func_info
+    assert setter_id in obs1.func_info
+
+
 def test_sample_until_stable_lifetime_budget(monkeypatch):
     """container_max_samples is a per-container lifetime budget, not a
     per-call cap.  Once the cumulative samples for a container reach the

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -366,9 +366,6 @@ def test_typeinfo_from_set():
     t = TypeInfo.from_set(set())
     assert str(t) == "typing.Never"
 
-    t = TypeInfo.from_set(set(), empty_is_none=True)
-    assert t is NoneTypeInfo
-
     t = TypeInfo.from_set({TypeInfo.from_type(int)})
 
     assert str(t) == 'int'
@@ -377,6 +374,46 @@ def test_typeinfo_from_set():
 
     assert t is not TypeInfo.from_type(int) # should be new object
     assert t.type_obj is int
+
+
+def test_typeinfo_from_set_on_empty():
+    """``from_set`` lets the caller name what to return when the input
+    set is empty. Replaces the older ``empty_is_none=True`` flag, which
+    conflated three distinct semantics into one boolean:
+
+    - ``NoneTypeInfo`` — for slots where empty observations genuinely
+      mean "the type is None" (e.g., a generator that never yielded).
+    - ``Never`` — for slots where empty observations contribute nothing
+      to a union (e.g., a varargs slot at a call with no extras).
+    - ``None`` (Python sentinel) — for slots where empty means "no
+      information was recorded" (e.g., the merged-arg-default rebuild
+      whose absence of defaults must not invent a None default).
+
+    A single ``on_empty=<value>`` parameter lets each caller pick the
+    right sentinel.
+    """
+    from righttyper.typeinfo import NoneTypeInfo
+
+    # Default behavior: empty → Never (unchanged from before).
+    t = TypeInfo.from_set(set())
+    assert str(t) == "typing.Never"
+
+    # Generator-yields-nothing case: empty → NoneTypeInfo.
+    t = TypeInfo.from_set(set(), on_empty=NoneTypeInfo)
+    assert t is NoneTypeInfo
+
+    # No-information case: empty → Python None (sentinel).
+    t = TypeInfo.from_set(set(), on_empty=None)
+    assert t is None
+
+    # Caller-supplied sentinel: anything else they want.
+    sentinel = TypeInfo.from_type(int)
+    t = TypeInfo.from_set(set(), on_empty=sentinel)
+    assert t is sentinel
+
+    # Non-empty input: unchanged (on_empty ignored).
+    t = TypeInfo.from_set({TypeInfo.from_type(int)}, on_empty=None)
+    assert str(t) == 'int'
 
     t = TypeInfo.from_set({
             TypeInfo.from_type(int),
@@ -1385,6 +1422,70 @@ def test_merge_observations_unions_overrides_lists():
     }
     # Each parent should appear exactly once.
     assert len(merged) == 3
+
+
+def test_merge_observations_preserves_no_default_for_args_lacking_defaults():
+    """Regression: ``merge_observations`` was converting a no-default arg
+    (``arg.default = Python None``) into a None-typed default
+    (``arg.default = NoneTypeInfo``) when the rebuild path triggered,
+    because the rebuild used ``TypeInfo.from_set({}, empty_is_none=True)``
+    which returns ``NoneTypeInfo`` for an empty set. The bogus
+    ``NoneTypeInfo`` default then propagated into the emitted annotation
+    as a spurious ``| None`` union member.
+
+    For an arg that has no recorded default in *either* observation set,
+    the merged default must remain Python ``None`` (the "no default
+    information" sentinel) — the rebuild must not invent a None default
+    from the absence of one.
+
+    Concretely modelled on ``tqdm_asyncio.as_completed`` where
+    ``cls``/``fs``/``tqdm_kwargs`` have no defaults and ``loop``/
+    ``timeout``/``total`` have ``=None``: the disagreement on the latter
+    forces ``args1 != args2``, triggers the rebuild, and the bug then
+    invented ``NoneTypeInfo`` defaults for the former.
+    """
+    from righttyper.observations import Observations, FuncInfo, ArgInfo
+    from righttyper.typeinfo import NoneTypeInfo
+    from righttyper.righttyper_types import (
+        ArgumentName, CodeId, Filename, FunctionName,
+    )
+
+    fid = CodeId(Filename("m.py"), FunctionName("f"), 1, 0)
+    # obs1: ``f(fs, loop)`` — neither arg has default information
+    # (pytest-like observation where defaults weren't captured).
+    args1 = (
+        ArgInfo(ArgumentName("fs"), None),
+        ArgInfo(ArgumentName("loop"), None),
+    )
+    # obs2: ``f(fs, loop=None)`` — same fs (no default), but loop has
+    # a ``=None`` default (NoneTypeInfo) recorded.
+    args2 = (
+        ArgInfo(ArgumentName("fs"), None),
+        ArgInfo(ArgumentName("loop"), NoneTypeInfo),
+    )
+
+    obs1 = Observations()
+    obs1.func_info[fid] = FuncInfo(
+        code_id=fid, args=args1, varargs=None, kwargs=None,
+    )
+    obs2 = Observations()
+    obs2.func_info[fid] = FuncInfo(
+        code_id=fid, args=args2, varargs=None, kwargs=None,
+    )
+
+    obs1.merge_observations(obs2)
+    merged_fs = obs1.func_info[fid].args[0]
+    assert merged_fs.arg_name == "fs"
+    assert merged_fs.default is None, (
+        f"fs had no recorded default in either observation; merge must "
+        f"preserve that as Python None (the no-default sentinel). Got "
+        f"{merged_fs.default!r}."
+    )
+
+    # loop should still report NoneTypeInfo (its ``=None`` default).
+    merged_loop = obs1.func_info[fid].args[1]
+    assert merged_loop.arg_name == "loop"
+    assert merged_loop.default is NoneTypeInfo
 
 
 def test_merge_observations_aborts_on_line_shifted_twin():

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1703,6 +1703,49 @@ def test_merge_observations_aborts_on_named_closure_drift():
     assert "65" in msg
 
 
+def test_merge_observations_accepts_genexprs_with_identical_bytecode():
+    """Two ``<genexpr>`` callables nested in the same enclosing function
+    frequently share *body* bytecode — Python compiles a genexp
+    ``(expr for var in iterable)`` so the iterable is passed as the
+    parameter ``.0`` rather than referenced from the body, leaving only
+    the per-element computation in the body.  Two physically distinct
+    genexps with the same per-element shape therefore produce identical
+    ``bytecode_hash``.
+
+    Regression: black's ``get_features_used`` contains two ``any(child.type ==
+    syms.star_expr for child in <iterable>)`` calls, lines 1228 and 1263.
+    The drift check raised on them and discarded all of black's recorded
+    observations.  Synthetic functions must be exempt from drift detection.
+    """
+    from righttyper.observations import (
+        Observations, FuncInfo, ArgInfo,
+    )
+    from righttyper.righttyper_types import (
+        ArgumentName, CodeId, Filename, FunctionName,
+    )
+
+    genexp_name = FunctionName("get_features_used.<locals>.<genexpr>")
+    # Identical bytecode_hash at different lines — synthetic case.
+    fid_a = CodeId(Filename("black.py"), genexp_name, 1228, 0xABCD)
+    fid_b = CodeId(Filename("black.py"), genexp_name, 1263, 0xABCD)
+    args = (ArgInfo(ArgumentName(".0"), None),)
+
+    obs1 = Observations()
+    obs1.func_info[fid_a] = FuncInfo(
+        code_id=fid_a, args=args, varargs=None, kwargs=None,
+    )
+    obs2 = Observations()
+    obs2.func_info[fid_b] = FuncInfo(
+        code_id=fid_b, args=args, varargs=None, kwargs=None,
+    )
+
+    # Must not raise — synthetics with identical bytecode at different
+    # lines are legitimate distinct genexp sites, not drift.
+    obs1.merge_observations(obs2)
+    assert fid_a in obs1.func_info
+    assert fid_b in obs1.func_info
+
+
 def test_sample_until_stable_lifetime_budget(monkeypatch):
     """container_max_samples is a per-container lifetime budget, not a
     per-call cap.  Once the cumulative samples for a container reach the

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1387,6 +1387,55 @@ def test_merge_observations_unions_overrides_lists():
     assert len(merged) == 3
 
 
+def test_merge_observations_aborts_on_line_shifted_twin():
+    """Two .rt files recorded against different source revisions of the same
+    function produce FuncInfo entries with identical (file_name, func_name)
+    but different ``first_code_line``. The dict-key-based merge would silently
+    keep both entries as orphans, with the downstream emitter selecting one
+    and discarding the other's traces. Detect this and raise a loud error
+    pointing at the offending function.
+
+    Regression: a deployment-study session ran ``process --output-files``
+    against an editable tqdm install between two ``--only-collect`` runs.
+    The annotation rewrite shifted line numbers, so the second ``.rt``'s
+    CodeIds drifted from the first's. The merge silently dropped the
+    second .rt's wider observations and emitted the narrower annotation.
+    """
+    from righttyper.observations import (
+        Observations, FuncInfo, ArgInfo,
+    )
+    from righttyper.righttyper_types import (
+        ArgumentName, CodeId, Filename, FunctionName,
+    )
+
+    args = (
+        ArgInfo(ArgumentName("self"), None),
+        ArgInfo(ArgumentName("x"), None),
+    )
+    fid_pre = CodeId(Filename("m.py"), FunctionName("Cls.method"), 61, 0)
+    fid_post = CodeId(Filename("m.py"), FunctionName("Cls.method"), 57, 0)
+
+    obs1 = Observations()
+    obs1.func_info[fid_pre] = FuncInfo(
+        code_id=fid_pre, args=args, varargs=None, kwargs=None,
+    )
+    obs2 = Observations()
+    obs2.func_info[fid_post] = FuncInfo(
+        code_id=fid_post, args=args, varargs=None, kwargs=None,
+    )
+
+    import pytest
+    with pytest.raises(ValueError) as exc_info:
+        obs1.merge_observations(obs2)
+
+    msg = str(exc_info.value)
+    # Error must be actionable: name the function and both line numbers.
+    assert "Cls.method" in msg
+    assert "m.py" in msg
+    assert "61" in msg
+    assert "57" in msg
+
+
 def test_sample_until_stable_lifetime_budget(monkeypatch):
     """container_max_samples is a per-container lifetime budget, not a
     per-call cap.  Once the cumulative samples for a container reach the

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -819,50 +819,50 @@ def test_from_set_with_any():
     assert t.args == ()
 
 
-def test_merged_types_for_variable_simple():
-    """Test that for_variable=True merges similar generics."""
-    # Without for_variable, should keep separate
+def test_merged_types_assume_covariant_simple():
+    """Test that assume_covariant=True merges similar generics."""
+    # Without assume_covariant, should keep separate
     assert "list[bool]|list[int]" == str(merged_types({
             TypeInfo.from_type(list, args=(TypeInfo.from_type(int),)),
             TypeInfo.from_type(list, args=(TypeInfo.from_type(bool),))
         }
     ))
 
-    # With for_variable=True, should merge type arguments.
+    # With assume_covariant=True, should merge type arguments.
     # bool is a subtype of int, so lub further reduces to list[int]
     assert "list[int]" == str(merged_types({
             TypeInfo.from_type(list, args=(TypeInfo.from_type(int),)),
             TypeInfo.from_type(list, args=(TypeInfo.from_type(bool),))
         },
-        for_variable=True
+        assume_covariant=True
     ))
 
 
-def test_merged_types_for_variable_with_none():
-    """Test for_variable with None in the union."""
+def test_merged_types_assume_covariant_with_none():
+    """Test assume_covariant with None in the union."""
     # list[int] | list[bool] | None -> list[int] | None (bool simplified to int)
     assert "list[int]|None" == str(merged_types({
             TypeInfo.from_type(list, args=(TypeInfo.from_type(int),)),
             TypeInfo.from_type(list, args=(TypeInfo.from_type(bool),)),
             TypeInfo.from_type(type(None))
         },
-        for_variable=True
+        assume_covariant=True
     ))
 
 
-def test_merged_types_for_variable_dict():
-    """Test for_variable with dict types."""
+def test_merged_types_assume_covariant_dict():
+    """Test assume_covariant with dict types."""
     # dict[str, int] | dict[str, float] -> dict[str, float] (int simplified to float via numeric tower)
     assert "dict[str, float]" == str(merged_types({
             TypeInfo.from_type(dict, args=(TypeInfo.from_type(str), TypeInfo.from_type(int))),
             TypeInfo.from_type(dict, args=(TypeInfo.from_type(str), TypeInfo.from_type(float)))
         },
-        for_variable=True
+        assume_covariant=True
     ))
 
 
-def test_merged_types_for_variable_nested():
-    """Test for_variable with nested generics."""
+def test_merged_types_assume_covariant_nested():
+    """Test assume_covariant with nested generics."""
     # list[tuple[int, float]] | list[tuple[bool, float]] -> list[tuple[int, float]] (bool simplified to int)
     assert "list[tuple[int, float]]" == str(merged_types({
             TypeInfo.from_type(list, args=(
@@ -878,28 +878,28 @@ def test_merged_types_for_variable_nested():
                 )),
             )),
         },
-        for_variable=True
+        assume_covariant=True
     ))
 
 
-def test_merged_types_for_variable_different_containers():
+def test_merged_types_assume_covariant_different_containers():
     """Test that different container types are not merged."""
-    # list[int] | set[int] should stay separate even with for_variable=True
+    # list[int] | set[int] should stay separate even with assume_covariant=True
     assert "list[int]|set[int]" == str(merged_types({
             TypeInfo.from_type(list, args=(TypeInfo.from_type(int),)),
             TypeInfo.from_type(set, args=(TypeInfo.from_type(int),))
         },
-        for_variable=True
+        assume_covariant=True
     ))
 
 
-def test_merged_types_for_variable_different_arity():
+def test_merged_types_assume_covariant_different_arity():
     """Different-arity tuples merge to varlen (wider but valid, see test_generalize.py)."""
     result = str(merged_types({
             TypeInfo.from_type(tuple, args=(TypeInfo.from_type(int),)),
             TypeInfo.from_type(tuple, args=(TypeInfo.from_type(int), TypeInfo.from_type(str)))
         },
-        for_variable=True
+        assume_covariant=True
     ))
     assert result == "tuple[int|str, ...]"
 

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1436,6 +1436,44 @@ def test_merge_observations_aborts_on_line_shifted_twin():
     assert "57" in msg
 
 
+def test_merge_observations_accepts_nested_lambda_at_different_lines():
+    """Two ``<lambda>`` expressions nested in the same enclosing function
+    (qualname ``Outer.<locals>.<lambda>``) can legitimately appear at
+    different lines with the same parameter shape — they're distinct
+    callable values, not a line-shifted version of one another.
+    The synthetic check must look at the trailing qualname segment, not
+    only the first character.
+
+    Regression: tqdm's ``_decr_instances`` has two
+    ``Outer.<locals>.<lambda>`` callables at different lines, both with
+    parameter ``(inst,)``. The first-pass detection raised on them."""
+    from righttyper.observations import (
+        Observations, FuncInfo, ArgInfo,
+    )
+    from righttyper.righttyper_types import (
+        ArgumentName, CodeId, Filename, FunctionName,
+    )
+
+    nested_name = FunctionName("tqdm._decr_instances.<locals>.<lambda>")
+    fid_a = CodeId(Filename("m.py"), nested_name, 708, 0)
+    fid_b = CodeId(Filename("m.py"), nested_name, 712, 0)
+    args = (ArgInfo(ArgumentName("inst"), None),)
+
+    obs1 = Observations()
+    obs1.func_info[fid_a] = FuncInfo(
+        code_id=fid_a, args=args, varargs=None, kwargs=None,
+    )
+    obs2 = Observations()
+    obs2.func_info[fid_b] = FuncInfo(
+        code_id=fid_b, args=args, varargs=None, kwargs=None,
+    )
+
+    # Must not raise — distinct nested lambdas are legitimate.
+    obs1.merge_observations(obs2)
+    assert fid_a in obs1.func_info
+    assert fid_b in obs1.func_info
+
+
 def test_merge_observations_accepts_property_getter_setter_pair():
     """A property getter and setter share ``func_name`` but live at
     distinct lines with different parameter shapes (``(self,)`` vs

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -973,14 +973,15 @@ def test_small_container_is_fully_scanned():
 
     _cache._cache.clear()
 
-    # Small list
-    data = [1, 'a', 2.0]
+    # Small list — uses non-numeric-tower types so lub rule 4 doesn't
+    # absorb any element type (e.g., ``int`` into ``float``).
+    data = ['a', b'c', 2.0]
     assert len(data) <= run_options.container_small_threshold  # Test precondition
     t = get_value_type(data)
 
     # Should see all types
-    assert 'int' in t
     assert 'str' in t
+    assert 'bytes' in t
     assert 'float' in t
 
 

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1514,8 +1514,10 @@ def test_merge_observations_aborts_on_line_shifted_twin():
         ArgInfo(ArgumentName("self"), None),
         ArgInfo(ArgumentName("x"), None),
     )
-    fid_pre = CodeId(Filename("m.py"), FunctionName("Cls.method"), 61, 0)
-    fid_post = CodeId(Filename("m.py"), FunctionName("Cls.method"), 57, 0)
+    # Identical bytecode_hash → same content; different first_code_line
+    # → genuine source-revision drift.
+    fid_pre = CodeId(Filename("m.py"), FunctionName("Cls.method"), 61, 0xCAFE)
+    fid_post = CodeId(Filename("m.py"), FunctionName("Cls.method"), 57, 0xCAFE)
 
     obs1 = Observations()
     obs1.func_info[fid_pre] = FuncInfo(
@@ -1557,8 +1559,9 @@ def test_merge_observations_accepts_nested_lambda_at_different_lines():
     )
 
     nested_name = FunctionName("tqdm._decr_instances.<locals>.<lambda>")
-    fid_a = CodeId(Filename("m.py"), nested_name, 708, 0)
-    fid_b = CodeId(Filename("m.py"), nested_name, 712, 0)
+    # Distinct callable values ⇒ different bytecode_hash.
+    fid_a = CodeId(Filename("m.py"), nested_name, 708, 0xAAAA)
+    fid_b = CodeId(Filename("m.py"), nested_name, 712, 0xBBBB)
     args = (ArgInfo(ArgumentName("inst"), None),)
 
     obs1 = Observations()
@@ -1594,8 +1597,9 @@ def test_merge_observations_accepts_property_getter_setter_pair():
         ArgumentName, CodeId, Filename, FunctionName,
     )
 
-    getter_id = CodeId(Filename("m.py"), FunctionName("Cls.prop"), 100, 0)
-    setter_id = CodeId(Filename("m.py"), FunctionName("Cls.prop"), 104, 0)
+    # Distinct bodies ⇒ different bytecode_hash.
+    getter_id = CodeId(Filename("m.py"), FunctionName("Cls.prop"), 100, 0x1111)
+    setter_id = CodeId(Filename("m.py"), FunctionName("Cls.prop"), 104, 0x2222)
 
     obs1 = Observations()
     obs1.func_info[getter_id] = FuncInfo(
@@ -1615,6 +1619,88 @@ def test_merge_observations_accepts_property_getter_setter_pair():
     obs1.merge_observations(obs2)
     assert getter_id in obs1.func_info
     assert setter_id in obs1.func_info
+
+
+def test_merge_observations_accepts_named_closures_at_different_lines():
+    """Two *named* closures (qualname like ``Outer.<locals>.view``) defined
+    in different branches of the same enclosing function may share parameter
+    shape. They are distinct callable values, not source-revision drift —
+    the bytecode hash discriminates them.
+
+    Regression: flask's ``View.as_view`` defines two ``def view(**kwargs):``
+    closures in adjacent branches of an ``if`` statement (lines 56 and 65 in
+    flask/views.py), both with the same signature. The earlier
+    signature-shape-based detector flagged this as drift and aborted the
+    merge, discarding all flask observations.
+    """
+    from righttyper.observations import (
+        Observations, FuncInfo, ArgInfo,
+    )
+    from righttyper.righttyper_types import (
+        ArgumentName, CodeId, Filename, FunctionName,
+    )
+
+    closure_name = FunctionName("View.as_view.<locals>.view")
+    # Distinct closure bodies ⇒ different bytecode_hash.
+    fid_a = CodeId(Filename("views.py"), closure_name, 56, 0xAAAA)
+    fid_b = CodeId(Filename("views.py"), closure_name, 65, 0xBBBB)
+    args = ()
+
+    obs1 = Observations()
+    obs1.func_info[fid_a] = FuncInfo(
+        code_id=fid_a, args=args,
+        varargs=None, kwargs=ArgumentName("kwargs"),
+    )
+    obs2 = Observations()
+    obs2.func_info[fid_b] = FuncInfo(
+        code_id=fid_b, args=args,
+        varargs=None, kwargs=ArgumentName("kwargs"),
+    )
+
+    # Must not raise — distinct closures with different content are legitimate.
+    obs1.merge_observations(obs2)
+    assert fid_a in obs1.func_info
+    assert fid_b in obs1.func_info
+
+
+def test_merge_observations_aborts_on_named_closure_drift():
+    """A named closure with identical bytecode appearing at different lines
+    across .rt files IS genuine source-revision drift and must raise — the
+    closure didn't change shape, the source was rewritten between collects.
+    """
+    from righttyper.observations import (
+        Observations, FuncInfo, ArgInfo,
+    )
+    from righttyper.righttyper_types import (
+        ArgumentName, CodeId, Filename, FunctionName,
+    )
+
+    closure_name = FunctionName("View.as_view.<locals>.view")
+    # Identical bytecode_hash at different lines ⇒ drift.
+    fid_pre = CodeId(Filename("views.py"), closure_name, 56, 0xCAFE)
+    fid_post = CodeId(Filename("views.py"), closure_name, 65, 0xCAFE)
+    args = ()
+
+    obs1 = Observations()
+    obs1.func_info[fid_pre] = FuncInfo(
+        code_id=fid_pre, args=args,
+        varargs=None, kwargs=ArgumentName("kwargs"),
+    )
+    obs2 = Observations()
+    obs2.func_info[fid_post] = FuncInfo(
+        code_id=fid_post, args=args,
+        varargs=None, kwargs=ArgumentName("kwargs"),
+    )
+
+    import pytest
+    with pytest.raises(ValueError) as exc_info:
+        obs1.merge_observations(obs2)
+
+    msg = str(exc_info.value)
+    assert "View.as_view.<locals>.view" in msg
+    assert "views.py" in msg
+    assert "56" in msg
+    assert "65" in msg
 
 
 def test_sample_until_stable_lifetime_budget(monkeypatch):

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1746,6 +1746,43 @@ def test_merge_observations_accepts_genexprs_with_identical_bytecode():
     assert fid_b in obs1.func_info
 
 
+def test_resolve_container_snapshot_handles_self_reference():
+    """A self-aliasing container (e.g., httpx response.request → response,
+    or any object that contains itself transitively) produces a
+    ContainerSamples entry whose ``resolved_samples()`` includes a
+    TypeInfo tagged with the same ``container_id`` as the outer container.
+
+    Without a cycle guard in the resolver, the visitor descends into that
+    inner TypeInfo, re-resolves the same cid back to the same args, and
+    recurses forever — observed as RecursionError during the httpx pytest
+    suite. The resolver must short-circuit re-entry on a cid currently
+    being resolved up the stack.
+    """
+    from righttyper.recorder import _ResolveContainerSnapshotT
+    from righttyper.typeinfo import TypeInfo
+
+    cid = 42
+
+    class FakeEntry:
+        def resolved_samples(self):
+            # Inner TypeInfo carries the same cid as the outer — the
+            # self-reference. Returned as the single element-type arg.
+            inner = TypeInfo.from_type(dict, args=(), container_id=cid)
+            return (inner,)
+
+    cid_to_entry = {cid: FakeEntry()}
+    outer = TypeInfo.from_type(dict, args=(), container_id=cid)
+
+    # Must terminate (no RecursionError).
+    resolver = _ResolveContainerSnapshotT(cid_to_entry)
+    result = resolver.visit(outer)
+
+    # Result should be a finite TypeInfo — the outer dict with its
+    # element-args refreshed once.
+    assert result is not None
+    assert result.container_id == cid
+
+
 def test_sample_until_stable_lifetime_budget(monkeypatch):
     """container_max_samples is a per-container lifetime budget, not a
     per-call cap.  Once the cumulative samples for a container reach the


### PR DESCRIPTION
## Summary

- **Annotation diagnostics** — new `--with-coverage` flag on `process` runs SlipCover during the apply step and emits `righttyper-diagnostics.json`, joining per-slot observations with coverage and a `degenerate_shape` predicate for downstream consumers.
- **Return-type generalization (Rule 6.5)** — reverts the unsound covariant return merge and replaces it with a sound MRO-supertype lift; return-position type unions now collapse via lub; renamed `for_variable` → `assume_covariant`.
- **Container snapshots** — id-tracking dedup of refinement-fragment progressive snapshots; simpler resolution via `container_id` dedup of `all_samples` plus uniform `ti.replace(args=...)` transform; per-cid `resolved_samples()` cache and `ContainerSamples.sample_view` cache; guard against self-aliasing cids.
- **Drift detection** — per-function content hash replaces the line-shift heuristic (fixes false positives where closures in adjacent branches were flagged as drift); synthetic functions exempted from content-hash collision.
- **Other** — `--poisson-warmup-samples` exposed on the CLI; README CLI overview refreshed; refuses to merge `Observations` recorded against different source revisions; signature-shape disambiguation for same-name `FuncInfo` entries; nested synthetics handled in the line-shift check; re-sample arg types from live frame locals on return; `empty_is_none` → `on_empty` on `TypeInfo.from_set`; assorted mypy / pyright cleanups; `sys.modules` snapshot in `_is_private_type`.

## Test plan

- [ ] Full test suite green on Linux + macOS + Windows in CI
- [ ] New tests pass: `test_coverage_loader.py`, `test_diagnostics_emit.py`, `test_diagnostics_predicate.py`
- [ ] Manually run `righttyper process --with-coverage` on a sample project and verify `righttyper-diagnostics.json` schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)